### PR TITLE
content(seo): trim ADK course + 8 post titles (Plan 03)

### DIFF
--- a/src/content/courses.generated.json
+++ b/src/content/courses.generated.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T18:08:21.551Z",
+  "generatedAt": "2026-05-29T08:21:42.480Z",
   "source": "mdx",
   "count": 11,
   "courses": [
@@ -66,7 +66,7 @@
                 "name": "Introduction"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4806,
@@ -83,7 +83,7 @@
                 "name": "Introduction"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4659,
@@ -100,7 +100,7 @@
                 "name": "Introduction"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4808,
@@ -117,7 +117,7 @@
                 "name": "Introduction"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             }
           ]
         },
@@ -143,7 +143,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4810,
@@ -160,7 +160,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4811,
@@ -177,7 +177,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4812,
@@ -194,7 +194,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4813,
@@ -211,7 +211,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4815,
@@ -228,7 +228,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4814,
@@ -245,7 +245,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4816,
@@ -262,7 +262,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4851,
@@ -279,7 +279,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4852,
@@ -296,7 +296,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4853,
@@ -313,7 +313,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4854,
@@ -330,7 +330,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4804,
@@ -347,7 +347,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4805,
@@ -364,7 +364,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4855,
@@ -381,7 +381,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4856,
@@ -398,7 +398,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4857,
@@ -415,7 +415,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4858,
@@ -432,7 +432,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4859,
@@ -449,7 +449,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4860,
@@ -466,7 +466,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4861,
@@ -483,7 +483,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4862,
@@ -500,7 +500,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4643,
@@ -517,7 +517,7 @@
                 "name": "HTML5"
               },
               "resources": [],
-              "article": "Create a new project and create the following business card using HTML and CSS.  \r\nYou're supposed to have the following things as per mock:\r\n- Heading saying \"Business Card\"\r\n- Profile Image\r\n- Name & Email\r\n- Skills (put any random skills)\r\n- Interests (put any random interests)\r\n- Social links at the bottom with images\r\n  - Clicking on the image should navigate to the corresponding link in a new tab\r\n\r\n![Assignment](https://github.com/AhsanAyaz/slides/raw/main/talks/assets/images/web-dev-basics/assignments/basic-business-card.png)\r\n"
+              "article": "Create a new project and create the following business card using HTML and CSS.  \nYou're supposed to have the following things as per mock:\n- Heading saying \"Business Card\"\n- Profile Image\n- Name & Email\n- Skills (put any random skills)\n- Interests (put any random interests)\n- Social links at the bottom with images\n  - Clicking on the image should navigate to the corresponding link in a new tab\n\n![Assignment](https://github.com/AhsanAyaz/slides/raw/main/talks/assets/images/web-dev-basics/assignments/basic-business-card.png)\n"
             }
           ]
         },
@@ -543,7 +543,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4840,
@@ -560,7 +560,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4839,
@@ -577,7 +577,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4838,
@@ -594,7 +594,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4837,
@@ -611,7 +611,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4836,
@@ -628,7 +628,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4835,
@@ -645,7 +645,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4834,
@@ -662,7 +662,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4833,
@@ -679,7 +679,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4832,
@@ -696,7 +696,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4831,
@@ -713,7 +713,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4830,
@@ -730,7 +730,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4829,
@@ -747,7 +747,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4828,
@@ -764,7 +764,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4827,
@@ -781,7 +781,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4826,
@@ -798,7 +798,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4825,
@@ -815,7 +815,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4824,
@@ -832,7 +832,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4823,
@@ -849,7 +849,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4820,
@@ -866,7 +866,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4821,
@@ -883,7 +883,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4822,
@@ -900,7 +900,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4819,
@@ -917,7 +917,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4818,
@@ -934,7 +934,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4817,
@@ -951,7 +951,7 @@
                 "name": "CSS3"
               },
               "resources": [],
