### PR TITLE
fix(events): improve SEO for all event slugs, titles, descriptions

### DIFF
--- a/src/content/events/BWAI-May2026/event.mdx
+++ b/src/content/events/BWAI-May2026/event.mdx
@@ -1,11 +1,11 @@
 ---
-slug: BWAI-May2026
-title: "Build with AI: Building an AI Travel Agent with ADK and Gemini CLI"
-description: "Join us live to learn how to build an intelligent, production-ready AI Travel Agent using Google's Agent Development Kit (ADK) and Gemini CLI!"
+slug: build-ai-travel-agent-adk-gemini-cli-may-2026
+title: "Build an AI Travel Agent with Google ADK & Gemini CLI – Code with Ahsan (May 2026)"
+description: "Free online workshop by Code with Ahsan – May 21, 2026. Build a production-ready AI Travel Agent using Google's Agent Development Kit (ADK) and Gemini CLI. Join via Google Meet."
 type: workshop
 date: "2026-05-21"
 location: "Online via Google Meet"
-speaker: "Muhammad Aahsan Ayaz - GDE in AI & Angular"
+speaker: "Muhammad Ahsan Ayaz - GDE in AI & Angular"
 isVisible: true
 status: upcoming
 visibilityOrder: 100
@@ -33,5 +33,5 @@ visibilityOrder: 100
 - **Anyone curious about Multi-Agent systems** and how to orchestrate collaboration between specialized AI helpers.
 
 ## Join CWA Discord 
-Join our Discord Community of thounsands of developers and tech enthusiasts for availing the FREE programs we’re offering and attending these events:
-https://discord.gg/aFAG7ZHq6A 
+Join our Discord Community of thousands of developers and tech enthusiasts for availing the FREE programs we're offering and attending these events:
+https://discord.gg/aFAG7ZHq6A

--- a/src/content/events/README.md
+++ b/src/content/events/README.md
@@ -10,13 +10,31 @@ The build script reads all `event.mdx` files and generates `events.generated.jso
 2. Add an `event.mdx` file using the template below
 3. Run `npm run build:events` to regenerate the index (or just `npm run build`)
 
+## SEO Guidelines
+
+Good SEO on event pages helps Google surface them for searches like "AI workshop May 2026" or "Code with Ahsan event".
+
+**Slug** — use full descriptive keywords, lowercase, hyphenated. Never use acronyms or internal codes.
+- ✅ `build-ai-travel-agent-adk-gemini-cli-may-2026`
+- ❌ `BWAI-May2026`
+
+**Title** — include the community name and date. Pattern: `"<Event Topic> – Code with Ahsan (<Month Year>)"`.
+- ✅ `"Build an AI Travel Agent with Google ADK & Gemini CLI – Code with Ahsan (May 2026)"`
+- ❌ `"Build with AI: Building an AI Travel Agent with ADK and Gemini CLI"`
+
+**Description** — 150–160 characters. Must include: event date, "Code with Ahsan", 2–3 topic keywords, and location/format (online/in-person).
+- ✅ `"Free online workshop by Code with Ahsan – May 21, 2026. Build a production-ready AI Travel Agent using Google's ADK and Gemini CLI. Join via Google Meet."`
+- ❌ `"Join us live to learn how to build an intelligent, production-ready AI Travel Agent using Google's Agent Development Kit (ADK) and Gemini CLI!"`
+
+**Speaker** — use the exact public name. Watch for typos (`Aahsan` → `Ahsan`).
+
 ## Template
 
 ```mdx
 ---
-slug: my-event-2027
-title: "My Event 2027"
-description: "A short description shown on the events listing page (1–2 sentences)."
+slug: my-event-topic-keywords-month-year
+title: "My Event Full Title – Code with Ahsan (Month Year)"
+description: "Free online/in-person event by Code with Ahsan – Month DD, YYYY. 1–2 sentences covering topic keywords and location."
 type: workshop
 date: "2027-06-15"
 endDate: "2027-06-16"

--- a/src/content/events/cwa-promptathon-2026/event.mdx
+++ b/src/content/events/cwa-promptathon-2026/event.mdx
@@ -1,7 +1,7 @@
 ---
-slug: cwa-promptathon-2026
-title: "CWA Prompt-a-thon 2026"
-description: "A Generative AI & #BuildWithAI Hackathon. Collaborate, build, and showcase innovative solutions using Generative AI."
+slug: cwa-promptathon-generative-ai-hackathon-2026
+title: "CWA Prompt-a-thon 2026 – Generative AI Hackathon by Code with Ahsan"
+description: "Free online Generative AI hackathon by Code with Ahsan – March 28 to April 10, 2026. Collaborate, build, and showcase innovative AI solutions. Open to all skill levels."
 type: hackathon
 date: "2026-03-28"
 endDate: "2026-04-10"
@@ -14,6 +14,6 @@ visibilityOrder: 50
 
 # CWA Prompt-a-thon 2026
 
-A Generative AI & #BuildWithAI Hackathon hosted by CodeWithAhsan. Collaborate with fellow developers to build innovative AI-powered solutions.
+A Generative AI & #BuildWithAI Hackathon hosted by Code with Ahsan. Collaborate with fellow developers to build innovative AI-powered solutions.
 
 > Note: This event has a dedicated landing page. You'll be redirected to it automatically.

--- a/src/content/events/hackstack-2023/event.mdx
+++ b/src/content/events/hackstack-2023/event.mdx
@@ -1,7 +1,7 @@
 ---
-slug: hackstack-2023
-title: "HackStack Pakistan 2023"
-description: "Pakistan's premier 2-week hybrid hackathon focused on Full Stack Development. Organized with GDG Kolachi."
+slug: hackstack-pakistan-fullstack-hackathon-2023
+title: "HackStack Pakistan 2023 – Full Stack Hackathon with GDG Kolachi & Code with Ahsan"
+description: "Pakistan's premier 2-week hybrid Full Stack Development hackathon – October 2023. Organized by Code with Ahsan and GDG Kolachi in Karachi with an online track."
 type: hackathon
 date: "2023-10-01"
 location: "Karachi, Pakistan (Hybrid)"
@@ -13,6 +13,6 @@ visibilityOrder: 10
 
 # HackStack Pakistan 2023
 
-Pakistan's premier 2-week hybrid hackathon focused on Full Stack Development, organized with GDG Kolachi.
+Pakistan's premier 2-week hybrid hackathon focused on Full Stack Development, organized by Code with Ahsan and GDG Kolachi.
 
 > Note: This event has a dedicated landing page. You'll be redirected to it automatically.


### PR DESCRIPTION
- BWAI-May2026: slug → build-ai-travel-agent-adk-gemini-cli-may-2026, title and description now include date, "Code with Ahsan", topic keywords; fix speaker name typo (Aahsan → Ahsan)
- cwa-promptathon-2026: slug, title, description updated with community name, date range, and AI hackathon keywords
- hackstack-2023: slug, title, description updated with community name, date, location, and full-stack keywords
- README: add SEO guidelines section with slug/title/description patterns, good/bad examples, and updated template frontmatter