### PR TITLE
Fix: require display name during onboarding

### DIFF
--- a/src/app/mentorship/onboarding/page.tsx
+++ b/src/app/mentorship/onboarding/page.tsx
@@ -91,7 +91,7 @@ function OnboardingContent() {
       const profileData = {
         uid: user.uid,
         role: selectedRole,
-        displayName: user.displayName,
+        displayName: formData.displayName || user.displayName,
         email: user.email,
         photoURL: user.photoURL,
         ...formData,
@@ -234,11 +234,13 @@ function OnboardingContent() {
               <MentorRegistrationForm
                 onSubmit={handleFormSubmit}
                 isSubmitting={isSubmitting}
+                initialData={{ displayName: user?.displayName || "" }}
               />
             ) : (
               <MenteeRegistrationForm
                 onSubmit={handleFormSubmit}
                 isSubmitting={isSubmitting}
+                initialData={{ displayName: user?.displayName || "" }}
               />
             )}
           </div>

--- a/src/components/mentorship/MenteeRegistrationForm.tsx
+++ b/src/components/mentorship/MenteeRegistrationForm.tsx
@@ -9,6 +9,7 @@ interface MenteeRegistrationFormProps {
   onSubmit: (data: Record<string, unknown>) => Promise<void>;
   isSubmitting: boolean;
   initialData?: {
+    displayName?: string;
     discordUsername?: string;
     discordUsernameValidated?: boolean;
     education?: string;
@@ -66,6 +67,9 @@ export default function MenteeRegistrationForm({
   mode = "create",
 }: MenteeRegistrationFormProps) {
   const toast = useToast();
+  const [displayName, setDisplayName] = useState(
+    initialData?.displayName || ""
+  );
   const [discordUsername, setDiscordUsername] = useState(
     initialData?.discordUsername || ""
   );
@@ -202,6 +206,11 @@ export default function MenteeRegistrationForm({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
+    if (!displayName.trim()) {
+      toast.error("Please enter your display name");
+      return;
+    }
+
     if (skillsSought.length === 0) {
       toast.error("Please select at least one skill you want to learn");
       return;
@@ -251,6 +260,7 @@ export default function MenteeRegistrationForm({
     }
 
     await onSubmit({
+      displayName: displayName.trim(),
       discordUsername: finalDiscordUsername,
       education,
       skillsSought,
@@ -262,6 +272,26 @@ export default function MenteeRegistrationForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
+      {/* Display Name */}
+      <div className="form-control">
+        <label className="label">
+          <span className="label-text font-semibold">Display Name *</span>
+        </label>
+        <input
+          type="text"
+          placeholder="Your full name"
+          className="input input-bordered w-full"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          required
+        />
+        <label className="label">
+          <span className="label-text-alt text-base-content/60">
+            This is how your name appears across the platform
+          </span>
+        </label>
+      </div>
+
       {/* Discord Username + Education - Two column grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {/* Discord Username */}

--- a/src/components/mentorship/MentorRegistrationForm.tsx
+++ b/src/components/mentorship/MentorRegistrationForm.tsx
@@ -257,6 +257,11 @@ export default function MentorRegistrationForm({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
+    if (!displayName.trim()) {
+      toast.error("Please enter your display name");
+      return;
+    }
+
     if (expertise.length === 0) {
       toast.error("Please select at least one area of expertise");
       return;
@@ -316,6 +321,7 @@ export default function MentorRegistrationForm({
       );
 
     await onSubmit({
+      displayName: displayName.trim(),
       expertise,
       currentRole,
       bio,
@@ -326,9 +332,6 @@ export default function MentorRegistrationForm({
       isPublic,
       discordUsername: finalDiscordUsername,
       ...(mode === "edit" && username ? { username: username.trim() } : {}),
-      ...(mode === "edit" && displayName
-        ? { displayName: displayName.trim() }
-        : {}),
       ...(mode === "edit" && photoURL ? { photoURL } : {}),
     });
   };
@@ -366,11 +369,11 @@ export default function MentorRegistrationForm({
         </div>
       )}
 
-      {/* Display Name and Profile Image - Only shown in edit mode */}
-      {mode === "edit" && (
-        <div className="form-control">
-          <div className="flex flex-row gap-6 items-start">
-            {/* Profile Image */}
+      {/* Display Name and Profile Image */}
+      <div className="form-control">
+        <div className="flex flex-row gap-6 items-start">
+          {/* Profile Image - Only shown in edit mode */}
+          {mode === "edit" && (
             <div className="flex flex-col items-center gap-2">
               <div className="relative">
                 <div className="avatar">
@@ -414,28 +417,29 @@ export default function MentorRegistrationForm({
                 Max 5MB
               </span>
             </div>
+          )}
 
-            {/* Display Name */}
-            <div className="flex-1">
-              <label className="label pt-0">
-                <span className="label-text font-semibold">Display Name</span>
-              </label>
-              <input
-                type="text"
-                placeholder="Your display name"
-                className="input input-bordered w-full"
-                value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
-              />
-              <label className="label">
-                <span className="label-text-alt text-base-content/60">
-                  This is how your name appears across the platform
-                </span>
-              </label>
-            </div>
+          {/* Display Name */}
+          <div className="flex-1">
+            <label className="label pt-0">
+              <span className="label-text font-semibold">Display Name *</span>
+            </label>
+            <input
+              type="text"
+              placeholder="Your full name"
+              className="input input-bordered w-full"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              required
+            />
+            <label className="label">
+              <span className="label-text-alt text-base-content/60">
+                This is how your name appears across the platform
+              </span>
+            </label>
           </div>
         </div>
-      )}
+      </div>
 
       {/* Current Role + Discord Username - Two column grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- **MenteeRegistrationForm**: Added required Display Name field (was completely missing)
- **MentorRegistrationForm**: Display Name field now shows in both create and edit mode (was edit-only)
- **Onboarding page**: Pre-fills Display Name from Firebase Auth, but uses the form value on submit so users can correct/set it

Previously, `displayName` was sourced exclusively from `user.displayName` (Firebase Auth) during onboarding. If a user signed up with email/password (no Google), Firebase Auth has no display name, resulting in profiles saved with empty `displayName` — shown as "Unknown" in the admin dashboard.

## Test plan
- [ ] Register as mentee with email/password account — verify Display Name field is shown and required
- [ ] Register as mentor — verify Display Name field appears with pre-filled value from Google auth
- [ ] Try submitting with empty Display Name — verify validation error appears
- [ ] Verify existing edit mode still works for both forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)