-              "article": "### Assignment\r\n\r\nCreate a new project and create the following portfolio site using HTML and CSS (without flexbox)\r\nYou're supposed to have the following things as per mock:\r\n\r\n#### Mockup\r\n\r\n![Assignment](https://raw.githubusercontent.com/AhsanAyaz/slides/main/talks/assets/images/web-dev-basics/assignments/portfolio-without-css.png)\r\n"
+              "article": "### Assignment\n\nCreate a new project and create the following portfolio site using HTML and CSS (without flexbox)\nYou're supposed to have the following things as per mock:\n\n#### Mockup\n\n![Assignment](https://raw.githubusercontent.com/AhsanAyaz/slides/main/talks/assets/images/web-dev-basics/assignments/portfolio-without-css.png)\n"
             }
           ]
         },
@@ -977,7 +977,7 @@
                 "name": "CSS Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4849,
@@ -994,7 +994,7 @@
                 "name": "CSS Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4848,
@@ -1011,7 +1011,7 @@
                 "name": "CSS Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4847,
@@ -1028,7 +1028,7 @@
                 "name": "CSS Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4845,
@@ -1045,7 +1045,7 @@
                 "name": "CSS Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4846,
@@ -1062,7 +1062,7 @@
                 "name": "CSS Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4844,
@@ -1079,7 +1079,7 @@
                 "name": "CSS Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4843,
@@ -1096,7 +1096,7 @@
                 "name": "CSS Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4602,
@@ -1113,7 +1113,7 @@
                 "name": "CSS Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4842,
@@ -1130,7 +1130,7 @@
                 "name": "CSS Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             }
           ]
         },
@@ -1156,7 +1156,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4863,
@@ -1173,7 +1173,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4701,
@@ -1190,7 +1190,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4702,
@@ -1207,7 +1207,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4703,
@@ -1224,7 +1224,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4704,
@@ -1241,7 +1241,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4737,
@@ -1258,7 +1258,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4736,
@@ -1275,7 +1275,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4735,
@@ -1292,7 +1292,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4734,
@@ -1309,7 +1309,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4733,
@@ -1326,7 +1326,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4732,
@@ -1343,7 +1343,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4731,
@@ -1360,7 +1360,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4730,
@@ -1377,7 +1377,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4729,
@@ -1394,7 +1394,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4728,
@@ -1411,7 +1411,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4727,
@@ -1428,7 +1428,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4726,
@@ -1445,7 +1445,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4725,
@@ -1462,7 +1462,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4724,
@@ -1479,7 +1479,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4723,
@@ -1496,7 +1496,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4722,
@@ -1513,7 +1513,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4721,
@@ -1530,7 +1530,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4720,
@@ -1547,7 +1547,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4719,
@@ -1564,7 +1564,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4718,
@@ -1581,7 +1581,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4717,
@@ -1598,7 +1598,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4716,
@@ -1615,7 +1615,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4715,
@@ -1632,7 +1632,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4714,
@@ -1649,7 +1649,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4713,
@@ -1666,7 +1666,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4712,
@@ -1683,7 +1683,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4711,
@@ -1700,7 +1700,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4710,
@@ -1717,7 +1717,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4709,
@@ -1734,7 +1734,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4708,
@@ -1751,7 +1751,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4707,
@@ -1768,7 +1768,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4706,
@@ -1785,7 +1785,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4705,
@@ -1802,7 +1802,7 @@
                 "name": "JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             }
           ]
         },
@@ -1828,7 +1828,7 @@
                 "name": "JavaScript Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4695,
@@ -1845,7 +1845,7 @@
                 "name": "JavaScript Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4696,
@@ -1862,7 +1862,7 @@
                 "name": "JavaScript Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4697,
@@ -1879,7 +1879,7 @@
                 "name": "JavaScript Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4698,
@@ -1896,7 +1896,7 @@
                 "name": "JavaScript Advanced"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             }
           ]
         },
@@ -1922,7 +1922,7 @@
                 "name": "Conclusion"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             }
           ]
         }
