### PR TITLE
chore(seo): content audit script + rubric for courses/posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ firestore-debug.log
 
 # LLM scratch / inputs
 /for_llm/
+
+# SEO audit reports (local, regenerable via `npm run audit:seo`)
+/.seo-audit/

--- a/docs/SEO_CONTENT_RUBRIC.md
+++ b/docs/SEO_CONTENT_RUBRIC.md
@@ -1,0 +1,91 @@
+# SEO Content Rubric
+
+How we grade course + post quality for search indexing. Every new course or post must clear this bar before merge.
+
+## Quick check
+
+```bash
+npm run audit:seo            # human-readable summary + bottom-15 weakest posts
+npm run audit:seo -- --top 30
+npm run audit:seo -- --warn-as-fail   # exits non-zero on WARN
+npm run audit:seo:json       # only print path to JSON report
+```
+
+Output: `.seo-audit/audit-<YYYY-MM-DD>.json` (gitignored).
+
+The script reads `src/content/courses.generated.json` and the underlying `.mdx` files. Run `npm run content:build` first (the `audit:seo` script does this for you).
+
+## Rubric
+
+### Course (`src/content/courses/<slug>/course.mdx`)
+
+| Check | Pass | Warn | Fail |
+|---|---|---|---|
+| `name` length | 25–70 chars | 15–80 | other |
+| `description` length | ≥ 200 | ≥ 100 | < 100 |
+| `banner.url` | present | — | missing |
+| `chapters` count | ≥ 1 | — | 0 |
+
+### Post (`src/content/courses/<slug>/posts/*.mdx`)
+
+| Check | Pass | Warn | Fail |
+|---|---|---|---|
+| **effective SERP title** (`<title> - <course name>`) | 25–70 chars | 15–80 | other |
+| `description` | ≥ 120 chars | ≥ 60 | < 60 |
+| body word count *(article posts only)* | ≥ 150 | ≥ 50 | < 50 |
+| body for video posts | ≥ 50 word summary/transcript | empty | (never fails) |
+| media | thumbnail set | videoUrl only | neither |
+| schema (page output) | `Article` (article) | `Article` only on `type: video` post | — |
+| `publishedAt` | present | — | missing |
+
+Score = pass(2) + warn(1) + fail(0). 6 checks × 2 = max 12 per post.
+
+## Author checklist
+
+When adding a new post, fill in the frontmatter:
+
+```yaml
+---
+slug: my-post-slug
+title: A clear, specific lesson title          # 25–70 chars when joined with course name
+description: A 1–2 sentence summary of what the learner will achieve. Include the topic + the tech stack so it can rank for long-tail queries. # ≥ 120 chars
+type: video                                    # or "article"
+videoUrl: https://www.youtube.com/watch?v=...
+thumbnail: https://res.cloudinary.com/.../thumb.jpg   # OG image. Sitemap + OG card needs this.
+publishedAt: '2026-05-29T00:00:00.000Z'
+chapterId: 123
+chapterOrder: 4
+order: 7
+---
+
+A short written summary or transcript (≥ 50 words) lifts a video post out of "Crawled - currently not indexed" because the page is no longer an empty shell to crawlers. Even 2-3 bullet points of what the video covers helps.
+```
+
+For a course (`course.mdx`), fill:
+
+- `name`
+- `description` (≥ 200 chars)
+- `banner.url`
+- `chapters` array with ordered chapter objects
+
+## Known systemic gaps (2026-05-29 snapshot)
+
+- **126 / 233 posts have empty `description`** — biggest indexing lever.
+- **232 / 233 posts are `type: video`** but page emits `Article` JSON-LD only — should emit `VideoObject` for video rich results.
+- **8 Google ADK posts** carry full course suffix in the post title (`... - Google Agent Development Kit for Beginners Part N`), then the page metadata appends ` - <course name>` again → 160+ char SERP title. Strip the redundant suffix from `title:` in the mdx frontmatter.
+- **2 courses missing `banner.url`** (`design-patterns-javascript`, `js-beginners-series`).
+- **3 courses missing/short `description`** (`angular-in-90ish-minutes`, `react-redux-toolkit`, `angular-nestjs-fullstack-course`).
+
+Track follow-ups via `npm run audit:seo` over time — score should trend up.
+
+## Why these thresholds
+
+- **Description ≥ 120**: Google truncates SERP meta descriptions ~155–160 chars on desktop. < 60 = essentially missing.
+- **SERP title 25–70**: < 30 chars under-uses pixel width; > 70 truncates with ellipsis.
+- **Body ≥ 150 words (article)**: Empirical floor below which "Crawled - currently not indexed" hits.
+- **Video summary ≥ 50 words**: Minimum to give crawlers something to read; can be a bulleted topic list.
+- **Schema**: `VideoObject` lets Google show video rich results (thumbnail, duration in SERP).
+
+## When to update the rubric
+
+Bump thresholds upward (never downward) as content quality improves. Keep `audit:seo` exit code in CI advisory only — do not block PRs on it yet (too many existing failures). Switch to blocking once `summary.posts.fail === 0`.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "content:mdx:from-json": "node scripts/migrate/convert-course-json-to-mdx.js",
     "content:build": "node scripts/content/build-courses-index.js",
     "build:events": "node scripts/content/build-events-index.js",
