### PR TITLE
[CI]: Initialize build step for feedback on gatsby build on every  commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,11 @@
+name: "Build"
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - run: yarn
+      - run: yarn build


### PR DESCRIPTION
This PR sets up basic CI capabilities through GitHub actions.

1. It will fetch the repository
2. yarn install the dependencies
3. invoke yarn build to ensure that gatsby is still building after the change.