### PR TITLE
Update Discord username field text with server name and invite link

### DIFF
--- a/src/components/mentorship/MenteeRegistrationForm.tsx
+++ b/src/components/mentorship/MenteeRegistrationForm.tsx
@@ -403,9 +403,21 @@ export default function MenteeRegistrationForm({
           )}
           <label className="label">
             <span className="label-text-alt text-base-content/60">
-              {mode === "create"
-                ? "You must be on our Discord server to register"
-                : "Used for private mentorship channels"}
+              {mode === "create" ? (
+                <>
+                  You must be on our Discord (CodeWithAhsan) server to register.{" "}
+                  <a
+                    href={DISCORD_INVITE_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="link link-primary"
+                  >
+                    Join here
+                  </a>
+                </>
+              ) : (
+                "Used for private mentorship channels"
+              )}
             </span>
           </label>
         </div>

--- a/src/components/mentorship/MentorRegistrationForm.tsx
+++ b/src/components/mentorship/MentorRegistrationForm.tsx
@@ -574,9 +574,21 @@ export default function MentorRegistrationForm({
           )}
           <label className="label">
             <span className="label-text-alt text-base-content/60">
-              {mode === "create"
-                ? "You must be on our Discord server to register"
-                : "Used for private mentorship channels"}
+              {mode === "create" ? (
+                <>
+                  You must be on our Discord (CodeWithAhsan) server to register.{" "}
+                  <a
+                    href={DISCORD_INVITE_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="link link-primary"
+                  >
+                    Join here
+                  </a>
+                </>
+              ) : (
+                "Used for private mentorship channels"
+              )}
             </span>
           </label>
         </div>


### PR DESCRIPTION
## Summary
- Changed helper text from "You must be on our Discord server to register" to "You must be on our Discord (CodeWithAhsan) server to register."
- Added a "Join here" invite link (`codewithahsan.dev/discord`) inline so users coming from socials or the site directly can join before registering
- Applied to both MentorRegistrationForm and MenteeRegistrationForm

Closes #127

## Test plan
- [ ] Verify mentor registration form shows updated text with "CodeWithAhsan" and clickable "Join here" link
- [ ] Verify mentee registration form shows the same updated text
- [ ] Verify the link opens the Discord invite in a new tab
- [ ] Verify edit mode still shows "Used for private mentorship channels"

🤖 Generated with [Claude Code](https://claude.com/claude-code)