@@ -1958,7 +1958,7 @@
     {
       "id": 330,
       "slug": "google-agent-development-kit-for-beginners",
-      "name": "Building your first AI Agent - Google Agent Development Kit for Beginners (Part 1)",
+      "name": "Google Agent Development Kit for Beginners",
       "description": "Master the essentials of AI agent creation with this comprehensive guide to the Google Agent Development Kit (ADK) for beginners. You will learn to build, deploy, and scale intelligent agents using Vertex AI, function calling, and multi-model integration with LiteLLM. By the end of this course, you will be able to manage session states and develop custom user interfaces, transforming from a novice into a proficient AI developer.",
       "outline": "Master the essentials of AI agent creation with this comprehensive guide to the Google Agent Development Kit (ADK) for beginners. You will learn to build, deploy, and scale intelligent agents using Vertex AI, function calling, and multi-model integration with LiteLLM. By the end of this course, you will be able to manage session states and develop custom user interfaces, transforming from a novice into a proficient AI developer.",
       "publishedAt": "2026-03-11T09:45:32.004Z",
@@ -1983,7 +1983,7 @@
       "chapters": [
         {
           "id": 447,
-          "name": "Building your first AI Agent - Google Agent Development Kit for Beginners (Part 1)",
+          "name": "Google Agent Development Kit for Beginners",
           "description": "",
           "showName": false,
           "order": 0,
@@ -1991,7 +1991,7 @@
             {
               "id": 4887,
               "slug": "building-your-first-ai-agent---google-agent-development-kit-for-beginners-part-1",
-              "title": "Building your first AI Agent - Google Agent Development Kit for Beginners (Part 1)",
+              "title": "First AI Agent (Part 1)",
               "description": "",
               "type": "video",
               "videoUrl": "https://www.youtube.com/watch?v=r-JsrEoctCQ",
@@ -2000,15 +2000,15 @@
               "publishedAt": "2026-03-11T09:45:32.004Z",
               "chapter": {
                 "id": 447,
-                "name": "Building your first AI Agent - Google Agent Development Kit for Beginners (Part 1)"
+                "name": "Google Agent Development Kit for Beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4888,
               "slug": "working-with-tools--function-calling---google-agent-development-kit-for-beginners-part-2",
-              "title": "Working with Tools & Function calling - Google Agent Development Kit for Beginners (Part 2)",
+              "title": "Function Calling (Part 2)",
               "description": "",
               "type": "video",
               "videoUrl": "https://www.youtube.com/watch?v=nRpyp2m6mn8",
@@ -2017,15 +2017,15 @@
               "publishedAt": "2026-03-11T09:45:32.004Z",
               "chapter": {
                 "id": 447,
-                "name": "Building your first AI Agent - Google Agent Development Kit for Beginners (Part 1)"
+                "name": "Google Agent Development Kit for Beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4889,
               "slug": "using-multiple-ai-models-with-litellm---google-agent-development-kit-for-beginners-part-3",
-              "title": "Using multiple AI models with LiteLLM - Google Agent Development Kit for Beginners (Part 3)",
+              "title": "LiteLLM Models (Part 3)",
               "description": "",
               "type": "video",
               "videoUrl": "https://www.youtube.com/watch?v=Dg7laIcb1I8",
@@ -2034,15 +2034,15 @@
               "publishedAt": "2026-03-11T09:45:32.004Z",
               "chapter": {
                 "id": 447,
-                "name": "Building your first AI Agent - Google Agent Development Kit for Beginners (Part 1)"
+                "name": "Google Agent Development Kit for Beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4890,
               "slug": "using-structured-datastructured-output---google-agent-development-kit-for-beginners-part-4",
-              "title": "Using Structured Data/Structured Output - Google Agent Development Kit for Beginners (Part 4)",
+              "title": "Pydantic Output (Part 4)",
               "description": "",
               "type": "video",
               "videoUrl": "https://www.youtube.com/watch?v=u8tSzHb45MM",
@@ -2051,15 +2051,15 @@
               "publishedAt": "2026-03-11T09:45:32.004Z",
               "chapter": {
                 "id": 447,
-                "name": "Building your first AI Agent - Google Agent Development Kit for Beginners (Part 1)"
+                "name": "Google Agent Development Kit for Beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4891,
               "slug": "how-to-use-sessions--state-in-google-adk---google-agent-development-kit-for-beginners-part-5",
-              "title": "How to use Sessions & State in Google ADK - Google Agent Development Kit for Beginners (Part 5)",
+              "title": "Sessions & State (Part 5)",
               "description": "",
               "type": "video",
               "videoUrl": "https://www.youtube.com/watch?v=z8Q3qLi9m78",
@@ -2068,15 +2068,15 @@
               "publishedAt": "2026-03-11T09:45:32.004Z",
               "chapter": {
                 "id": 447,
-                "name": "Building your first AI Agent - Google Agent Development Kit for Beginners (Part 1)"
+                "name": "Google Agent Development Kit for Beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4892,
               "slug": "deploy-ai-agents-on-agent-engine-vertex-ai---google-agent-development-kit-for-beginners-part-6",
-              "title": "Deploy AI Agents on Agent Engine (Vertex AI) - Google Agent Development Kit for Beginners (Part 6)",
+              "title": "Vertex AI Deploy (Part 6)",
               "description": "",
               "type": "video",
               "videoUrl": "https://www.youtube.com/watch?v=6ISS31L3bqI",
@@ -2085,15 +2085,15 @@
               "publishedAt": "2026-03-11T09:45:32.004Z",
               "chapter": {
                 "id": 447,
-                "name": "Building your first AI Agent - Google Agent Development Kit for Beginners (Part 1)"
+                "name": "Google Agent Development Kit for Beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4893,
               "slug": "how-to-use-callbacks-in-google-adk--google-agent-development-kit-for-beginners-part-7",
-              "title": "How to use callbacks in Google ADK ? Google Agent Development Kit for Beginners (Part 7)",
+              "title": "Callbacks (Part 7)",
               "description": "",
               "type": "video",
               "videoUrl": "https://www.youtube.com/watch?v=yhUlAl08kII",
@@ -2102,15 +2102,15 @@
               "publishedAt": "2026-03-11T09:45:32.004Z",
               "chapter": {
                 "id": 447,
-                "name": "Building your first AI Agent - Google Agent Development Kit for Beginners (Part 1)"
+                "name": "Google Agent Development Kit for Beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4894,
               "slug": "build-ui-for-your-ai-agent-google-agent-development-kit-for-beginners-part-8",
-              "title": "Build UI for your AI Agent! Google Agent Development Kit for Beginners (Part 8)",
+              "title": "Build a UI (Part 8)",
               "description": "",
               "type": "video",
               "videoUrl": "https://www.youtube.com/watch?v=y7damsm8Qos",
@@ -2119,10 +2119,10 @@
               "publishedAt": "2026-03-11T09:45:32.004Z",
               "chapter": {
                 "id": 447,
-                "name": "Building your first AI Agent - Google Agent Development Kit for Beginners (Part 1)"
+                "name": "Google Agent Development Kit for Beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             }
           ]
         }
@@ -2176,7 +2176,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4672,
@@ -2193,7 +2193,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4677,
@@ -2210,7 +2210,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4663,
@@ -2227,7 +2227,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4662,
@@ -2244,7 +2244,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4665,
@@ -2261,7 +2261,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4675,
@@ -2278,7 +2278,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4676,
@@ -2295,7 +2295,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4667,
@@ -2312,7 +2312,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4673,
@@ -2329,7 +2329,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4671,
@@ -2346,7 +2346,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4666,
@@ -2363,7 +2363,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4670,
@@ -2380,7 +2380,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4668,
@@ -2397,7 +2397,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4681,
@@ -2414,7 +2414,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4664,
@@ -2431,7 +2431,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4674,
@@ -2448,7 +2448,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4669,
@@ -2465,7 +2465,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4679,
@@ -2482,7 +2482,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4678,
@@ -2499,7 +2499,7 @@
                 "name": "Angular in 90ish minutes"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             }
           ]
         }
@@ -2553,7 +2553,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4865,
@@ -2570,7 +2570,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4866,
@@ -2587,7 +2587,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4867,
@@ -2604,7 +2604,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4868,
@@ -2621,7 +2621,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4869,
@@ -2638,7 +2638,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4870,
@@ -2655,7 +2655,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4871,
@@ -2672,7 +2672,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4872,
@@ -2689,7 +2689,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4873,
@@ -2706,7 +2706,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4874,
@@ -2723,7 +2723,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4875,
@@ -2740,7 +2740,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4876,
@@ -2757,7 +2757,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4877,
@@ -2774,7 +2774,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4878,
@@ -2791,7 +2791,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4879,
@@ -2808,7 +2808,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4880,
@@ -2825,7 +2825,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4881,
@@ -2842,7 +2842,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4882,
@@ -2859,7 +2859,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4883,
@@ -2876,7 +2876,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4884,
@@ -2893,7 +2893,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4885,
@@ -2910,7 +2910,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4886,
@@ -2927,7 +2927,7 @@
                 "name": "React 19 Crash Course for Beginners 2026 (Learn in 90 Minutes)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             }
           ]
         }
@@ -2975,7 +2975,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4803,
@@ -2992,7 +2992,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4792,
@@ -3009,7 +3009,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4794,
@@ -3026,7 +3026,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4800,
@@ -3043,7 +3043,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4789,
@@ -3060,7 +3060,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4791,
@@ -3077,7 +3077,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4802,
@@ -3094,7 +3094,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4795,
@@ -3111,7 +3111,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4798,
@@ -3128,7 +3128,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4797,
@@ -3145,7 +3145,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4801,
@@ -3162,7 +3162,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4790,
@@ -3179,7 +3179,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4796,
@@ -3196,7 +3196,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4799,
@@ -3213,7 +3213,7 @@
                 "name": "React Redux Toolkit tutorial for beginners"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             }
           ]
         }
@@ -3261,7 +3261,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4762,
@@ -3278,7 +3278,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4763,
@@ -3295,7 +3295,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4764,
@@ -3312,7 +3312,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4765,
@@ -3329,7 +3329,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4766,
@@ -3346,7 +3346,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4767,
@@ -3363,7 +3363,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4768,
@@ -3380,7 +3380,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4769,
@@ -3397,7 +3397,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4770,
@@ -3414,7 +3414,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4771,
@@ -3431,7 +3431,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4772,
@@ -3448,7 +3448,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4773,
@@ -3465,7 +3465,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4774,
@@ -3482,7 +3482,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4776,
@@ -3499,7 +3499,7 @@
                 "name": "MERN Stack Crash Course Default Chapter"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             }
           ]
         }
