### PR TITLE
content(seo): fill descriptions for react-19-crash-course (23 posts)

### DIFF
--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-000---introduction--roadmap.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-000---introduction--roadmap.mdx
@@ -2,7 +2,7 @@
 id: 4864
 slug: '--introduction--roadmap'
 title: '- Introduction & Roadmap'
-description: ''
+description: "Kick off the React 19 crash course with the full roadmap of topics: components, hooks, routing, performance, React 19 features, and a full-stack AI project."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=0'
 order: 0

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-001---environment-setup-vite--react.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-001---environment-setup-vite--react.mdx
@@ -2,7 +2,7 @@
 id: 4865
 slug: '--environment-setup-vite--react'
 title: '- Environment Setup (Vite & React)'
-description: ''
+description: "Scaffold a React 19 project with Vite, install dependencies, and run the dev server so you have a working starter ready for the rest of the crash course."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=91'
 order: 1

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-002---agenda--instructor-intro.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-002---agenda--instructor-intro.mdx
@@ -2,7 +2,7 @@
 id: 4866
 slug: '--agenda--instructor-intro'
 title: '- Agenda & Instructor Intro'
-description: ''
+description: "Quick walkthrough of the crash course agenda and a short instructor intro so you know what to expect across the next 90 minutes of React 19 content."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=150'
 order: 2

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-003---what-is-react-architecture-explained.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-003---what-is-react-architecture-explained.mdx
@@ -2,7 +2,7 @@
 id: 4867
 slug: '--what-is-react-architecture-explained'
 title: '- What is React? (Architecture Explained)'
-description: ''
+description: "Understand what React is and how its component-based architecture works under the hood, framing the rest of this crash course on React 19 fundamentals."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=589'
 order: 3

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-004---understanding-jsx.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-004---understanding-jsx.mdx
@@ -2,7 +2,7 @@
 id: 4868
 slug: '--understanding-jsx'
 title: '- Understanding JSX'
-description: ''
+description: "Learn JSX syntax in React 19 — how it compiles to JavaScript, when to use braces, and the common pitfalls beginners hit when mixing markup and logic."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=830'
 order: 4

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-005---virtual-dom-vs-real-dom.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-005---virtual-dom-vs-real-dom.mdx
@@ -2,7 +2,7 @@
 id: 4869
 slug: '--virtual-dom-vs-real-dom'
 title: '- Virtual DOM vs Real DOM'
-description: ''
+description: "Compare React's virtual DOM to the real DOM and see how diffing and reconciliation let React 19 update only the parts of the UI that actually change."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=1482'
 order: 5

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-006---components--props-deep-dive.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-006---components--props-deep-dive.mdx
@@ -2,7 +2,7 @@
 id: 4870
 slug: '--components--props-deep-dive'
 title: '- Components & Props Deep Dive'
-description: ''
+description: "Deep dive into React 19 functional components and props: composition, default values, children, and the patterns that scale from tiny widgets to apps."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=1715'
 order: 6

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-007---handling-events-in-react.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-007---handling-events-in-react.mdx
@@ -2,7 +2,7 @@
 id: 4871
 slug: '--handling-events-in-react'
 title: '- Handling Events in React'
-description: ''
+description: "Wire up React 19 event handlers — onClick, onChange, onSubmit — including event objects, default prevention, and binding values from form inputs."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=2595'
 order: 7

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-008---conditional-rendering-patterns.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-008---conditional-rendering-patterns.mdx
@@ -2,7 +2,7 @@
 id: 4872
 slug: '--conditional-rendering-patterns'
 title: '- Conditional Rendering Patterns'
-description: ''
+description: "Render React 19 UI conditionally with ternaries, short-circuit &&, early returns, and dedicated components — and know which pattern fits which use case."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=3263'
 order: 8

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-009---rendering-lists--loops.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-009---rendering-lists--loops.mdx
@@ -2,7 +2,7 @@
 id: 4873
 slug: '--rendering-lists--loops'
 title: '- Rendering Lists & Loops'
-description: ''
+description: "Render dynamic lists in React 19 with map(), pick stable keys to avoid re-render bugs, and handle empty-state and nested-list edge cases cleanly."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=3927'
 order: 9

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-010---forms--input-handling.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-010---forms--input-handling.mdx
@@ -2,7 +2,7 @@
 id: 4874
 slug: '--forms--input-handling'
 title: '- Forms & Input Handling'
-description: ''
+description: "Build controlled React 19 forms with useState, handle text/select/checkbox inputs, and submit data without page reloads or external form libraries."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=4538'
 order: 10

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-011---state-management-context-api-vs-prop-drilling.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-011---state-management-context-api-vs-prop-drilling.mdx
@@ -2,7 +2,7 @@
 id: 4875
 slug: '--state-management-context-api-vs-prop-drilling'
 title: '- State Management: Context API vs Prop Drilling'
-description: ''
+description: "Compare prop drilling vs React Context API for sharing state across components, and learn when each pattern is the right fit in a React 19 app."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=4985'
 order: 11

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-012---react-router--navigation.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-012---react-router--navigation.mdx
@@ -2,7 +2,7 @@
 id: 4876
 slug: '--react-router--navigation'
 title: '- React Router & Navigation'
-description: ''
+description: "Add client-side routing to a React 19 app with React Router — routes, links, params, and nested layouts — for a multi-page single-page application."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=5940'
 order: 12

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-013---react-19-features-overview.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-013---react-19-features-overview.mdx
@@ -2,7 +2,7 @@
 id: 4877
 slug: '--react-19-features-overview'
 title: '- React 19 Features Overview'
