### PR TITLE
fix: signin modal z-index rendering above Hero

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -14,7 +14,7 @@ export default function Hero() {
       <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-secondary/20 rounded-full blur-[128px] animate-pulse"></div>
       <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-primary/20 rounded-full blur-[128px] animate-pulse delay-1000"></div>
 
-      <div className="relative z-10 grid grid-cols-1 lg:grid-cols-2 gap-12 items-center w-full px-4 sm:px-8 md:px-12 lg:px-16">
+      <div className="relative z-[1] grid grid-cols-1 lg:grid-cols-2 gap-12 items-center w-full px-4 sm:px-8 md:px-12 lg:px-16">
         {/* Text Content */}
         <div className="space-y-8">
           <a

--- a/src/components/LoginModal.js
+++ b/src/components/LoginModal.js
@@ -21,7 +21,7 @@ export default function LoginModal({ show }) {
 
   return (
     <div
-      className="fixed top-0 bottom-0 left-0 right-0 mx-auto sm:px-6 lg:px-8 w-full bg-slate-900/50 z-10"
+      className="fixed top-0 bottom-0 left-0 right-0 mx-auto sm:px-6 lg:px-8 w-full bg-slate-900/50 z-[9999]"
       role="article"
       onClick={() => {
         setShowLoginPopup(false)


### PR DESCRIPTION
Fixes #143

## Changes
- Updated LoginModal overlay z-index from `z-10` to `z-[9999]` (matching toast pattern)
- Updated Hero content z-index from `z-10` to `z-[1]` (sufficient for internal layering)

## Root Cause
Both LoginModal and Hero were using `z-10`, causing the Hero content to compete with the modal overlay.

## Testing
- Build passes without errors
- Modal now renders above all page content
- Z-index hierarchy follows existing codebase patterns

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>