@@ -3547,7 +3547,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4779,
@@ -3564,7 +3564,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4688,
@@ -3581,7 +3581,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4785,
@@ -3598,7 +3598,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4782,
@@ -3615,7 +3615,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4686,
@@ -3632,7 +3632,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4781,
@@ -3649,7 +3649,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4777,
@@ -3666,7 +3666,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4784,
@@ -3683,7 +3683,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4685,
@@ -3700,7 +3700,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4687,
@@ -3717,7 +3717,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4786,
@@ -3734,7 +3734,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4780,
@@ -3751,7 +3751,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4684,
@@ -3768,7 +3768,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4778,
@@ -3785,7 +3785,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4682,
@@ -3802,7 +3802,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4690,
@@ -3819,7 +3819,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4787,
@@ -3836,7 +3836,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4691,
@@ -3853,7 +3853,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4683,
@@ -3870,7 +3870,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4788,
@@ -3887,7 +3887,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4689,
@@ -3904,7 +3904,7 @@
                 "name": "Angular NestJS FullStack Course"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             }
           ]
         }
@@ -3978,7 +3978,7 @@
                 "name": "Web Development Bootcamp (Figma Design to HTML and CSS)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4756,
@@ -3995,7 +3995,7 @@
                 "name": "Web Development Bootcamp (Figma Design to HTML and CSS)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4757,
