### PR TITLE
content(seo): fill descriptions for angular-nestjs-fullstack-course (22 posts)

### DIFF
--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-0464cf.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-0464cf.mdx
@@ -2,7 +2,7 @@
 id: 4783
 slug: 0464cf
 title: Integrating MongoDB with NestJS
-description: ''
+description: "Connect a NestJS backend to MongoDB using @nestjs/mongoose, configure the connection string, and verify reads/writes work from a sample endpoint."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=1045'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-0e3429.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-0e3429.mdx
@@ -2,7 +2,7 @@
 id: 4779
 slug: '0e3429'
 title: Architecture & UI of the app
-description: ''
+description: "Walk through the architecture of the Threads-style app: Angular SPA, NestJS REST API, MongoDB, and how the UI for nested comment threads is composed."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=73'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-105f12.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-105f12.mdx
@@ -2,7 +2,7 @@
 id: 4688
 slug: 105f12
 title: Creating the comment-form component
-description: ''
+description: "Build the Angular comment-form component for posting new comments and replies, with reactive forms, validation, and a submit handler that calls the API."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=6130'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-280fda.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-280fda.mdx
@@ -2,7 +2,7 @@
 id: 4785
 slug: 280fda
 title: Using Mongoose Models in API calls
-description: ''
+description: "Inject Mongoose models into NestJS services so your API endpoints can create, read, update, and delete comments and users with type-safe queries."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=1355'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-2fdad2.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-2fdad2.mdx
@@ -2,7 +2,7 @@
 id: 4782
 slug: 2fdad2
 title: 'Creating NestJS resources (users, comments)'
-description: ''
+description: "Generate NestJS resources for users and comments with the CLI, getting controllers, services, DTOs, and modules wired up for the Threads-style API."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=580'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-41698c.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-41698c.mdx
@@ -2,7 +2,7 @@
 id: 4686
 slug: 41698c
 title: Rendering top-level comments from the API call
-description: ''
+description: "Fetch top-level threads from the NestJS API in Angular and render them in the comment list, wiring HttpClient observables to the component template."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=6684'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-4270c9.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-4270c9.mdx
@@ -2,7 +2,7 @@
 id: 4781
 slug: 4270c9
 title: Schema for comments & threads
-description: ''
+description: "Design the data schema for comments and threads in the Threads-style app, mapping nested replies and parent references for a clean MongoDB layout."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=406'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-4cd559.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-4cd559.mdx
@@ -2,7 +2,7 @@
 id: 4777
 slug: 4cd559
 title: Intro
-description: ''
+description: "Welcome to the full-stack TypeScript course where we build a Threads-style nested-comments app with Angular on the frontend and NestJS on the backend."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=0'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-5dc1c1.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-5dc1c1.mdx
@@ -2,7 +2,7 @@
 id: 4784
 slug: 5dc1c1
 title: Creating Schemas & Models for MongoDB
-description: ''
+description: "Define Mongoose schemas and models for comments, replies, and users in NestJS, including timestamps, references, and validation needed for the Threads app."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=1355'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-8899a4.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-8899a4.mdx
@@ -2,7 +2,7 @@
 id: 4685
 slug: 8899a4
 title: Expanding & collapsing comments
-description: ''
+description: "Add expand/collapse interaction to nested comments in the Angular UI so users can drill into deep reply threads or hide branches with a single click."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=7330'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-8e8d67.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-8e8d67.mdx
@@ -2,7 +2,7 @@
 id: 4687
 slug: 8e8d67
 title: Setting up HttpClient in Angular
-description: ''
+description: "Set up Angular HttpClient with provideHttpClient, build a typed service that talks to the NestJS API, and centralize the base URL for the Threads app."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=6522'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-905425.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-905425.mdx
@@ -2,7 +2,7 @@
 id: 4786
 slug: '905425'
 title: Validating request bodies calls in NestJS
-description: ''
+description: "Validate incoming request bodies in NestJS using class-validator and DTOs, rejecting malformed payloads before they touch the database or service layer."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=1985'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-a4dcab.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-a4dcab.mdx
@@ -2,7 +2,7 @@
 id: 4780
 slug: a4dcab
 title: Creating a NestJS app
-description: ''
+description: "Scaffold a NestJS backend from the CLI, understand the modules/controllers/services layout, and run the dev server ready for adding the Threads resources."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=215'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-a7ad9a.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-a7ad9a.mdx
@@ -2,7 +2,7 @@
 id: 4684
 slug: a7ad9a
 title: Creating users on the fly for creating comments
