### PR TITLE
fix(mentorship): make CV/Resume link mandatory

### DIFF
--- a/src/components/mentorship/MentorRegistrationForm.tsx
+++ b/src/components/mentorship/MentorRegistrationForm.tsx
@@ -272,6 +272,11 @@ export default function MentorRegistrationForm({
       return;
     }
 
+    if (!cvUrl.trim()) {
+      toast.error("Please provide your CV or Resume link");
+      return;
+    }
+
     if (!discordUsername.trim()) {
       toast.error("Please enter your Discord username");
       return;
@@ -325,7 +330,7 @@ export default function MentorRegistrationForm({
       expertise,
       currentRole,
       bio,
-      cvUrl: cvUrl.trim() || undefined,
+      cvUrl: cvUrl.trim(),
       majorProjects: majorProjects.trim() || undefined,
       maxMentees,
       availability: availableDays,
@@ -719,8 +724,8 @@ export default function MentorRegistrationForm({
         <div className="form-control">
           <label className="label">
             <span className="label-text font-semibold">CV / Resume Link</span>
-            <span className="label-text-alt text-base-content/60">
-              Optional
+            <span className="label-text-alt text-error">
+              *Required
             </span>
           </label>
           <input
@@ -729,6 +734,7 @@ export default function MentorRegistrationForm({
             className="input input-bordered w-full"
             value={cvUrl}
             onChange={(e) => setCvUrl(e.target.value)}
+            required
           />
           <label className="label">
             <span className="label-text-alt text-base-content/60">


### PR DESCRIPTION
## Summary
- Makes the CV/Resume link field mandatory in the mentor registration form
- Adds validation check that shows a toast error if the field is empty on submit
- Updates the field label from "Optional" to "*Required" with error styling
- Adds HTML `required` attribute to the input

Closes #126

## Test plan
- [ ] Open the mentor onboarding form and try submitting without a CV/Resume link — should show error toast
- [ ] Enter a valid URL and submit — should succeed
- [ ] Open mentor settings and verify the field shows as required
- [ ] Verify existing mentors with no CV link can still edit other fields (they'll need to add a CV link to save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)