@@ -4012,7 +4012,7 @@
                 "name": "Web Development Bootcamp (Figma Design to HTML and CSS)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4758,
@@ -4029,7 +4029,7 @@
                 "name": "Web Development Bootcamp (Figma Design to HTML and CSS)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4759,
@@ -4046,7 +4046,7 @@
                 "name": "Web Development Bootcamp (Figma Design to HTML and CSS)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4760,
@@ -4063,7 +4063,7 @@
                 "name": "Web Development Bootcamp (Figma Design to HTML and CSS)"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             }
           ]
         }
@@ -4109,7 +4109,7 @@
                 "name": "Design Patterns in JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4751,
@@ -4126,7 +4126,7 @@
                 "name": "Design Patterns in JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4753,
@@ -4143,7 +4143,7 @@
                 "name": "Design Patterns in JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4752,
@@ -4160,7 +4160,7 @@
                 "name": "Design Patterns in JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4750,
@@ -4177,7 +4177,7 @@
                 "name": "Design Patterns in JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4754,
@@ -4194,7 +4194,7 @@
                 "name": "Design Patterns in JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4755,
@@ -4211,7 +4211,7 @@
                 "name": "Design Patterns in JavaScript"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             }
           ]
         }
@@ -4257,7 +4257,7 @@
                 "name": "JavaScript Beginners Series"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4740,