-description: ''
+description: "Create a user record on the fly from the comment form so guests can post comments without a separate signup flow, hooking into the NestJS users endpoint."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=7810'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-aa37e4.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-aa37e4.mdx
@@ -2,7 +2,7 @@
 id: 4778
 slug: aa37e4
 title: Web Dev Basics Course (promo)
-description: ''
+description: "Short shoutout to the Web Dev Basics course for newcomers who want to brush up on HTML, CSS, and JavaScript before tackling this Angular + NestJS build."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=20'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-ad318c.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-ad318c.mdx
@@ -2,7 +2,7 @@
 id: 4682
 slug: ad318c
 title: Replying to comments
-description: ''
+description: "Build the reply-to-comment flow in Angular: open the form inline under any comment, post the reply to NestJS, and append it to the right nested branch."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=9480'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-b1d81d.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-b1d81d.mdx
@@ -2,7 +2,7 @@
 id: 4690
 slug: b1d81d
 title: Creating the main layout (Angular)
-description: ''
+description: "Build the main page layout for the Threads Angular app with Tailwind — header, content area, and a thread list shell ready to host the comment components."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=4552'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-c04819.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-c04819.mdx
@@ -2,7 +2,7 @@
 id: 4787
 slug: c04819
 title: Creating nested comments
-description: ''
+description: "Implement nested comment storage and retrieval in the NestJS API, modeling parent/child relationships so the Threads app can render arbitrarily deep replies."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=3155'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-dc2bf7.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-dc2bf7.mdx
@@ -2,7 +2,7 @@
 id: 4691
 slug: dc2bf7
 title: Setting up Tailwind CSS for Angular
-description: ''
+description: "Install and configure Tailwind CSS in the Angular project, including PostCSS, content globs, and verifying utility classes render in a sample component."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=4358'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-e1a7ad.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-e1a7ad.mdx
@@ -2,7 +2,7 @@
 id: 4683
 slug: e1a7ad
 title: Creating comments using API calls
-description: ''
+description: "Post new comments from the Angular UI to the NestJS API, update the local thread tree on success, and handle validation errors returned by the backend."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=8340'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-e2489b.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-e2489b.mdx
@@ -2,7 +2,7 @@
 id: 4788
 slug: e2489b
 title: Creating the Angular app
-description: ''
+description: "Scaffold the Angular frontend for the Threads app using the Angular CLI, set up standalone components, and wire the dev server to the running NestJS backend."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=3805'
 order: 0

--- a/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-efa5da.mdx
+++ b/src/content/courses/angular-nestjs-fullstack-course/posts/000-000-efa5da.mdx
@@ -2,7 +2,7 @@
 id: 4689
 slug: efa5da
 title: Creating the comment component
-description: ''
+description: "Build the Angular comment component that renders a single comment plus its nested replies, with inputs, outputs, and recursive child rendering."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=cAj6gzAMNfA&t=5148'
 order: 0


### PR DESCRIPTION
## Summary
Fill empty \`description:\` frontmatter on all 22 posts in the Angular + NestJS full-stack course (Threads-style nested-comments app build). Each description is 142-159 chars, outcome-led, names Angular / NestJS / MongoDB / Tailwind as appropriate.

22 posts are timestamped chapters of one full-stack build video. Coverage spans backend (NestJS scaffold, Mongoose schemas, DTOs/validation, nested-comment storage) → frontend (Angular scaffold, Tailwind, layout, comment + comment-form components, HttpClient, expand/collapse, user-on-the-fly, post + reply flows).

## Why
- Description is the dominant SEO FAIL across the site. Pre-batch: 126 posts. This batch: 22.
- Now that PR #181 (VideoObject schema) is live, descriptions are also the gating field for VideoObject emission — empty description suppressed emit. Filling these activates video rich-result eligibility for 22 more posts.

## Audit deltas (this PR, off main)
- description FAILs: 126 → 104 (−22)
- course score: \`angular-nestjs-fullstack-course\` still 63% — gated by course-level fields (long course \`name\`, empty course \`description\`). Out of Plan 04 scope; can be a follow-up.

Phase: \`tools-seo-indexability-uplift\`, Plan 04 (sub-batch 3/10).

## Test plan
- [x] \`npm run audit:seo\` confirms −22 description FAILs
- [ ] After merge: view-source on 1 post → confirm meta description matches + VideoObject JSON-LD emits with description filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)