-description: ''
+description: "Tour the headline React 19 features: the new use() hook, Actions, useFormStatus, useOptimistic, and the React Compiler — what's actually shippable today."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=6466'
 order: 13

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-014---project-building-a-full-stack-ai-app.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-014---project-building-a-full-stack-ai-app.mdx
@@ -2,7 +2,7 @@
 id: 4878
 slug: '--project-building-a-full-stack-ai-app'
 title: '- PROJECT: Building a Full Stack AI App'
-description: ''
+description: "Kick off the hands-on project: a full-stack React 19 AI app powered by Gemini, with frontend state, API calls, and a complete user-facing experience."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=6540'
 order: 14

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-015---api-integration-gemini-ai.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-015---api-integration-gemini-ai.mdx
@@ -2,7 +2,7 @@
 id: 4879
 slug: '--api-integration-gemini-ai'
 title: '- API Integration (Gemini AI)'
-description: ''
+description: "Wire the Gemini AI API into a React 19 app — request shape, API keys, environment variables, and rendering streamed AI responses in the UI."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=6855'
 order: 15

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-016---state-handlers--logic.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-016---state-handlers--logic.mdx
@@ -2,7 +2,7 @@
 id: 4880
 slug: '--state-handlers--logic'
 title: '- State Handlers & Logic'
-description: ''
+description: "Wire up state handlers and business logic for the React 19 AI app, including input state, loading flags, and the round-trip between UI and Gemini."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=7104'
 order: 16

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-017---custom-hooks--data-fetching.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-017---custom-hooks--data-fetching.mdx
@@ -2,7 +2,7 @@
 id: 4881
 slug: '--custom-hooks--data-fetching'
 title: '- Custom Hooks & Data Fetching'
-description: ''
+description: "Extract data-fetching logic into a custom React 19 hook so multiple components can reuse the same fetch lifecycle without duplicating useState and useEffect."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=7460'
 order: 17

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-018---theming-with-context-api.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-018---theming-with-context-api.mdx
@@ -2,7 +2,7 @@
 id: 4882
 slug: '--theming-with-context-api'
 title: '- Theming with Context API'
-description: ''
+description: "Build a light/dark theme switcher in React 19 using Context API, exposing a useTheme hook so any component can read and toggle the active theme."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=7805'
 order: 18

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-019---performance-usememo--optimization.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-019---performance-usememo--optimization.mdx
@@ -2,7 +2,7 @@
 id: 4883
 slug: '--performance-usememo--optimization'
 title: '- Performance: useMemo & Optimization'
-description: ''
+description: "Optimize a React 19 app with useMemo and useCallback to cache expensive computations and stop unnecessary child re-renders, with profiler tips."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=8005'
 order: 19

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-020---lazy-loading--suspense.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-020---lazy-loading--suspense.mdx
@@ -2,7 +2,7 @@
 id: 4884
 slug: '--lazy-loading--suspense'
 title: '- Lazy Loading & Suspense'
-description: ''
+description: "Code-split a React 19 app with React.lazy and Suspense to defer non-critical routes, shrink the initial bundle, and show fallback UI while chunks load."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=8290'
 order: 20

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-021---error-boundaries--best-practices.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-021---error-boundaries--best-practices.mdx
@@ -2,7 +2,7 @@
 id: 4885
 slug: '--error-boundaries--best-practices'
 title: '- Error Boundaries & Best Practices'
-description: ''
+description: "Catch render errors in React 19 with error boundaries, display fallback UI without crashing the tree, and round up best practices from the crash course."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=8452'
 order: 21

--- a/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-022---what-to-learn-next.mdx
+++ b/src/content/courses/react-19-crash-course-for-beginners-2026-learn-in-90-minutes/posts/000-022---what-to-learn-next.mdx
@@ -2,7 +2,7 @@
 id: 4886
 slug: '--what-to-learn-next'
 title: '- What to learn next?'
-description: ''
+description: "Wrap up the crash course with the natural next steps after React 19 fundamentals: Next.js, server components, testing, animations, and state libraries."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=tqjJrXd27m4&t=8600'
 order: 22


### PR DESCRIPTION
## Summary
Fill empty \`description:\` frontmatter on all 23 posts in the React 19 crash course. Each description is 142-160 chars, outcome-led, names React 19 + the specific lesson topic (JSX, components, hooks, routing, Context API, React 19 features, Gemini AI project, performance, error boundaries).

The 23 posts are timestamped chapters of one 90-min crash course video, so descriptions differentiate by chapter content while keeping a consistent voice.

## Why
- Description is the dominant SEO FAIL across the site (126 posts pre-batch). This is the largest single-course batch (23 of 126).
- Now that PR #181 (VideoObject schema) is live, descriptions are also the gating field for VideoObject emission — empty description suppressed emit. Filling these activates video rich-result eligibility for 23 more posts.

## Audit deltas (this PR, off main)
- description FAILs: 126 → 103 (−23)
- course score: \`react-19-crash-course-for-beginners-2026-learn-in-90-minutes\` 88% → 100%

Phase: \`tools-seo-indexability-uplift\`, Plan 04 (sub-batch 2/10).

## Test plan
- [x] \`npm run audit:seo\` confirms −23 description FAILs
- [ ] After merge: view-source on 1 post → confirm meta description matches + VideoObject JSON-LD emits with description filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)