@@ -4274,7 +4274,7 @@
                 "name": "JavaScript Beginners Series"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4741,
@@ -4291,7 +4291,7 @@
                 "name": "JavaScript Beginners Series"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4742,
@@ -4308,7 +4308,7 @@
                 "name": "JavaScript Beginners Series"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4743,
@@ -4325,7 +4325,7 @@
                 "name": "JavaScript Beginners Series"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4744,
@@ -4342,7 +4342,7 @@
                 "name": "JavaScript Beginners Series"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4745,
@@ -4359,7 +4359,7 @@
                 "name": "JavaScript Beginners Series"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4746,
@@ -4376,7 +4376,7 @@
                 "name": "JavaScript Beginners Series"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4747,
@@ -4393,7 +4393,7 @@
                 "name": "JavaScript Beginners Series"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             },
             {
               "id": 4748,
@@ -4410,7 +4410,7 @@
                 "name": "JavaScript Beginners Series"
               },
               "resources": [],
-              "article": "\r\n"
+              "article": "\n"
             }
           ]
         }

--- a/src/content/courses/google-agent-development-kit-for-beginners/course.mdx
+++ b/src/content/courses/google-agent-development-kit-for-beginners/course.mdx
@@ -1,9 +1,7 @@
 ---
 id: 330
 slug: google-agent-development-kit-for-beginners
-name: >-
-  Building your first AI Agent - Google Agent Development Kit for Beginners
-  (Part 1)
+name: Google Agent Development Kit for Beginners
 description: >-
   Master the essentials of AI agent creation with this comprehensive guide to
   the Google Agent Development Kit (ADK) for beginners. You will learn to build,
@@ -41,9 +39,7 @@ authors:
     avatar: null
 chapters:
   - id: 447
-    name: >-
-      Building your first AI Agent - Google Agent Development Kit for Beginners
-      (Part 1)
+    name: Google Agent Development Kit for Beginners
     description: ''
     showName: false
     order: 0

--- a/src/content/courses/google-agent-development-kit-for-beginners/posts/000-000-building-your-first-ai-agent---google-agent-development-kit-for-beginners-part-1.mdx
+++ b/src/content/courses/google-agent-development-kit-for-beginners/posts/000-000-building-your-first-ai-agent---google-agent-development-kit-for-beginners-part-1.mdx
@@ -2,9 +2,7 @@
 id: 4887
 slug: >-
   building-your-first-ai-agent---google-agent-development-kit-for-beginners-part-1
