### PR TITLE
docs(seo-phase): close out tools-seo-indexability-uplift with plan + phase SUMMARYs

### DIFF
--- a/.planning/phases/tools-seo-indexability-uplift/01-SUMMARY.md
+++ b/.planning/phases/tools-seo-indexability-uplift/01-SUMMARY.md
@@ -1,0 +1,46 @@
+---
+phase: tools-seo-indexability-uplift
+plan: "01"
+title: VideoObject JSON-LD on video posts
+wave: 1
+status: shipped
+shipped_at: 2026-05-29
+pr: 181
+commit: a10ac45
+metrics:
+  schema_warns_before: 232
+  schema_warns_after: 0
+  posts_lifted: 232
+  files_changed: 6
+  insertions: 266
+  deletions: 13
+---
+
+# Plan 01 — VideoObject JSON-LD on video posts
+
+**Shipped:** PR [#181](https://github.com/AhsanAyaz/code-with-ahsan/pull/181) (Wave 1 — combined with Plan 02).
+
+## What landed
+
+- `src/lib/seo/videoSchema.ts` — `extractYouTubeId` (covers `watch?v=`, `youtu.be`, `/embed/`, `/shorts/`, `&t=` / `&list=` / `?si=` suffixes); `buildVideoObjectLd` returns `null` when description or YouTube ID missing.
+- `src/app/courses/[course]/[post]/page.tsx` — emits a second JSON-LD `<script>` block when `type: video` AND `description` non-empty AND `videoUrl` is YouTube. Existing `Article` block untouched.
+- `src/__tests__/lib/seo/videoSchema.test.ts` — 18 vitest cases covering ID parsing edge cases + suppression rules.
+- `scripts/content/audit-seo.js` — `checkSchema` reflects new emit contract (PASS when both schemas land, WARN when description/videoUrl gate suppresses VideoObject).
+- `docs/SEO_CONTENT_RUBRIC.md` — strikethrough closed item.
+
+## Metric impact
+
+| Metric | Before | After |
+|---|---|---|
+| `schema` WARN posts | 232 | 0 |
+
+Every video post that has a description now emits both `Article` + `VideoObject` JSON-LD. Posts with empty descriptions still emit only `Article` (suppression by design; Plan 04 backfilled descriptions for all 126 empty cases so all 232 video posts now emit both blocks).
+
+## Verification
+
+- Vitest: 18/18 pass
+- Manual: `curl /courses/google-agent-development-kit-for-beginners/<post>` returned 2 JSON-LD blocks; `curl /courses/web-dev-bootcamp/web-development-bootcamp-day-1-5` (description was empty at time of test) returned 1 block — suppression working.
+
+## Deviations
+
+None.

--- a/.planning/phases/tools-seo-indexability-uplift/02-SUMMARY.md
+++ b/.planning/phases/tools-seo-indexability-uplift/02-SUMMARY.md
@@ -1,0 +1,44 @@
+---
+phase: tools-seo-indexability-uplift
+plan: "02"
+title: Course + BreadcrumbList JSON-LD
+wave: 1
+status: shipped
+shipped_at: 2026-05-29
+pr: 181
+commit: e13fcc2
+metrics:
+  course_pages_with_course_ld: 11
+  pages_with_breadcrumb_ld: 244
+  files_changed: 6
+  insertions: 219
+  deletions: 15
+---
+
+# Plan 02 — Course + BreadcrumbList JSON-LD
+
+**Shipped:** PR [#181](https://github.com/AhsanAyaz/code-with-ahsan/pull/181) (Wave 1 — combined with Plan 01).
+
+## What landed
+
+- `src/lib/seo/courseSchema.ts` — extracts Course schema builder (refactor of inline emission on course page); adds `hasCourseInstance` with `courseMode: "online"`.
+- `src/lib/seo/breadcrumbSchema.ts` — `buildBreadcrumbLd` helper.
+- `src/app/courses/[course]/page.tsx` — Course JSON-LD on 11 course pages; 3-item breadcrumb (Home → Courses → Course).
+- `src/app/courses/[course]/[post]/page.tsx` — 4-item breadcrumb (Home → Courses → Course → Post) on 233 post pages.
+- Tests: 6 `courseSchema` + 3 `breadcrumbSchema` — all pass.
+
+## Coverage
+
+| Schema | Pages emitting |
+|---|---|
+| `Course` JSON-LD | 11 (all `/courses/[slug]` pages) |
+| `BreadcrumbList` JSON-LD | 244 (11 course pages + 233 post pages) |
+
+## Verification
+
+- Vitest: 9/9 pass (6 course + 3 breadcrumb)
+- Audit: course pages no longer lack site-hierarchy markup; ready for Google Rich Results Test validation.
+
+## Deviations
+
+None.

--- a/.planning/phases/tools-seo-indexability-uplift/03-SUMMARY.md
+++ b/.planning/phases/tools-seo-indexability-uplift/03-SUMMARY.md
@@ -1,0 +1,47 @@
+---
+phase: tools-seo-indexability-uplift
+plan: "03"
+title: Trim duplicated course suffix from Google ADK post titles
+wave: 2
+status: shipped
+shipped_at: 2026-05-29
+pr: 182
+commit: 94fcfd4
+metrics:
+  title_fails_before: 82
+  title_fails_after: 74
+  posts_fixed: 8
+  course_name_chars_before: 79
+  course_name_chars_after: 42
+---
+
+# Plan 03 — Trim ADK post titles for SERP
+
+**Shipped:** PR [#182](https://github.com/AhsanAyaz/code-with-ahsan/pull/182).
+
+## Problem
+
+Course `name` and chapter `name` carried the full post-1 title ("Building your first AI Agent - Google Agent Development Kit for Beginners (Part 1)"). Page metadata then appended ` - <course name>` again, producing 167–183 char effective SERP titles that Google truncated with visible duplication ~70 chars in.
+
+## What landed
+
+- Course `name`: → "Google Agent Development Kit for Beginners" (42 chars)
+- 8 post titles trimmed to ≤25 chars each:
+  - `First AI Agent (Part 1)`
+  - `Function Calling (Part 2)`
+  - `Sessions & State (Part 5)`
+  - …and 5 more
+- `src/content/courses.generated.json` regenerated.
+
+## Metric impact
+
+| Metric | Before | After |
+|---|---|---|
+| `criteriaFails.title` | 82 | 74 |
+| ADK effective SERP titles | 167–183 chars | 60–67 chars (PASS) |
+
+74 remaining title FAILs are out of plan scope (react-19 + web-dev-basics — separate phase candidate).
+
+## Deviations
+
+None.

--- a/.planning/phases/tools-seo-indexability-uplift/04-SUMMARY.md
+++ b/.planning/phases/tools-seo-indexability-uplift/04-SUMMARY.md
@@ -1,0 +1,69 @@
+---
+phase: tools-seo-indexability-uplift
+plan: "04"
+title: Bulk-fill empty post descriptions per course
+wave: 3
+status: shipped
+shipped_at: 2026-05-29
+prs: [183, 184, 185, 186, 187, 188]
+metrics:
+  description_fails_before: 126
+  description_fails_after: 0
+  posts_filled: 126
+  courses_covered: 9
+  sub_prs_planned: 10
+  sub_prs_shipped: 8
+---
+
+# Plan 04 — Bulk-fill empty post descriptions per course
+
+**Shipped:** 6 PRs ([#183](https://github.com/AhsanAyaz/code-with-ahsan/pull/183), [#184](https://github.com/AhsanAyaz/code-with-ahsan/pull/184), [#185](https://github.com/AhsanAyaz/code-with-ahsan/pull/185), [#186](https://github.com/AhsanAyaz/code-with-ahsan/pull/186), [#187](https://github.com/AhsanAyaz/code-with-ahsan/pull/187), [#188](https://github.com/AhsanAyaz/code-with-ahsan/pull/188)) covering 9 courses.
+
+## Per-PR breakdown
+
+| PR | Course | Posts |
+|---|---|---|
+| #183 | `google-agent-development-kit-for-beginners` | 8 |
+| #184 | `react-19-crash-course-for-beginners-2026-learn-in-90-minutes` | 23 |
+| #185 | `angular-nestjs-fullstack-course` | 22 |
+| #186 | `angular-in-90ish-minutes` | 20 (+ B2B rates card overhaul swept in) |
+| #187 | `react-redux-toolkit` | 15 |
+| #188 | `mern-stack-crash-course` (15) + `js-beginners-series` (10) + `design-patterns-javascript` (7) + `web-dev-bootcamp` (6) | 38 |
+| **Total** | **9 courses** | **126** |
+
+## Plan vs actual
+
+- Plan called for 10 sub-PRs (one per course). Shipped 6 PRs covering 9 courses:
+  - 4 courses bundled into a single PR (#188) per user direction to "combine multiple in one PR" once velocity stabilised.
+  - `web-dev-basics` (originally listed as 6 failing posts) turned out to have 0 empty descriptions — already 100% PASS pre-plan. Skipped, no work needed.
+- One PR (#186) was an opportunistic sweep that also shipped the B2B sponsorship card overhaul + `POST /api/sponsorship` endpoint that had been stashed from earlier WIP.
+
+## Drafting approach
+
+Each description: 140–160 chars, outcome-led, names the topic + the tech stack. Source signals: post `title`, course `name`, video `title` via YouTube context. User reviewed each batch's table before approval; no batch required re-drafts.
+
+## Metric impact
+
+| Metric | Before | After |
+|---|---|---|
+| `criteriaFails.description` | 126 | 0 |
+| Site-wide post description FAILs | 126 | 0 |
+
+Combined with Plan 01's VideoObject emission, every video post with description now ships both `Article` + `VideoObject` JSON-LD (suppression no longer triggers).
+
+## Deviations
+
+- 10 → 6 PRs (user direction; bundled tail-end courses)
+- `web-dev-basics` skipped (already PASS)
+- PR #186 unrelated B2B rates work bundled in (explicit user request to sweep stashed WIP)
+- PRs #184 + #185 required mid-flight cleanup of contaminated commits (1084 lines of unrelated `RatesClient.tsx` + `courses.generated.json` had been bundled via a `git add -A` slip — resolved via soft-reset + selective re-staging + force-push before merge)
+
+## Follow-up not in this plan
+
+Course-level audit FAILs remain (out of original scope per CONTEXT.md):
+- `design-patterns-javascript` + `js-beginners-series`: missing course banner
+- `angular-in-90ish-minutes` + `react-redux-toolkit` + `angular-nestjs-fullstack-course`: empty course description
+- `mern-stack-crash-course`: 84-char course `name`
+- `web-dev-bootcamp`: short course description
+
+These are addressed in a follow-up mini-phase (see phase SUMMARY § "Follow-ups").

--- a/.planning/phases/tools-seo-indexability-uplift/SUMMARY.md
+++ b/.planning/phases/tools-seo-indexability-uplift/SUMMARY.md
@@ -1,0 +1,72 @@
+---
+phase: tools-seo-indexability-uplift
+status: shipped
+opened: 2026-05-29
+shipped: 2026-05-29
+plans:
+  - { id: "01", title: "VideoObject JSON-LD", pr: 181, status: shipped }
+  - { id: "02", title: "Course + BreadcrumbList JSON-LD", pr: 181, status: shipped }
+  - { id: "03", title: "Trim ADK post titles", pr: 182, status: shipped }
+  - { id: "04", title: "Bulk-fill post descriptions", prs: [183, 184, 185, 186, 187, 188], status: shipped }
+prs: [181, 182, 183, 184, 185, 186, 187, 188]
+related_prs:
+  - { pr: 179, title: "Sitemap hygiene (prior work)" }
+  - { pr: 180, title: "Audit framework (prior work)" }
+success_criteria:
+  - { id: 1, description: "description FAILs 126 → 0", actual: "0", met: true }
+  - { id: 2, description: "title FAILs 82 → ≤74", actual: "74", met: true }
+  - { id: 3, description: "schema WARN 232 → 0", actual: "0", met: true }
+  - { id: 4, description: "Course JSON-LD on /courses/[slug]", actual: "11 pages emitting", met: true }
+  - { id: 5, description: "GSC: 4-wk re-check, indexed up / not-indexed flat-or-down", actual: "pending", met: deferred }
+follow_ups:
+  - "Course-level cleanups: 2 missing banners, 3 empty course descriptions, 1 long course name, 1 short course description (mini-phase B)"
+  - "Non-ADK post title FAILs: 74 across react-19 + web-dev-basics + others (separate phase candidate)"
+  - "GSC re-validation: submit URL Inspection / Validate fixes in GSC after sitemap re-crawl; revisit metric 5 on 2026-06-26"
+---
+
+# Phase: tools-seo-indexability-uplift — SUMMARY
+
+**Trigger:** GSC Coverage report 2026-05-28 — 44 indexed / 353 not-indexed; `Crawled - currently not indexed` trending 57 → 66 in one week; 126/233 course posts had empty `description` frontmatter.
+
+**Prior work (not in this phase):** PR #179 sitemap hygiene; PR #180 audit framework + `npm run audit:seo`.
+
+## What shipped
+
+| Wave | Plan | Type | Output |
+|---|---|---|---|
+| 1 | 01 | Code | `VideoObject` JSON-LD on 232 video posts |
+| 1 | 02 | Code | `Course` + `BreadcrumbList` JSON-LD (244 pages) |
+| 2 | 03 | Content | ADK course + 8 post titles trimmed to <70 char SERP |
+| 3 | 04 | Content | 126 post descriptions filled across 9 courses (6 PRs) |
+
+Total PRs merged: 8 (#181–#188).
+
+## Audit deltas
+
+| Metric | Baseline (pre-phase) | Post-phase |
+|---|---|---|
+| `criteriaFails.description` | 126 | **0** |
+| `criteriaFails.title` | 82 | **74** |
+| `criteriaFails.schema` (WARN) | 232 | **0** |
+| `criteriaFails.media` | 1 | 1 |
+| Posts FAIL | 158 | 75 |
+| Courses FAIL | 8 | 7 |
+
+Phase reduced post-level FAILs by 52% (158 → 75). Remaining 75 are post title length (74) + 1 media — both out of original scope.
+
+## Success criteria
+
+All 4 in-scope criteria met. Criterion 5 (GSC re-check) deferred to 2026-06-26 per CONTEXT.md tracking guidance.
+
+## Decisions worth keeping
+
+- **Waves**: Code (Wave 1) shipped in one PR even when two plans touched overlapping files — single review pass beat coordination overhead.
+- **Plan 04 batching**: Started at 1 course per PR (max reviewability), collapsed to 4-courses-per-PR by the tail when drafting cadence was steady. User direction drove the consolidation.
+- **`web-dev-basics` skip**: Plan listed 6 failing posts but the actual audit (run pre-batch) showed 0 — saved one PR by skipping.
+- **PR contamination recovery**: PRs #184 + #185 had unrelated changes bundled via `git add -A` mistake. Soft-reset + selective re-stage + force-push (with `--force-with-lease`) cleanly recovered; user explicitly prioritised this hygiene over batch velocity.
+
+## Follow-ups
+
+1. **Course-level cleanups (mini-phase B)** — 5 course-level FAILs remain (banners, descriptions, name length). Small mechanical batch, locks in 100% course PASS.
+2. **Non-ADK title trims (future phase candidate)** — 74 post title FAILs concentrated in react-19, web-dev-basics. Higher impact than ADK trim was, but bigger blast radius (touches 74 mdx files + risks SERP CTR changes on already-indexed pages).
+3. **GSC re-validation** — submit URL Inspection / Validate fixes in GSC after next sitemap re-crawl; re-check Coverage report on or after **2026-06-26** to validate metric 5.


### PR DESCRIPTION
## Summary

Closes out the **tools-seo-indexability-uplift** phase with per-plan SUMMARY docs (01-04) and a phase-level SUMMARY.

All 4 plans shipped across PRs #181-#188:

| Plan | PRs | Result |
|---|---|---|
| 01 — VideoObject JSON-LD | #181 | schema WARN 232 → 0 |
| 02 — Course + BreadcrumbList | #181 | 11 + 244 pages gain schema |
| 03 — Trim ADK titles | #182 | title FAILs 82 → 74 |
| 04 — Bulk descriptions | #183-#188 | description FAILs 126 → 0 |

## Success criteria

- ✅ description FAILs 126 → 0
- ✅ title FAILs 82 → ≤74 (now 74)
- ✅ schema WARN 232 → 0
- ✅ Course JSON-LD on 11 course pages
- ⏸ GSC re-validation deferred to 2026-06-26

## Follow-ups captured

1. Mini-phase B: 5 course-level FAILs (banners, descriptions, name trims) — next up
2. Non-ADK title trims (74 post titles) — separate phase candidate
3. GSC re-validation on or after 2026-06-26

## Test plan

- [x] All 5 SUMMARY files exist in `.planning/phases/tools-seo-indexability-uplift/`
- [x] No code changes, no audit regression risk
- [x] Phase CONTEXT.md success criteria mapped 1:1 to `success_criteria` block in phase SUMMARY frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)