### PR TITLE
feat(seo): Wave 1 — VideoObject + Course + Breadcrumb JSON-LD

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,13 +3,13 @@ gsd_state_version: 1.0
 milestone: v7.0
 milestone_name: Agentic Orchestra Upgrade
 status: verifying
-stopped_at: context exhaustion at 76% (2026-05-23)
-last_updated: "2026-05-23T13:36:16.010Z"
+stopped_at: context exhaustion at 75% (2026-05-29)
+last_updated: "2026-05-29T08:05:53.096Z"
 last_activity: 2026-05-23 — Phase 07 Wave 3 (07-03) complete
 progress:
   total_phases: 9
   completed_phases: 7
-  total_plans: 42
+  total_plans: 44
   completed_plans: 43
   percent: 78
 ---
@@ -226,8 +226,8 @@ Do not deploy the rules flip before `sync-custom-claims.ts` completes. Dual-clai
 
 ## Session Continuity
 
-Last session: 2026-05-23T13:36:16.004Z
-Stopped at: context exhaustion at 76% (2026-05-23)
+Last session: 2026-05-29T08:05:53.088Z
+Stopped at: context exhaustion at 75% (2026-05-29)
 Resume file: None
 
 ---

--- a/.planning/phases/tools-seo-indexability-uplift/01-videoobject-schema-PLAN.md
+++ b/.planning/phases/tools-seo-indexability-uplift/01-videoobject-schema-PLAN.md
@@ -1,0 +1,107 @@
+---
+phase: tools-seo-indexability-uplift
+plan: 01
+title: VideoObject JSON-LD on video posts
+type: execute
+wave: 1
+depends_on: []
+autonomous: true
+files_modified:
+  - src/lib/seo/videoSchema.ts
+  - src/app/courses/[course]/[post]/page.tsx
+  - src/__tests__/lib/seo/videoSchema.test.ts
+---
+
+<objective>
+Make every course post with `type: video` emit a Google-compliant `VideoObject` JSON-LD block in addition to the existing `Article` block. Lifts 232 / 233 posts out of "Crawled - currently not indexed" risk + makes them eligible for video rich results (thumbnail, duration, embed in SERP).
+
+Audit rubric currently reports `schema: WARN` for every video post (232 WARNs). This plan closes all 232 in one ship.
+</objective>
+
+<context>
+Today `src/app/courses/[course]/[post]/page.tsx` builds an `articleLd` object and emits one `<script type="application/ld+json">`. The rendered JSON is `Article` schema regardless of post type.
+
+Post frontmatter shape (verified via `src/content/courses.generated.json`):
+- `type: "video" | "article"`
+- `videoUrl: "https://www.youtube.com/watch?v=<ID>"` (sometimes with `&t=<seconds>s` or `&list=...`)
+- `thumbnail`: rarely set; fall back to `https://img.youtube.com/vi/<ID>/maxresdefault.jpg`
+- `publishedAt`: ISO string
+- `description`: may be empty (plan 04 fills it)
+
+YouTube ID parsing: handle both `youtube.com/watch?v=ID`, `youtu.be/ID`, and the `&t=` / `?si=` / `&list=` suffixes already in the dataset. `youtu.be/ID` is rare in this dataset but the parser should still cover it for future content.
+</context>
+
+<tasks>
+
+## Task 1: Create the schema builder util
+
+`src/lib/seo/videoSchema.ts` exports:
+
+```ts
+export function extractYouTubeId(url: string | undefined | null): string | null;
+
+export function buildVideoObjectLd(input: {
+  name: string;
+  description: string;
+  uploadDate: string;            // ISO
+  videoUrl: string;              // raw videoUrl from frontmatter
+  thumbnailOverride?: string;    // optional, overrides YouTube poster
+  pageUrl: string;               // canonical post URL
+}): Record<string, unknown> | null;  // null when YouTube ID can't be extracted
+```
+
+Rules:
+- If `extractYouTubeId` returns null, `buildVideoObjectLd` returns null (caller skips the script tag).
+- `embedUrl` = `https://www.youtube.com/embed/<id>`.
+- `thumbnailUrl` array: `[thumbnailOverride ?? maxresdefault.jpg, hqdefault.jpg]` (two URLs satisfies Google's recommendation of multiple resolutions).
+- `contentUrl` is intentionally OMITTED (we don't host the raw video file; the embedUrl is sufficient per schema.org).
+- `@context: "https://schema.org"`, `@type: "VideoObject"`.
+- `description`: trim. If empty after trim, return null (a VideoObject without a description is worse than no VideoObject — Google flags it).
+- `name`: trim. If empty, return null.
+
+## Task 2: Wire into the post page
+
+In `src/app/courses/[course]/[post]/page.tsx`:
+
+1. Import `buildVideoObjectLd` from `@/lib/seo/videoSchema`.
+2. After the existing `articleLd` block, conditionally build `videoLd` when `post.type === "video"` and `post.videoUrl` is truthy.
+3. Render a second `<script type="application/ld+json">` only when `videoLd !== null`.
+4. Use the same `JSON.stringify` pattern — no `JSON.parse(JSON.stringify(...))` round-trip; build the object inline.
+
+Do NOT touch the existing `articleLd` block. Both can coexist — Google accepts multiple JSON-LD blocks per page.
+
+## Task 3: Tests
+
+`src/__tests__/lib/seo/videoSchema.test.ts` (vitest):
+
+- `extractYouTubeId` cases: `watch?v=`, `youtu.be/`, `embed/`, with `&t=`, with `&list=`, with `?si=`, with `&start=`, missing URL → null, malformed URL → null, URL on a non-YouTube host → null.
+- `buildVideoObjectLd`:
+  - Happy path: returns object with `@type: "VideoObject"`, `thumbnailUrl` length 2, `embedUrl` shape, `description` preserved, `uploadDate` preserved.
+  - Description empty after trim → returns null.
+  - Name empty after trim → returns null.
+  - `thumbnailOverride` provided → appears as first entry in `thumbnailUrl`.
+  - YouTube ID unrecoverable → returns null.
+
+No integration test on the page component — JSON-LD is a string literal; if the builder util is correct and the page calls it on the right branch, the page emits the right output. The audit script will re-baseline schema check on next `npm run audit:seo`.
+
+</tasks>
+
+<verification>
+
+1. `npm run lint` clean.
+2. `npx tsc --noEmit` clean.
+3. `npm test -- src/__tests__/lib/seo/videoSchema.test.ts` passes.
+4. `npm run dev` + `curl -s http://localhost:3000/courses/web-dev-bootcamp/web-development-bootcamp-day-1-5 | grep -c 'application/ld+json'` returns `2`.
+5. The second script tag contains `"@type":"VideoObject"` and `"thumbnailUrl":[`.
+6. After deploy: paste a course post URL into Google Rich Results Test → `Video` detected, no errors.
+7. After `npm run audit:seo`: the `schema` check switches the video post rows from WARN to PASS (rubric in audit-seo.js needs an update — see task 4 below).
+
+## Task 4 (rubric sync)
+
+After tasks 1-3 land, update `scripts/content/audit-seo.js` `checkSchema()` to:
+- PASS for `type: video` posts (since they now emit VideoObject).
+- Keep WARN as a fallback if we ever introduce a post type we can't classify.
+
+Update `docs/SEO_CONTENT_RUBRIC.md` schema row accordingly.
+
+</verification>

--- a/.planning/phases/tools-seo-indexability-uplift/02-course-schema-and-breadcrumbs-PLAN.md
+++ b/.planning/phases/tools-seo-indexability-uplift/02-course-schema-and-breadcrumbs-PLAN.md
@@ -1,0 +1,97 @@
+---
+phase: tools-seo-indexability-uplift
+plan: 02
+title: Course + BreadcrumbList JSON-LD
+type: execute
+wave: 1
+depends_on: []
+autonomous: true
+files_modified:
+  - src/lib/seo/courseSchema.ts
+  - src/lib/seo/breadcrumbSchema.ts
+  - src/app/courses/[course]/page.tsx
+  - src/app/courses/[course]/[post]/page.tsx
+  - src/__tests__/lib/seo/courseSchema.test.ts
+  - src/__tests__/lib/seo/breadcrumbSchema.test.ts
+---
+
+<objective>
+Add `Course` JSON-LD on `/courses/[slug]` (11 pages) and `BreadcrumbList` JSON-LD on both `/courses/[slug]` and `/courses/[slug]/[post]` (244 pages total). Helps Google understand the site hierarchy + makes courses eligible for course rich-result carousels.
+
+Independent of plan 01 — both can ship in parallel; they touch overlapping files but different concerns, so coordinate via single PR.
+</objective>
+
+<context>
+- `/courses/[slug]/page.tsx` already exists (used `Read` earlier in the planning). Currently it does NOT emit any JSON-LD.
+- `/courses/[slug]/[post]/page.tsx` emits `Article` JSON-LD; plan 01 adds `VideoObject`; this plan adds `BreadcrumbList` (a third script tag).
+- Course schema required fields (Google): `name`, `description`, `provider`.
+- Recommended: `hasCourseInstance` (we can use `CourseInstance` with `courseMode: "online"` since these are self-paced YouTube series).
+- BreadcrumbList: position 1 = "Home" → `/`, position 2 = "Courses" → `/courses`, position 3 = course name → `/courses/<slug>`, (post page) position 4 = post title → `/courses/<slug>/<post>`.
+</context>
+
+<tasks>
+
+## Task 1: Course schema util
+
+`src/lib/seo/courseSchema.ts` exports:
+
+```ts
+export function buildCourseLd(input: {
+  name: string;
+  description: string;
+  url: string;
+  imageUrl?: string;        // course.banner.url
+  publishedAt?: string;     // ISO; used for dateCreated
+}): Record<string, unknown> | null;
+```
+
+Rules:
+- Return null if `name.trim()` or `description.trim()` is empty (don't ship a broken Course schema — Google will flag).
+- `provider`: hardcoded `{ "@type": "Organization", "name": "Code with Ahsan", "url": "https://www.codewithahsan.dev" }`.
+- `hasCourseInstance`: `{ "@type": "CourseInstance", "courseMode": "online", "courseWorkload": "PT1H" }` (placeholder workload; refine later if we capture duration).
+- Image: if `imageUrl` truthy, include `image: imageUrl`.
+
+## Task 2: Breadcrumb schema util
+
+`src/lib/seo/breadcrumbSchema.ts` exports:
+
+```ts
+export function buildBreadcrumbLd(items: Array<{ name: string; url: string }>): Record<string, unknown>;
+```
+
+Returns `BreadcrumbList` with positions 1..N. No null fallback — always returns a valid object (caller controls input).
+
+## Task 3: Wire into `/courses/[slug]/page.tsx`
+
+1. Build `courseLd` (Task 1) — render `<script type="application/ld+json">` if non-null.
+2. Build `breadcrumbLd` with 3 items: Home, Courses, course.name.
+3. Render the breadcrumb script tag unconditionally.
+
+`generateMetadata` should already exist for this route — verify it sets canonical to `/courses/<slug>` and the OG image to course banner. If not, add it.
+
+## Task 4: Wire into `/courses/[slug]/[post]/page.tsx`
+
+Add breadcrumb with 4 items: Home, Courses, course.name, post.title. Render a third `<script type="application/ld+json">`.
+
+## Task 5: Tests
+
+`src/__tests__/lib/seo/courseSchema.test.ts`:
+- Happy path returns full Course object.
+- Empty name or description → null.
+- imageUrl optional.
+
+`src/__tests__/lib/seo/breadcrumbSchema.test.ts`:
+- 3 items → 3-position list.
+- 4 items → 4-position list with correct positions.
+
+</tasks>
+
+<verification>
+
+1. `npm run lint` + `npx tsc --noEmit` clean.
+2. Unit tests pass.
+3. `curl -s http://localhost:3000/courses/web-dev-bootcamp | grep -c 'application/ld+json'` returns ≥ 2 (Course + Breadcrumb).
+4. `curl -s http://localhost:3000/courses/web-dev-bootcamp/web-development-bootcamp-day-1-5 | grep -c 'application/ld+json'` returns ≥ 3 (Article + VideoObject from plan 01 + Breadcrumb from this plan).
+5. Google Rich Results Test on both URLs detects `Course` + `BreadcrumbList` (+ `Article` + `VideoObject` on post).
+
+</verification>

--- a/.planning/phases/tools-seo-indexability-uplift/03-trim-adk-post-titles-PLAN.md
+++ b/.planning/phases/tools-seo-indexability-uplift/03-trim-adk-post-titles-PLAN.md
@@ -1,0 +1,54 @@
+---
+phase: tools-seo-indexability-uplift
+plan: 03
+title: Trim duplicated course suffix from Google ADK post titles
+type: execute
+wave: 2
+depends_on: [01]   # not technical — just sequencing to keep PRs small after wave 1 ships
+autonomous: true
+files_modified:
+  - src/content/courses/google-agent-development-kit-for-beginners/posts/*.mdx
+  - src/content/courses.generated.json   # regenerated via prebuild
+---
+
+<objective>
+Eight posts under `google-agent-development-kit-for-beginners` carry the full course name as a suffix inside the post title (e.g. `Building Your First AI Agent - Google Agent Development Kit for Beginners Part 1`). Page metadata then appends ` - <course name>` again, producing a 167–183 char effective SERP title that Google truncates with ellipsis ~70 chars in and visibly duplicates the course phrase.
+
+Trim the redundant suffix in the mdx frontmatter so the effective SERP title is 25–70 chars. Keeps "Part N" so post identity stays clear.
+</objective>
+
+<context>
+Audit baseline shows 8 posts in this course with `title` length 82–98 chars in the mdx frontmatter, producing effective SERP titles 164–183 chars after the page appends the course name.
+
+Identified posts (from audit JSON):
+
+| Slug | Current title | Proposed title |
+|---|---|---|
+| `building-your-first-ai-agent---google-agent-development-kit-for-beginners-part-1` | Building Your First AI Agent - Google Agent Development Kit for Beginners Part 1 | Building Your First AI Agent (Part 1) |
+| `working-with-tools--function-calling---google-agent-development-kit-for-beginners-part-2` | Working with Tools / Function Calling - Google Agent Development Kit for Beginners Part 2 | Working with Tools & Function Calling (Part 2) |
+| `using-multiple-ai-models-with-litellm---google-agent-development-kit-for-beginners-part-3` | Using Multiple AI Models with LiteLLM - Google Agent Development Kit for Beginners Part 3 | Using Multiple AI Models with LiteLLM (Part 3) |
+| `using-structured-datastructured-output---google-agent-development-kit-for-beginners-part-4` | Using Structured Data / Structured Output - Google Agent Development Kit for Beginners Part 4 | Structured Output with Pydantic Schemas (Part 4) |
+| `how-to-use-sessions--state-in-google-adk---google-agent-development-kit-for-beginners-part-5` | How to Use Sessions & State in Google ADK - Google Agent Development Kit for Beginners Part 5 | Sessions & State in Google ADK (Part 5) |
+| `deploy-ai-agents-on-agent-engine-vertex-ai---google-agent-development-kit-for-beginners-part-6` | Deploy AI Agents on Agent Engine (Vertex AI) - Google Agent Development Kit for Beginners Part 6 | Deploy Agents to Vertex AI Agent Engine (Part 6) |
+| `how-to-use-callbacks-in-google-adk--google-agent-development-kit-for-beginners-part-7` | How to Use Callbacks in Google ADK - Google Agent Development Kit for Beginners Part 7 | Callbacks in Google ADK (Part 7) |
+| `build-ui-for-your-ai-agent-google-agent-development-kit-for-beginners-part-8` | Build UI for Your AI Agent - Google Agent Development Kit for Beginners Part 8 | Build a UI for Your AI Agent (Part 8) |
+
+Slug is NOT changing (would break canonical URLs and lose Google's existing crawl history). Only the `title:` frontmatter line.
+</context>
+
+<tasks>
+
+1. For each of the 8 mdx files, edit the `title:` frontmatter line to the proposed value above. Use `Edit` tool with the literal old line for safety.
+2. Run `npm run content:build`.
+3. Run `npm run audit:seo -- --top 5` — confirm none of these 8 posts appear in the bottom-5 anymore on the `title` criterion.
+
+</tasks>
+
+<verification>
+
+1. `npm run audit:seo`: `summary.criteriaFails.title` drops by 8 (82 → 74).
+2. Effective SERP title for each post is 50–70 chars after the page appends ` - <course name>`. (Course name is `Google Agent Development Kit for Beginners` = 42 chars, so post title can be up to ~25–28 chars and stay in band.)
+3. The 8 posts still resolve at the same URL (slugs unchanged).
+4. After deploy, GSC URL Inspection on one of these URLs shows the new title in the rendered page metadata.
+
+</verification>

--- a/.planning/phases/tools-seo-indexability-uplift/04-bulk-descriptions-per-course-PLAN.md
+++ b/.planning/phases/tools-seo-indexability-uplift/04-bulk-descriptions-per-course-PLAN.md
@@ -1,0 +1,88 @@
+---
+phase: tools-seo-indexability-uplift
+plan: 04
+title: Bulk-fill empty post descriptions per course
+type: execute
+wave: 3
+depends_on: [01, 02, 03]
+autonomous: false   # HUMAN-REVIEW: each course's batch needs user approval on the drafted descriptions
+files_modified:
+  - src/content/courses/<course-slug>/posts/*.mdx   # per sub-PR
+  - src/content/courses.generated.json
+---
+
+<objective>
+Fill the empty `description:` frontmatter field on 126 posts identified by the audit. Description is the single highest-leverage SEO criterion in the rubric — `summary.criteriaFails.description = 126` is the dominant FAIL.
+
+Ship as 10 sub-PRs (one per course) so each batch is reviewable in <5 min and a bad batch is independently revertible.
+</objective>
+
+<context>
+Courses ordered by failing-post count (audit 2026-05-29):
+
+| # | Course | Failing posts |
+|---|---|---|
+| 1 | `react-19-crash-course-for-beginners-2026-learn-in-90-minutes` | 23 |
+| 2 | `angular-nestjs-fullstack-course` | 22 |
+| 3 | `angular-in-90ish-minutes` | 20 |
+| 4 | `react-redux-toolkit` | 15 |
+| 5 | `mern-stack-crash-course` | 15 |
+| 6 | `js-beginners-series` | 10 |
+| 7 | `google-agent-development-kit-for-beginners` | 8 |
+| 8 | `design-patterns-javascript` | 7 |
+| 9 | `web-dev-basics` | 6 |
+| 10 | `web-dev-bootcamp` | 6 |
+
+Source signal for drafting each description:
+- Post `title` (what the lesson is).
+- Post `videoUrl` — YouTube video title is the strongest hint (fetch via oEmbed if needed: `https://www.youtube.com/oembed?url=<encoded videoUrl>&format=json`).
+- Course `name` + `description` (topic + tech stack context).
+
+Description rules:
+- 120–160 chars (audit rubric pass threshold = 120).
+- Lead with the outcome / topic, not "In this video".
+- Mention the tech stack explicitly (React, Angular, NestJS, JavaScript, etc.).
+- End with a benefit or scope hint when room allows.
+- Quote-safe YAML (escape internal single quotes; use double-quoted YAML strings if needed).
+
+Example:
+```yaml
+# Before
+description: ''
+# After
+description: "Learn how to compose React 19 components with the new use() hook for async data, including loading states and error boundaries with Suspense."
+```
+</context>
+
+<workflow>
+
+For each course (in priority order above):
+
+1. Read the course's mdx post files.
+2. For each post with empty `description`, fetch YouTube oEmbed for the videoUrl (if API rate-limit tolerates) and draft a description.
+3. Present the draft batch to the user as a markdown table (post slug → proposed description).
+4. On user approval: apply edits via `Edit` tool, run `npm run audit:seo`, commit with message `chore(seo): fill descriptions for <course-slug> (N posts)`.
+5. Open one PR per course. Don't bundle.
+
+If oEmbed is rate-limited or returns non-200, fall back to inferring from the post title alone. Flag the post as "low-confidence" in the user-review table and let the user adjust.
+
+</workflow>
+
+<verification>
+
+After all 10 sub-PRs merge:
+
+1. `npm run audit:seo`: `summary.criteriaFails.description = 0`.
+2. `summary.posts.fail` drops by ≥126.
+3. GSC re-validation 4 weeks later: `Crawled - currently not indexed` is flat or down; `Indexed` is up.
+
+</verification>
+
+<notes>
+This plan is the **only** non-autonomous one in the phase. The user must approve each course batch because:
+- Descriptions are user-facing copy.
+- AI-drafted descriptions need a quick human sanity-check for tone / accuracy (e.g. avoiding inventing a feature the video doesn't cover).
+- One bad batch shouldn't block the others.
+
+If the user prefers to draft descriptions themselves and just wants the script to flag empties, this plan converts to "report-only" — drop the autonomous=false flag and skip the drafting step.
+</notes>

--- a/.planning/phases/tools-seo-indexability-uplift/CONTEXT.md
+++ b/.planning/phases/tools-seo-indexability-uplift/CONTEXT.md
@@ -1,0 +1,49 @@
+---
+phase: tools-seo-indexability-uplift
+created: 2026-05-29
+trigger: GSC Coverage report 2026-05-28 — 44 indexed / 353 not-indexed; `Crawled - currently not indexed` trending up (57 → 66 in one week); 126/233 course posts have empty `description` frontmatter.
+prior_work:
+  - "PR #179: sitemap hygiene — dropped /resources + /submissions from sitemap, added noindex on both routes."
+  - "PR #180: audit framework — added `npm run audit:seo` + docs/SEO_CONTENT_RUBRIC.md + Claude skill `seo-content-audit`."
+---
+
+# Phase: SEO Indexability Uplift
+
+## Why
+
+Two PRs landed the **structural** side (sitemap + tooling). This phase lands the **content + schema** side: the rich-result schema upgrade for 232 video posts, redundant-suffix cleanup in 8 ADK post titles, the course-level `Course` / `BreadcrumbList` schema, and the bulk description fills that the audit rubric flagged as the dominant FAIL criterion (126 posts).
+
+All 4 plans below target the levers identified in the 2026-05-29 audit baseline (`summary.criteriaFails.description = 126`, `summary.criteriaFails.title = 82`, `summary.criteriaFails.schema (WARN) = 232 video posts`).
+
+## Scope
+
+| # | Plan | Type | Files / Posts | Wave |
+|---|---|---|---|---|
+| 01 | `VideoObject` JSON-LD on video posts | Code | 1 file, lifts all 232 video posts | 1 |
+| 02 | `Course` + `BreadcrumbList` JSON-LD on course pages | Code | 2 files, 11 courses + 233 posts | 1 |
+| 03 | Trim duplicated course suffix from 8 ADK post titles | Content | 8 mdx files | 2 |
+| 04 | Bulk-fill empty post descriptions per course (×10 courses) | Content | ≤126 mdx files | 3 (one PR per course) |
+
+Wave 1 (plans 01 + 02) is pure code — safe to ship in parallel, no content auth needed.
+Wave 2 (plan 03) is content but tiny + clearly mechanical.
+Wave 3 (plan 04) is content with editorial judgement — split into 10 sub-PRs, one per course, drafted from the YouTube video title/description and reviewed by the user before merge.
+
+## Out of scope
+
+- Adding transcripts to video posts (separate effort, requires YouTube API or manual work; not blocking indexing).
+- Adding missing course banners (`design-patterns-javascript`, `js-beginners-series`) — handled as separate one-off commits.
+- 404 / 5xx triage from GSC URL exports — separate phase pending fresh GSC export.
+
+## Success criteria
+
+1. `npm run audit:seo`: `summary.criteriaFails.description` drops from 126 → 0 (after plan 04 across all 10 courses).
+2. `summary.criteriaFails.title` drops from 82 → at most 74 (after plan 03 closes the 8 ADK posts).
+3. `summary.posts.warn` for `schema` check drops from 232 → 0 (after plan 01 emits VideoObject).
+4. `/courses/[slug]` pages emit `Course` JSON-LD (validated via Google Rich Results Test).
+5. GSC Coverage report 4 weeks after merge: `Crawled - currently not indexed` is flat or down, `Indexed` is up.
+
+## Tracking
+
+- Per-plan PR linked back in each `*-SUMMARY.md`.
+- GSC re-validation requested in GSC UI after waves 1–2 merge.
+- Re-baseline audit (`npm run audit:seo`) at end of each wave, store JSON in commit message.

--- a/docs/SEO_CONTENT_RUBRIC.md
+++ b/docs/SEO_CONTENT_RUBRIC.md
@@ -35,7 +35,7 @@ The script reads `src/content/courses.generated.json` and the underlying `.mdx` 
 | body word count *(article posts only)* | ≥ 150 | ≥ 50 | < 50 |
 | body for video posts | ≥ 50 word summary/transcript | empty | (never fails) |
 | media | thumbnail set | videoUrl only | neither |
-| schema (page output) | `Article` (article) | `Article` only on `type: video` post | — |
+| schema (page output) | `Article` (article) OR `Article + VideoObject` (video w/ description + YouTube URL) | video w/ empty description or non-YouTube videoUrl (VideoObject suppressed) | — |
 | `publishedAt` | present | — | missing |
 
 Score = pass(2) + warn(1) + fail(0). 6 checks × 2 = max 12 per post.
@@ -71,7 +71,7 @@ For a course (`course.mdx`), fill:
 ## Known systemic gaps (2026-05-29 snapshot)
 
 - **126 / 233 posts have empty `description`** — biggest indexing lever.
-- **232 / 233 posts are `type: video`** but page emits `Article` JSON-LD only — should emit `VideoObject` for video rich results.
+- ~~**232 / 233 posts are `type: video`** but page emits `Article` JSON-LD only — should emit `VideoObject` for video rich results.~~ ✅ **Closed by Plan 01 (2026-05-29)** — `/courses/[slug]/[post]` now emits `VideoObject` alongside `Article` whenever post type is video, videoUrl is a YouTube URL, and description is non-empty. Posts with empty description still suppress VideoObject until Plan 04 fills them.
 - **8 Google ADK posts** carry full course suffix in the post title (`... - Google Agent Development Kit for Beginners Part N`), then the page metadata appends ` - <course name>` again → 160+ char SERP title. Strip the redundant suffix from `title:` in the mdx frontmatter.
 - **2 courses missing `banner.url`** (`design-patterns-javascript`, `js-beginners-series`).
 - **3 courses missing/short `description`** (`angular-in-90ish-minutes`, `react-redux-toolkit`, `angular-nestjs-fullstack-course`).

--- a/scripts/content/audit-seo.js
+++ b/scripts/content/audit-seo.js
@@ -156,17 +156,30 @@ function checkBody(courseSlug, post) {
 }
 
 function checkSchema(post) {
-  // Page currently emits Article schema on /courses/[slug]/[post]/page.tsx for
-  // every post regardless of type. Video posts should emit VideoObject (or both)
-  // so Google can show video rich results in SERP.
-  if (post.type === "video") {
+  // Page emits Article + VideoObject JSON-LD on video posts (see
+  // src/lib/seo/videoSchema.ts). Article-only posts get Article JSON-LD.
+  // VideoObject requires non-empty description + a recoverable YouTube ID;
+  // both conditions are validated in buildVideoObjectLd() at render time, so
+  // here we predict the same outcome to keep the audit honest.
+  if (post.type !== "video") return { status: "pass", value: "Article" };
+
+  const desc = (post.description || "").trim();
+  const url = (post.videoUrl || "").trim();
+  if (!desc) {
     return {
       status: "warn",
       value: "Article-only",
-      note: "video post emits Article schema only — add VideoObject schema for video rich results",
+      note: "video post: VideoObject suppressed — empty description blocks emit",
     };
   }
-  return { status: "pass", value: "Article" };
+  if (!url || !/youtu\.be|youtube\.com/.test(url)) {
+    return {
+      status: "warn",
+      value: "Article-only",
+      note: "video post: VideoObject suppressed — videoUrl missing or not YouTube",
+    };
+  }
+  return { status: "pass", value: "Article+VideoObject" };
 }
 
 // ---- Audit runners --------------------------------------------------------

--- a/src/__tests__/lib/seo/breadcrumbSchema.test.ts
+++ b/src/__tests__/lib/seo/breadcrumbSchema.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { buildBreadcrumbLd } from "@/lib/seo/breadcrumbSchema";
+
+const BASE = "https://www.codewithahsan.dev";
+
+describe("buildBreadcrumbLd", () => {
+  it("builds 3-position list for course page", () => {
+    const ld = buildBreadcrumbLd([
+      { name: "Home", url: `${BASE}/` },
+      { name: "Courses", url: `${BASE}/courses` },
+      { name: "Web Dev Bootcamp", url: `${BASE}/courses/web-dev-bootcamp` },
+    ]);
+    expect(ld).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+    });
+    expect((ld.itemListElement as unknown[])).toHaveLength(3);
+    expect((ld.itemListElement as Array<Record<string, unknown>>)[2]).toEqual({
+      "@type": "ListItem",
+      position: 3,
+      name: "Web Dev Bootcamp",
+      item: `${BASE}/courses/web-dev-bootcamp`,
+    });
+  });
+
+  it("builds 4-position list for post page", () => {
+    const ld = buildBreadcrumbLd([
+      { name: "Home", url: `${BASE}/` },
+      { name: "Courses", url: `${BASE}/courses` },
+      { name: "Web Dev Bootcamp", url: `${BASE}/courses/web-dev-bootcamp` },
+      { name: "Day 1", url: `${BASE}/courses/web-dev-bootcamp/day-1` },
+    ]);
+    expect((ld.itemListElement as unknown[])).toHaveLength(4);
+    expect(
+      (ld.itemListElement as Array<Record<string, unknown>>)[3].position
+    ).toBe(4);
+  });
+
+  it("preserves item order", () => {
+    const items = [
+      { name: "A", url: "https://x/a" },
+      { name: "B", url: "https://x/b" },
+    ];
+    const ld = buildBreadcrumbLd(items);
+    const list = ld.itemListElement as Array<Record<string, unknown>>;
+    expect(list[0].name).toBe("A");
+    expect(list[0].position).toBe(1);
+    expect(list[1].name).toBe("B");
+    expect(list[1].position).toBe(2);
+  });
+});

--- a/src/__tests__/lib/seo/courseSchema.test.ts
+++ b/src/__tests__/lib/seo/courseSchema.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { buildCourseLd } from "@/lib/seo/courseSchema";
+
+const BASE = "https://www.codewithahsan.dev";
+
+describe("buildCourseLd", () => {
+  const baseInput = {
+    name: "Web Development Bootcamp",
+    description:
+      "A 10-week guided learning path covering HTML5, CSS3, JavaScript, and modern web tooling.",
+    url: `${BASE}/courses/web-dev-bootcamp`,
+    baseUrl: BASE,
+  };
+
+  it("builds Course schema with required fields", () => {
+    const ld = buildCourseLd(baseInput);
+    expect(ld).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "Course",
+      name: baseInput.name,
+      description: baseInput.description,
+      url: baseInput.url,
+      provider: {
+        "@type": "Organization",
+        name: "Code with Ahsan",
+        url: BASE,
+        sameAs: BASE,
+      },
+      hasCourseInstance: {
+        "@type": "CourseInstance",
+        courseMode: "online",
+      },
+    });
+  });
+
+  it("includes image when provided", () => {
+    const ld = buildCourseLd({
+      ...baseInput,
+      imageUrl: "https://cdn.example/banner.jpg",
+    });
+    expect(ld?.image).toBe("https://cdn.example/banner.jpg");
+  });
+
+  it("omits image when not provided", () => {
+    const ld = buildCourseLd(baseInput);
+    expect(ld).not.toHaveProperty("image");
+  });
+
+  it("includes author when provided", () => {
+    const ld = buildCourseLd({ ...baseInput, authorName: "Muhammad Ahsan Ayaz" });
+    expect(ld?.author).toEqual({
+      "@type": "Person",
+      name: "Muhammad Ahsan Ayaz",
+    });
+  });
+
+  it("returns null when name is empty", () => {
+    expect(buildCourseLd({ ...baseInput, name: "" })).toBeNull();
+    expect(buildCourseLd({ ...baseInput, name: "   " })).toBeNull();
+  });
+
+  it("returns null when description is empty", () => {
+    expect(buildCourseLd({ ...baseInput, description: "" })).toBeNull();
+  });
+});

--- a/src/__tests__/lib/seo/videoSchema.test.ts
+++ b/src/__tests__/lib/seo/videoSchema.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractYouTubeId,
+  buildVideoObjectLd,
+} from "@/lib/seo/videoSchema";
+
+describe("extractYouTubeId", () => {
+  it("parses watch?v= URL", () => {
+    expect(extractYouTubeId("https://www.youtube.com/watch?v=NqDEt2FbvCA")).toBe(
+      "NqDEt2FbvCA"
+    );
+  });
+
+  it("parses watch?v= with &t= timestamp", () => {
+    expect(
+      extractYouTubeId("https://www.youtube.com/watch?v=NqDEt2FbvCA&t=0s")
+    ).toBe("NqDEt2FbvCA");
+  });
+
+  it("parses watch?v= with &list= playlist suffix", () => {
+    expect(
+      extractYouTubeId(
+        "https://www.youtube.com/watch?v=NqDEt2FbvCA&list=PLABCDEF"
+      )
+    ).toBe("NqDEt2FbvCA");
+  });
+
+  it("parses youtu.be short URL", () => {
+    expect(extractYouTubeId("https://youtu.be/Knn0TN2j8vc")).toBe(
+      "Knn0TN2j8vc"
+    );
+  });
+
+  it("parses youtu.be with ?si= share suffix", () => {
+    expect(
+      extractYouTubeId("https://youtu.be/Knn0TN2j8vc?si=abc123")
+    ).toBe("Knn0TN2j8vc");
+  });
+
+  it("parses /embed/ URL", () => {
+    expect(
+      extractYouTubeId("https://www.youtube.com/embed/Knn0TN2j8vc")
+    ).toBe("Knn0TN2j8vc");
+  });
+
+  it("parses /shorts/ URL", () => {
+    expect(
+      extractYouTubeId("https://www.youtube.com/shorts/Knn0TN2j8vc")
+    ).toBe("Knn0TN2j8vc");
+  });
+
+  it("returns null for non-YouTube hosts", () => {
+    expect(extractYouTubeId("https://vimeo.com/123456")).toBeNull();
+  });
+
+  it("returns null for malformed URLs", () => {
+    expect(extractYouTubeId("not a url")).toBeNull();
+  });
+
+  it("returns null for null / undefined", () => {
+    expect(extractYouTubeId(null)).toBeNull();
+    expect(extractYouTubeId(undefined)).toBeNull();
+    expect(extractYouTubeId("")).toBeNull();
+  });
+
+  it("returns null when /watch is missing v param", () => {
+    expect(extractYouTubeId("https://www.youtube.com/watch")).toBeNull();
+  });
+});
+
+describe("buildVideoObjectLd", () => {
+  const baseInput = {
+    name: "Intro to React 19",
+    description: "Learn the new use() hook and Suspense patterns in React 19.",
+    uploadDate: "2026-03-01T00:00:00.000Z",
+    videoUrl: "https://www.youtube.com/watch?v=NqDEt2FbvCA&t=0s",
+    pageUrl: "https://www.codewithahsan.dev/courses/react/intro",
+  };
+
+  it("builds a full VideoObject for happy path", () => {
+    const ld = buildVideoObjectLd(baseInput);
+    expect(ld).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "VideoObject",
+      name: "Intro to React 19",
+      description: baseInput.description,
+      uploadDate: baseInput.uploadDate,
+      embedUrl: "https://www.youtube.com/embed/NqDEt2FbvCA",
+    });
+  });
+
+  it("emits 2 thumbnail URLs (max + hq) without override", () => {
+    const ld = buildVideoObjectLd(baseInput);
+    expect(ld?.thumbnailUrl).toEqual([
+      "https://img.youtube.com/vi/NqDEt2FbvCA/maxresdefault.jpg",
+      "https://img.youtube.com/vi/NqDEt2FbvCA/hqdefault.jpg",
+    ]);
+  });
+
+  it("prepends override thumbnail", () => {
+    const ld = buildVideoObjectLd({
+      ...baseInput,
+      thumbnailOverride: "https://cdn.example/custom.jpg",
+    });
+    expect((ld?.thumbnailUrl as string[])[0]).toBe(
+      "https://cdn.example/custom.jpg"
+    );
+    expect((ld?.thumbnailUrl as string[]).length).toBe(3);
+  });
+
+  it("returns null when description is empty after trim", () => {
+    expect(buildVideoObjectLd({ ...baseInput, description: "  " })).toBeNull();
+  });
+
+  it("returns null when name is empty after trim", () => {
+    expect(buildVideoObjectLd({ ...baseInput, name: "" })).toBeNull();
+  });
+
+  it("returns null when videoUrl is unrecoverable", () => {
+    expect(
+      buildVideoObjectLd({ ...baseInput, videoUrl: "https://vimeo.com/x" })
+    ).toBeNull();
+  });
+
+  it("sets mainEntityOfPage to the page URL", () => {
+    const ld = buildVideoObjectLd(baseInput);
+    expect(ld?.mainEntityOfPage).toEqual({
+      "@type": "WebPage",
+      "@id": baseInput.pageUrl,
+    });
+  });
+});

--- a/src/app/courses/[course]/[post]/page.tsx
+++ b/src/app/courses/[course]/[post]/page.tsx
@@ -10,6 +10,7 @@ import {
   getPostBySlug,
 } from "@/lib/content/contentProvider";
 import { buildVideoObjectLd } from "@/lib/seo/videoSchema";
+import { buildBreadcrumbLd } from "@/lib/seo/breadcrumbSchema";
 
 const BASE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.codewithahsan.dev";
@@ -148,6 +149,12 @@ export default async function Page({
           pageUrl,
         })
       : null;
+  const breadcrumbLd = buildBreadcrumbLd([
+    { name: "Home", url: `${BASE_URL}/` },
+    { name: "Courses", url: `${BASE_URL}/courses` },
+    { name: course.name, url: `${BASE_URL}/courses/${courseSlug}` },
+    { name: post.title, url: pageUrl },
+  ]);
 
   return (
     <div className="page-padding">
@@ -161,6 +168,10 @@ export default async function Page({
           dangerouslySetInnerHTML={{ __html: JSON.stringify(videoLd) }}
         />
       )}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
       <PostDetail
         course={JSON.parse(JSON.stringify(course))}
         post={JSON.parse(JSON.stringify(post))}

--- a/src/app/courses/[course]/[post]/page.tsx
+++ b/src/app/courses/[course]/[post]/page.tsx
@@ -9,6 +9,7 @@ import {
   getCourses,
   getPostBySlug,
 } from "@/lib/content/contentProvider";
+import { buildVideoObjectLd } from "@/lib/seo/videoSchema";
 
 const BASE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.codewithahsan.dev";
@@ -135,12 +136,31 @@ export default async function Page({
     },
   };
 
+  const pageUrl = `${BASE_URL}/courses/${courseSlug}/${postSlug}`;
+  const videoLd =
+    post.type === "video" && post.videoUrl
+      ? buildVideoObjectLd({
+          name: post.title,
+          description: post.description ?? siteMetadata.description,
+          uploadDate: post.publishedAt ?? new Date().toISOString(),
+          videoUrl: post.videoUrl,
+          thumbnailOverride: post.thumbnail || course.banner,
+          pageUrl,
+        })
+      : null;
+
   return (
     <div className="page-padding">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(articleLd) }}
       />
+      {videoLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(videoLd) }}
+        />
+      )}
       <PostDetail
         course={JSON.parse(JSON.stringify(course))}
         post={JSON.parse(JSON.stringify(post))}

--- a/src/app/courses/[course]/page.tsx
+++ b/src/app/courses/[course]/page.tsx
@@ -3,6 +3,8 @@ import Course from "@/classes/Course.class";
 import CourseDetail from "./CourseDetail";
 import siteMetadata from "@/data/siteMetadata";
 import { getCourseBySlug, getCourses } from "@/lib/content/contentProvider";
+import { buildCourseLd } from "@/lib/seo/courseSchema";
+import { buildBreadcrumbLd } from "@/lib/seo/breadcrumbSchema";
 
 const BASE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.codewithahsan.dev";
@@ -72,28 +74,32 @@ export default async function Page({
 
   const coursePlain = JSON.parse(JSON.stringify(course));
 
-  const courseLd = {
-    "@context": "https://schema.org",
-    "@type": "Course",
+  const courseUrl = `${BASE_URL}/courses/${slug}`;
+  const courseLd = buildCourseLd({
     name: course.name,
     description: course.description ?? siteMetadata.description,
-    url: `${BASE_URL}/courses/${slug}`,
-    ...(course.banner ? { image: course.banner } : {}),
-    provider: {
-      "@type": "Organization",
-      name: "Code with Ahsan",
-      sameAs: BASE_URL,
-    },
-    ...(course.authors?.[0]?.name
-      ? { author: { "@type": "Person", name: course.authors[0].name } }
-      : {}),
-  };
+    url: courseUrl,
+    baseUrl: BASE_URL,
+    imageUrl: course.banner || undefined,
+    authorName: course.authors?.[0]?.name,
+  });
+  const breadcrumbLd = buildBreadcrumbLd([
+    { name: "Home", url: `${BASE_URL}/` },
+    { name: "Courses", url: `${BASE_URL}/courses` },
+    { name: course.name, url: courseUrl },
+  ]);
 
   return (
     <div className="page-padding">
+      {courseLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(courseLd) }}
+        />
+      )}
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(courseLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
       />
       <CourseDetail course={coursePlain} />
     </div>

--- a/src/lib/seo/breadcrumbSchema.ts
+++ b/src/lib/seo/breadcrumbSchema.ts
@@ -1,0 +1,22 @@
+// BreadcrumbList JSON-LD builder.
+// See https://developers.google.com/search/docs/appearance/structured-data/breadcrumb
+
+export interface BreadcrumbItem {
+  name: string;
+  url: string;
+}
+
+export function buildBreadcrumbLd(
+  items: BreadcrumbItem[]
+): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, idx) => ({
+      "@type": "ListItem",
+      position: idx + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}

--- a/src/lib/seo/courseSchema.ts
+++ b/src/lib/seo/courseSchema.ts
@@ -1,0 +1,49 @@
+// Course JSON-LD builder. Centralizes the shape so the audit script + the page
+// agree on what gets emitted. See:
+//   - https://developers.google.com/search/docs/appearance/structured-data/course
+//   - .planning/phases/tools-seo-indexability-uplift/02-course-schema-and-breadcrumbs-PLAN.md
+
+const SITE_NAME = "Code with Ahsan";
+
+export interface CourseSchemaInput {
+  name: string;
+  description: string;
+  url: string;
+  baseUrl: string;
+  imageUrl?: string;
+  authorName?: string;
+}
+
+export function buildCourseLd(
+  input: CourseSchemaInput
+): Record<string, unknown> | null {
+  const name = (input.name || "").trim();
+  const description = (input.description || "").trim();
+  if (!name || !description) return null;
+
+  const ld: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Course",
+    name,
+    description,
+    url: input.url,
+    provider: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      url: input.baseUrl,
+      sameAs: input.baseUrl,
+    },
+    hasCourseInstance: {
+      "@type": "CourseInstance",
+      courseMode: "online",
+      courseWorkload: "PT1H",
+    },
+  };
+
+  if (input.imageUrl) ld.image = input.imageUrl;
+  if (input.authorName) {
+    ld.author = { "@type": "Person", name: input.authorName };
+  }
+
+  return ld;
+}

--- a/src/lib/seo/videoSchema.ts
+++ b/src/lib/seo/videoSchema.ts
@@ -1,0 +1,88 @@
+// VideoObject JSON-LD builder for YouTube-hosted course posts.
+// See docs/SEO_CONTENT_RUBRIC.md and .planning/phases/tools-seo-indexability-uplift/01-videoobject-schema-PLAN.md.
+
+const YT_HOSTS = new Set([
+  "youtube.com",
+  "www.youtube.com",
+  "m.youtube.com",
+  "youtu.be",
+  "www.youtu.be",
+]);
+
+export function extractYouTubeId(
+  url: string | undefined | null
+): string | null {
+  if (!url || typeof url !== "string") return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (!YT_HOSTS.has(parsed.hostname)) return null;
+
+  if (parsed.hostname.endsWith("youtu.be")) {
+    const id = parsed.pathname.replace(/^\//, "").split("/")[0];
+    return isValidId(id) ? id : null;
+  }
+
+  if (parsed.pathname === "/watch") {
+    const id = parsed.searchParams.get("v");
+    return id && isValidId(id) ? id : null;
+  }
+
+  if (parsed.pathname.startsWith("/embed/")) {
+    const id = parsed.pathname.slice("/embed/".length).split("/")[0];
+    return isValidId(id) ? id : null;
+  }
+
+  if (parsed.pathname.startsWith("/shorts/")) {
+    const id = parsed.pathname.slice("/shorts/".length).split("/")[0];
+    return isValidId(id) ? id : null;
+  }
+
+  return null;
+}
+
+function isValidId(id: string | undefined | null): id is string {
+  return !!id && /^[A-Za-z0-9_-]{6,}$/.test(id);
+}
+
+export interface VideoSchemaInput {
+  name: string;
+  description: string;
+  uploadDate: string;
+  videoUrl: string;
+  thumbnailOverride?: string;
+  pageUrl: string;
+}
+
+export function buildVideoObjectLd(
+  input: VideoSchemaInput
+): Record<string, unknown> | null {
+  const name = (input.name || "").trim();
+  const description = (input.description || "").trim();
+  if (!name || !description) return null;
+
+  const id = extractYouTubeId(input.videoUrl);
+  if (!id) return null;
+
+  const thumbnails: string[] = [];
+  if (input.thumbnailOverride) thumbnails.push(input.thumbnailOverride);
+  thumbnails.push(`https://img.youtube.com/vi/${id}/maxresdefault.jpg`);
+  thumbnails.push(`https://img.youtube.com/vi/${id}/hqdefault.jpg`);
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "VideoObject",
+    name,
+    description,
+    thumbnailUrl: thumbnails,
+    uploadDate: input.uploadDate,
+    embedUrl: `https://www.youtube.com/embed/${id}`,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": input.pageUrl,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- **Plan 01**: Emit `VideoObject` JSON-LD on 232 video posts (eligible for video rich results in SERPs). Built `src/lib/seo/videoSchema.ts` with YouTube URL parser (watch/youtu.be/embed/shorts). Suppresses emission if description empty or YouTube ID missing.
- **Plan 02**: Refactor inline Course schema to `src/lib/seo/courseSchema.ts`, add `hasCourseInstance` (`courseMode: online`). Add `BreadcrumbList` on 11 course pages (3 items) and 233 post pages (4 items).
- Phase doc: `.planning/phases/tools-seo-indexability-uplift/`
- 27 SEO tests added, all pass. TypeScript clean.

## Why
GSC report (2026-05-28): 44 indexed / 353 not-indexed. Schema enrichment + breadcrumbs target the "Crawled-not-indexed" bucket by adding crawl/SERP signals Google currently sees no reason to surface.

## Out of scope (later waves)
- Wave 2 (Plan 03): trim 8 long Google ADK post titles
- Wave 3 (Plan 04): bulk-fill 126 empty post descriptions

## Test plan
- [x] `npm run test -- src/__tests__/lib/seo/` — 27 pass
- [x] `npm run typecheck` clean
- [x] Manual: dev server renders correct JSON-LD blocks on course + post pages (verified ListItem counts, VideoObject presence on video posts)
- [ ] After merge: run `https://search.google.com/test/rich-results` on 1 course page + 1 video post + 1 article post
- [ ] After merge: submit canonical URLs in GSC URL Inspection → "Request indexing" on 3-5 high-priority pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)