-title: >-
-  Building your first AI Agent - Google Agent Development Kit for Beginners
-  (Part 1)
+title: First AI Agent (Part 1)
 description: ''
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=r-JsrEoctCQ'

--- a/src/content/courses/google-agent-development-kit-for-beginners/posts/000-001-working-with-tools--function-calling---google-agent-development-kit-for-beginners-part-2.mdx
+++ b/src/content/courses/google-agent-development-kit-for-beginners/posts/000-001-working-with-tools--function-calling---google-agent-development-kit-for-beginners-part-2.mdx
@@ -2,9 +2,7 @@
 id: 4888
 slug: >-
   working-with-tools--function-calling---google-agent-development-kit-for-beginners-part-2
-title: >-
-  Working with Tools & Function calling - Google Agent Development Kit for
-  Beginners (Part 2)
+title: Function Calling (Part 2)
 description: ''
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=nRpyp2m6mn8'

--- a/src/content/courses/google-agent-development-kit-for-beginners/posts/000-002-using-multiple-ai-models-with-litellm---google-agent-development-kit-for-beginners-part-3.mdx
+++ b/src/content/courses/google-agent-development-kit-for-beginners/posts/000-002-using-multiple-ai-models-with-litellm---google-agent-development-kit-for-beginners-part-3.mdx
@@ -2,9 +2,7 @@
 id: 4889
 slug: >-
   using-multiple-ai-models-with-litellm---google-agent-development-kit-for-beginners-part-3
-title: >-
-  Using multiple AI models with LiteLLM - Google Agent Development Kit for
-  Beginners (Part 3)
+title: LiteLLM Models (Part 3)
 description: ''
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=Dg7laIcb1I8'

--- a/src/content/courses/google-agent-development-kit-for-beginners/posts/000-003-using-structured-datastructured-output---google-agent-development-kit-for-beginners-part-4.mdx
+++ b/src/content/courses/google-agent-development-kit-for-beginners/posts/000-003-using-structured-datastructured-output---google-agent-development-kit-for-beginners-part-4.mdx
@@ -2,9 +2,7 @@
 id: 4890
 slug: >-
   using-structured-datastructured-output---google-agent-development-kit-for-beginners-part-4
-title: >-
-  Using Structured Data/Structured Output - Google Agent Development Kit for
-  Beginners (Part 4)
+title: Pydantic Output (Part 4)
 description: ''
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=u8tSzHb45MM'

--- a/src/content/courses/google-agent-development-kit-for-beginners/posts/000-004-how-to-use-sessions--state-in-google-adk---google-agent-development-kit-for-beginners-part-5.mdx
+++ b/src/content/courses/google-agent-development-kit-for-beginners/posts/000-004-how-to-use-sessions--state-in-google-adk---google-agent-development-kit-for-beginners-part-5.mdx
@@ -2,9 +2,7 @@
 id: 4891
 slug: >-
   how-to-use-sessions--state-in-google-adk---google-agent-development-kit-for-beginners-part-5
-title: >-
-  How to use Sessions & State in Google ADK - Google Agent Development Kit for
-  Beginners (Part 5)
+title: Sessions & State (Part 5)
 description: ''
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=z8Q3qLi9m78'

--- a/src/content/courses/google-agent-development-kit-for-beginners/posts/000-005-deploy-ai-agents-on-agent-engine-vertex-ai---google-agent-development-kit-for-beginners-part-6.mdx
+++ b/src/content/courses/google-agent-development-kit-for-beginners/posts/000-005-deploy-ai-agents-on-agent-engine-vertex-ai---google-agent-development-kit-for-beginners-part-6.mdx
@@ -2,9 +2,7 @@
 id: 4892
 slug: >-
   deploy-ai-agents-on-agent-engine-vertex-ai---google-agent-development-kit-for-beginners-part-6
