### PR TITLE
chore(seo): sitemap hygiene + noindex auxiliary course pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ firestore-debug.log
 
 # local articles (publish directly to Ghost, not committed)
 /articles/
+
+# LLM scratch / inputs
+/for_llm/

--- a/src/app/courses/[course]/resources/page.tsx
+++ b/src/app/courses/[course]/resources/page.tsx
@@ -26,6 +26,7 @@ export async function generateMetadata({
       alternates: {
         canonical: `${BASE_URL}/courses`,
       },
+      robots: { index: false, follow: true },
     };
   }
 
@@ -34,6 +35,7 @@ export async function generateMetadata({
     alternates: {
       canonical: `${BASE_URL}/courses/${slug}/resources`,
     },
+    robots: { index: false, follow: true },
   };
 }
 

--- a/src/app/courses/[course]/submissions/layout.tsx
+++ b/src/app/courses/[course]/submissions/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+// Submissions is a client-only Firestore view with no SSR content (empty shell to crawlers)
+// and is auth-gated behind project submission flows. Explicitly noindex so any
+// internal-link rediscovery does not pollute the search index. See GSC 2026-05-28.
+export const metadata: Metadata = {
+  robots: { index: false, follow: true },
+};
+
+export default function SubmissionsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -68,6 +68,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.7,
   }));
 
+  // Resources + submissions intentionally excluded:
+  // - /resources is thin SSR (heading + links list) — Google flags as low-quality.
+  // - /submissions is a client-only Firestore shell with no SSR content — empty to crawlers.
+  // Both routes also carry `robots: { index: false }` metadata so any rediscovery via
+  // internal links does not pollute the index. See GSC report 2026-05-28.
   const courseEntries: MetadataRoute.Sitemap = courses.flatMap((course) => {
     const courseLastModified = toDate(course.publishedAt, now);
 
@@ -76,20 +81,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: courseLastModified,
       changeFrequency: "weekly" as const,
       priority: 0.8,
-    };
-
-    const resources = {
-      url: `${BASE_URL}/courses/${course.slug}/resources`,
-      lastModified: courseLastModified,
-      changeFrequency: "weekly" as const,
-      priority: 0.3,
-    };
-
-    const submissions = {
-      url: `${BASE_URL}/courses/${course.slug}/submissions`,
-      lastModified: courseLastModified,
-      changeFrequency: "weekly" as const,
-      priority: 0.3,
     };
 
     const posts = (course.chapters ?? []).flatMap((chapter) =>
@@ -103,7 +94,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         }))
     );
 
-    return [detail, resources, submissions, ...posts];
+    return [detail, ...posts];
   });
 
   return [...homepage, ...staticEntries, ...eventEntries, ...courseEntries];


### PR DESCRIPTION
## Summary
- Drop `/courses/[slug]/resources` and `/courses/[slug]/submissions` from `sitemap.xml` (18 URLs across 9 courses).
- Add `robots: { index: false, follow: true }` metadata to both routes so internal-link rediscovery does not pollute the index.
- Gitignore `/for_llm/` scratch dir used for GSC report ingestion.

## Why
Per the 2026-05-28 GSC Coverage report:
- 44 indexed / 353 not-indexed.
- `Crawled - currently not indexed` is climbing (57 → 66 in one week).
- `/resources` pages are thin SSR (heading + link list).
- `/submissions` pages are `"use client"` Firestore shells with **no SSR content** — Google fetches an empty HTML body. Both dilute crawl budget for the 225 high-value `/courses/[slug]/[post]` URLs that we actually want indexed.

Submissions page is a client component so metadata cannot be exported from it directly — added a server `layout.tsx` sibling that applies `noindex` to the whole subtree.

## Test plan
- [ ] `npm run build` succeeds locally.
- [ ] After deploy: `curl https://www.codewithahsan.dev/sitemap.xml | grep -c "<loc>"` returns **252** (was 270 — drop of 18).
- [ ] `curl -s https://www.codewithahsan.dev/courses/web-dev-bootcamp/resources | grep -i 'noindex'` shows `noindex` in meta robots.
- [ ] `curl -s https://www.codewithahsan.dev/courses/web-dev-bootcamp/submissions | grep -i 'noindex'` shows `noindex` in meta robots.
- [ ] Resubmit sitemap in GSC and request re-validation on the `Crawled - currently not indexed` group.

## Follow-ups (separate PRs)
- P0: pull fresh GSC URL exports (404 / 5xx / crawled-not-indexed) to triage the 44 new 404s + 6 stale 5xx.
- P1: audit content quality on the 225 course posts (descriptions, thumbnails).
- P1: add `BreadcrumbList` + `Course` JSON-LD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)