### PR TITLE
Auto-open Google Calendar on session creation

### DIFF
--- a/src/components/mentorship/SessionScheduler.tsx
+++ b/src/components/mentorship/SessionScheduler.tsx
@@ -107,8 +107,9 @@ export default function SessionScheduler({
 
       if (response.ok) {
         const data = await response.json();
+        const newSession = data.scheduledSession;
         setSessions((prev) =>
-          [...prev, data.scheduledSession].sort(
+          [...prev, newSession].sort(
             (a, b) =>
               new Date(a.scheduledAt).getTime() -
               new Date(b.scheduledAt).getTime()
@@ -123,6 +124,8 @@ export default function SessionScheduler({
         });
         setSelectedTemplate(null);
         setShowForm(false);
+        // Auto-open Google Calendar with the new session
+        openGoogleCalendar(newSession);
       }
     } catch (error) {
       console.error("Error scheduling session:", error);


### PR DESCRIPTION
## Summary
- After a mentor schedules a session, Google Calendar automatically opens in a new tab with pre-filled event details (title, date/time, duration, agenda, attendee email)
- Removes the extra step of manually clicking the "Calendar" button after scheduling

## Test plan
- [ ] Schedule a new session as a mentor — verify Google Calendar opens automatically with correct details
- [ ] Verify the Calendar button on existing sessions still works independently
- [ ] Verify popup blockers don't interfere (the open happens synchronously in the click handler chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)