+    "audit:seo": "npm run content:build && node scripts/content/audit-seo.js",
+    "audit:seo:json": "npm run content:build && node scripts/content/audit-seo.js --json",
     "prebuild": "npm run content:build && npm run build:events",
     "build": "next build",
     "content:export:strapi": "node scripts/migrate/export-strapi-content.js",

--- a/scripts/content/audit-seo.js
+++ b/scripts/content/audit-seo.js
@@ -1,0 +1,390 @@
+#!/usr/bin/env node
+
+// SEO content audit for courses + posts.
+//
+// Reads:
+//   - src/content/courses.generated.json (truth for structure + frontmatter)
+//   - src/content/courses/<slug>/posts/*.mdx (truth for body word count)
+//
+// Writes:
+//   - .seo-audit/audit-<YYYY-MM-DD>.json (full machine-readable report)
+//   - stdout: human-readable summary
+//
+// Exit codes:
+//   0 = no FAIL findings
+//   1 = at least one FAIL finding
+//   Use --warn-as-fail to also fail on WARN.
+//
+// Usage:
+//   node scripts/content/audit-seo.js
+//   node scripts/content/audit-seo.js --json   # only emit json path
+//   node scripts/content/audit-seo.js --top 20 # show bottom-N weakest posts
+
+const fs = require("fs");
+const path = require("path");
+const matter = require("gray-matter");
+
+const ROOT = process.cwd();
+const COURSES_INDEX = path.join(ROOT, "src/content/courses.generated.json");
+const COURSES_DIR = path.join(ROOT, "src/content/courses");
+const OUT_DIR = path.join(ROOT, ".seo-audit");
+
+// ---- Rubric ---------------------------------------------------------------
+// Each check returns { status: "pass" | "warn" | "fail", value, note? }.
+// Score: pass=2, warn=1, fail=0. Post max=10, course max=8.
+
+const POST_DESC_PASS = 120;
+const POST_DESC_WARN = 60;
+const POST_TITLE_MIN = 25;
+const POST_TITLE_MAX = 70;
+const POST_BODY_PASS = 150;
+const POST_BODY_WARN = 50;
+
+const COURSE_DESC_PASS = 200;
+const COURSE_DESC_WARN = 100;
+
+function scoreOf(status) {
+  return { pass: 2, warn: 1, fail: 0 }[status];
+}
+
+function checkLength(value, passAt, warnAt, label) {
+  const len = (value || "").trim().length;
+  if (len >= passAt) return { status: "pass", value: len };
+  if (len >= warnAt)
+    return { status: "warn", value: len, note: `${label} short (<${passAt})` };
+  return {
+    status: "fail",
+    value: len,
+    note: `${label} missing or too short (<${warnAt})`,
+  };
+}
+
+function checkTitle(title, courseName) {
+  // Effective SERP title is "<post title> - <course name>" (set in page metadata).
+  // Score on the effective string so short post titles like "Introduction" don't
+  // false-fail when the course suffix already brings the SERP title above 30 chars.
+  const effective = courseName
+    ? `${(title || "").trim()} - ${(courseName || "").trim()}`
+    : (title || "").trim();
+  const len = effective.length;
+  if (len >= POST_TITLE_MIN && len <= POST_TITLE_MAX)
+    return { status: "pass", value: len };
+  if (len >= 15 && len <= 80)
+    return {
+      status: "warn",
+      value: len,
+      note: `effective SERP title length ${len} outside ideal ${POST_TITLE_MIN}-${POST_TITLE_MAX}`,
+    };
+  return {
+    status: "fail",
+    value: len,
+    note: `effective SERP title length ${len} bad`,
+  };
+}
+
+function checkMedia(post) {
+  if (post.thumbnail) return { status: "pass", value: "thumbnail" };
+  if (post.videoUrl)
+    return {
+      status: "warn",
+      value: "video-only",
+      note: "no thumbnail; YouTube poster used (no og:image)",
+    };
+  return { status: "fail", value: "none", note: "no thumbnail and no video" };
+}
+
+function checkPublished(post) {
+  return post.publishedAt
+    ? { status: "pass", value: post.publishedAt }
+    : { status: "fail", value: null, note: "missing publishedAt" };
+}
+
+// ---- Body word count ------------------------------------------------------
+
+function postMdxPath(courseSlug) {
+  return path.join(COURSES_DIR, courseSlug, "posts");
+}
+
+function wordCount(text) {
+  if (!text) return 0;
+  return text
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/[#>*_~\-]+/g, " ")
+    .split(/\s+/)
+    .filter(Boolean).length;
+}
+
+function readPostBody(courseSlug, postSlug) {
+  const dir = postMdxPath(courseSlug);
+  if (!fs.existsSync(dir)) return "";
+  const files = fs.readdirSync(dir);
+  const match = files.find((f) => f.endsWith(`${postSlug}.mdx`));
+  if (!match) return "";
+  const { content } = matter(fs.readFileSync(path.join(dir, match), "utf8"));
+  return content;
+}
+
+function checkBody(courseSlug, post) {
+  const body = readPostBody(courseSlug, post.slug);
+  const words = wordCount(body);
+  // Video posts: body is expected to be empty (lesson is in the YouTube embed).
+  // SEO lever for video lessons is description + VideoObject schema, not body word count.
+  // We still WARN at 0 words to encourage adding a transcript or summary, but don't FAIL.
+  if (post.type === "video") {
+    if (words >= POST_BODY_WARN) return { status: "pass", value: words };
+    return {
+      status: "warn",
+      value: words,
+      note: `video post w/o transcript or summary (${words} words) — VideoObject schema + description carries SEO`,
+    };
+  }
+  if (words >= POST_BODY_PASS) return { status: "pass", value: words };
+  if (words >= POST_BODY_WARN)
+    return {
+      status: "warn",
+      value: words,
+      note: `thin body (${words} words)`,
+    };
+  return {
+    status: "fail",
+    value: words,
+    note: `empty/near-empty body (${words} words)`,
+  };
+}
+
+function checkSchema(post) {
+  // Page currently emits Article schema on /courses/[slug]/[post]/page.tsx for
+  // every post regardless of type. Video posts should emit VideoObject (or both)
+  // so Google can show video rich results in SERP.
+  if (post.type === "video") {
+    return {
+      status: "warn",
+      value: "Article-only",
+      note: "video post emits Article schema only — add VideoObject schema for video rich results",
+    };
+  }
+  return { status: "pass", value: "Article" };
+}
+
+// ---- Audit runners --------------------------------------------------------
+
+function auditPost(courseSlug, courseName, post) {
+  const checks = {
+    title: checkTitle(post.title, courseName),
+    description: checkLength(
+      post.description,
+      POST_DESC_PASS,
+      POST_DESC_WARN,
+      "description"
+    ),
+    body: checkBody(courseSlug, post),
+    media: checkMedia(post),
+    schema: checkSchema(post),
+    published: checkPublished(post),
+  };
+  const score = Object.values(checks).reduce(
+    (sum, c) => sum + scoreOf(c.status),
+    0
+  );
+  const max = Object.keys(checks).length * 2;
+  const failCount = Object.values(checks).filter(
+    (c) => c.status === "fail"
+  ).length;
+  const warnCount = Object.values(checks).filter(
+    (c) => c.status === "warn"
+  ).length;
+  return {
+    url: `/courses/${courseSlug}/${post.slug}`,
+    courseSlug,
+    postSlug: post.slug,
+    title: post.title,
+    score,
+    max,
+    pct: Math.round((score / max) * 100),
+    failCount,
+    warnCount,
+    checks,
+  };
+}
+
+function auditCourse(course) {
+  const checks = {
+    name: checkTitle(course.name, null),
+    description: checkLength(
+      course.description,
+      COURSE_DESC_PASS,
+      COURSE_DESC_WARN,
+      "description"
+    ),
+    banner: course.banner?.url
+      ? { status: "pass", value: course.banner.url }
+      : { status: "fail", value: null, note: "course banner missing" },
+    chapters: (course.chapters || []).length
+      ? { status: "pass", value: (course.chapters || []).length }
+      : { status: "fail", value: 0, note: "no chapters" },
+  };
+  const score = Object.values(checks).reduce(
+    (sum, c) => sum + scoreOf(c.status),
+    0
+  );
+  const max = Object.keys(checks).length * 2;
+  return {
+    url: `/courses/${course.slug}`,
+    courseSlug: course.slug,
+    name: course.name,
+    score,
+    max,
+    pct: Math.round((score / max) * 100),
+    checks,
+  };
+}
+
+// ---- Reporting ------------------------------------------------------------
+
+function summarize(courseResults, postResults) {
+  const total = postResults.length;
+  const buckets = { pass: 0, warn: 0, fail: 0 };
+  const criteriaFails = {};
+  for (const p of postResults) {
+    if (p.failCount > 0) buckets.fail++;
+    else if (p.warnCount > 0) buckets.warn++;
+    else buckets.pass++;
+    for (const [key, check] of Object.entries(p.checks)) {
+      if (check.status === "fail") {
+        criteriaFails[key] = (criteriaFails[key] || 0) + 1;
+      }
+    }
+  }
+  return {
+    posts: { total, ...buckets },
+    courses: {
+      total: courseResults.length,
+      fail: courseResults.filter((c) =>
+        Object.values(c.checks).some((x) => x.status === "fail")
+      ).length,
+    },
+    criteriaFails,
+  };
+}
+
+function fmtPct(n) {
+  return `${String(n).padStart(3)}%`;
+}
+
+function printReport(summary, courseResults, postResults, topN) {
+  const sorted = [...postResults].sort((a, b) => a.score - b.score);
+  const weakest = sorted.slice(0, topN);
+
+  console.log("\n=== SEO Content Audit ===");
+  console.log(`Courses: ${summary.courses.total} (${summary.courses.fail} with FAIL)`);
+  console.log(
+    `Posts:   ${summary.posts.total} | pass=${summary.posts.pass} warn=${summary.posts.warn} fail=${summary.posts.fail}`
+  );
+  console.log("\n-- Post-level FAIL counts by criterion --");
+  for (const [k, v] of Object.entries(summary.criteriaFails).sort(
+    (a, b) => b[1] - a[1]
+  )) {
+    console.log(`  ${k.padEnd(12)} ${v}`);
+  }
+
+  console.log("\n-- Courses --");
+  for (const c of courseResults) {
+    const tag = c.pct === 100 ? "PASS" : c.pct >= 75 ? "WARN" : "FAIL";
+    console.log(`  [${tag}] ${fmtPct(c.pct)} ${c.courseSlug}`);
+    for (const [key, check] of Object.entries(c.checks)) {
+      if (check.status !== "pass") {
+        console.log(`        - ${key}: ${check.status.toUpperCase()} (${check.note || check.value})`);
+      }
+    }
+  }
+
+  console.log(`\n-- Bottom ${topN} weakest posts --`);
+  for (const p of weakest) {
+    console.log(
+      `  ${fmtPct(p.pct)} ${p.url}  (fails:${p.failCount} warns:${p.warnCount})`
+    );
+    for (const [key, check] of Object.entries(p.checks)) {
+      if (check.status === "fail") {
+        console.log(`        - ${key}: ${check.note}`);
+      }
+    }
+  }
+}
+
+// ---- Main -----------------------------------------------------------------
+
+function main() {
+  const args = process.argv.slice(2);
+  const jsonOnly = args.includes("--json");
+  const warnAsFail = args.includes("--warn-as-fail");
+  const topIdx = args.indexOf("--top");
+  const topN = topIdx >= 0 ? Number(args[topIdx + 1]) || 15 : 15;
+
+  if (!fs.existsSync(COURSES_INDEX)) {
+    console.error(
+      `Missing ${COURSES_INDEX}. Run "npm run content:build" first.`
+    );
+    process.exit(2);
+  }
+
+  const idx = JSON.parse(fs.readFileSync(COURSES_INDEX, "utf8"));
+  const courseResults = [];
+  const postResults = [];
+
+  for (const course of idx.courses || []) {
+    courseResults.push(auditCourse(course));
+    for (const chapter of course.chapters || []) {
+      for (const post of chapter.posts || []) {
+        if (!post?.slug) continue;
+        postResults.push(auditPost(course.slug, course.name, post));
+      }
+    }
+  }
+
+  const summary = summarize(courseResults, postResults);
+  const date = new Date().toISOString().slice(0, 10);
+
+  if (!fs.existsSync(OUT_DIR)) fs.mkdirSync(OUT_DIR, { recursive: true });
+  const outPath = path.join(OUT_DIR, `audit-${date}.json`);
+  fs.writeFileSync(
+    outPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        rubric: {
+          postDescPass: POST_DESC_PASS,
+          postDescWarn: POST_DESC_WARN,
+          postTitleMin: POST_TITLE_MIN,
+          postTitleMax: POST_TITLE_MAX,
+          postBodyPass: POST_BODY_PASS,
+          postBodyWarn: POST_BODY_WARN,
+          courseDescPass: COURSE_DESC_PASS,
+          courseDescWarn: COURSE_DESC_WARN,
+        },
+        summary,
+        courses: courseResults,
+        posts: postResults,
+      },
+      null,
+      2
+    )
+  );
+
+  if (jsonOnly) {
+    console.log(outPath);
+  } else {
+    printReport(summary, courseResults, postResults, topN);
+    console.log(`\nFull report: ${outPath}`);
+  }
+
+  const hasFail =
+    summary.posts.fail > 0 ||
+    summary.courses.fail > 0 ||
+    (warnAsFail && summary.posts.warn > 0);
+  process.exit(hasFail ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
## Summary
- New `npm run audit:seo` script — grades every course + post against a 6-check rubric (description, effective SERP title, body, media, schema, publishedAt).
- New `docs/SEO_CONTENT_RUBRIC.md` — author-facing rubric + frontmatter template + thresholds rationale.
- Reports go to `.seo-audit/audit-<date>.json` (gitignored).

## Why
GSC 2026-05-28 shows ~287 not-indexed pages; primary cause is content thinness. Sitemap hygiene (#179) handled the structural side. This PR adds a deterministic, repeatable way to find and fix the content side, plus a framework so the bar is enforced for future courses.

## Baseline (2026-05-29)
- **Posts:** 233 total — 0 PASS, 101 WARN, 132 FAIL.
- **Courses:** 11 total — 3 PASS, 8 with at least one FAIL.

Top FAIL criteria (the levers):

| Criterion | FAIL count |
|---|---|
| `description` | 126 |
| `title` (effective SERP) | 82 |
| `media` | 1 |

Failing posts by course (descending):

| Course | Failing posts |
|---|---|
| `react-19-crash-course-for-beginners-2026-learn-in-90-minutes` | 23 |
| `angular-nestjs-fullstack-course` | 22 |
| `angular-in-90ish-minutes` | 20 |
| `react-redux-toolkit` | 15 |
| `mern-stack-crash-course` | 15 |
| `js-beginners-series` | 10 |
| `google-agent-development-kit-for-beginners` | 8 |
| `design-patterns-javascript` | 7 |
| `web-dev-basics` | 6 |
| `web-dev-bootcamp` | 6 |

## Usage

```bash
npm run audit:seo                  # full report + bottom-15 weakest
npm run audit:seo -- --top 30      # bottom-30
npm run audit:seo -- --warn-as-fail # CI-style exit code
npm run audit:seo:json             # only print JSON path (for tooling)
```

## CI integration
**Not blocking yet.** Too many existing FAILs (132). The rubric (`docs/SEO_CONTENT_RUBRIC.md`) calls out that we flip it to blocking once `summary.posts.fail === 0`.

## Test plan
- [x] `npm run audit:seo` runs successfully.
- [x] Exits 1 when FAILs exist (validated locally).
- [x] JSON report written to `.seo-audit/audit-2026-05-29.json`.
- [x] `.seo-audit/` ignored by git.
- [ ] Manual: confirm rubric matches `docs/SEO_CONTENT_RUBRIC.md`.

## Companion: Claude skill (not in this PR)
A user-scoped Claude skill `seo-content-audit` was added at `~/.claude/skills/seo-content-audit/SKILL.md` to make future audits + content fixes invokable as `/seo-content-audit`. It triggers on the audit script + rubric in this PR. Lives outside the repo by design — skill is per-user, framework is per-project.

## Follow-ups (separate PRs)
- Bulk-fill the 126 empty post descriptions (one PR per course).
- Trim the 8 Google ADK post titles to remove the duplicated course suffix.
- Add `VideoObject` JSON-LD on video posts (currently emits `Article` only).
- Add `Course` JSON-LD on `/courses/[slug]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)