-title: >-
-  Deploy AI Agents on Agent Engine (Vertex AI) - Google Agent Development Kit
-  for Beginners (Part 6)
+title: Vertex AI Deploy (Part 6)
 description: ''
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=6ISS31L3bqI'

--- a/src/content/courses/google-agent-development-kit-for-beginners/posts/000-006-how-to-use-callbacks-in-google-adk--google-agent-development-kit-for-beginners-part-7.mdx
+++ b/src/content/courses/google-agent-development-kit-for-beginners/posts/000-006-how-to-use-callbacks-in-google-adk--google-agent-development-kit-for-beginners-part-7.mdx
@@ -2,9 +2,7 @@
 id: 4893
 slug: >-
   how-to-use-callbacks-in-google-adk--google-agent-development-kit-for-beginners-part-7
-title: >-
-  How to use callbacks in Google ADK ? Google Agent Development Kit for
-  Beginners (Part 7)
+title: Callbacks (Part 7)
 description: ''
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=yhUlAl08kII'

--- a/src/content/courses/google-agent-development-kit-for-beginners/posts/000-007-build-ui-for-your-ai-agent-google-agent-development-kit-for-beginners-part-8.mdx
+++ b/src/content/courses/google-agent-development-kit-for-beginners/posts/000-007-build-ui-for-your-ai-agent-google-agent-development-kit-for-beginners-part-8.mdx
@@ -1,9 +1,7 @@
 ---
 id: 4894
 slug: build-ui-for-your-ai-agent-google-agent-development-kit-for-beginners-part-8
-title: >-
-  Build UI for your AI Agent! Google Agent Development Kit for Beginners (Part
-  8)
+title: Build a UI (Part 8)
 description: ''
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=y7damsm8Qos'


### PR DESCRIPTION
## Summary
- Course `name` was the literal post-1 title (`Building your first AI Agent - Google Agent Development Kit for Beginners (Part 1)`), making effective SERP titles 167–183 chars after page metadata appended the course name a second time.
- Renamed course → `Google Agent Development Kit for Beginners` (42 chars). Same for the single chapter.
- Trimmed 8 post titles to ≤25 chars each to land under the 70-char SERP threshold:

| Slug | Old | New |
|---|---|---|
| …part-1 | Building your first AI Agent - Google Agent Development Kit for Beginners (Part 1) | First AI Agent (Part 1) |
| …part-2 | Working with Tools & Function calling - … (Part 2) | Function Calling (Part 2) |
| …part-3 | Using multiple AI models with LiteLLM - … (Part 3) | LiteLLM Models (Part 3) |
| …part-4 | Using Structured Data/Structured Output - … (Part 4) | Pydantic Output (Part 4) |
| …part-5 | How to use Sessions & State in Google ADK - … (Part 5) | Sessions & State (Part 5) |
| …part-6 | Deploy AI Agents on Agent Engine (Vertex AI) - … (Part 6) | Vertex AI Deploy (Part 6) |
| …part-7 | How to use callbacks in Google ADK ? … (Part 7) | Callbacks (Part 7) |
| …part-8 | Build UI for your AI Agent! … (Part 8) | Build a UI (Part 8) |

- Slugs unchanged → canonical URLs and existing crawl history preserved.

## Why
GSC + audit: 8 worst-SERP-title posts all in this course. Long titles get ellipsis-truncated and visibly duplicate the course phrase. Tighter titles + breadcrumbs (shipped in PR #181) give Google a cleaner signal.

## Test plan
- [x] `npm run audit:seo` → title FAILs 82 → 74 (matches Plan 03 target)
- [x] `npx tsc --noEmit` clean
- [ ] After merge: verify rendered `<title>` tag in browser shows new short title + " - Google Agent Development Kit for Beginners"
- [ ] After merge: GSC URL Inspection on 1-2 of these URLs → re-request indexing

Phase: `tools-seo-indexability-uplift`, Plan 03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)