### PR TITLE
content(seo): add banners to design-patterns-js + js-beginners-series

### DIFF
--- a/src/content/courses.generated.json
+++ b/src/content/courses.generated.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-29T14:08:49.101Z",
+  "generatedAt": "2026-05-29T15:25:46.768Z",
   "source": "mdx",
   "count": 11,
   "courses": [
@@ -4083,7 +4083,9 @@
       "externalCourseUrl": null,
       "externalStudentsCount": null,
       "isVisible": false,
-      "banner": null,
+      "banner": {
+        "url": "https://img.youtube.com/vi/uFyj0_n1uD8/maxresdefault.jpg"
+      },
       "resources": [],
       "authors": [],
       "chapters": [
@@ -4231,7 +4233,9 @@
       "externalCourseUrl": null,
       "externalStudentsCount": null,
       "isVisible": false,
-      "banner": null,
+      "banner": {
+        "url": "https://img.youtube.com/vi/e8CKjkwpadA/maxresdefault.jpg"
+      },
       "resources": [],
       "authors": [],
       "chapters": [

--- a/src/content/courses/design-patterns-javascript/course.mdx
+++ b/src/content/courses/design-patterns-javascript/course.mdx
@@ -11,7 +11,8 @@ visibilityOrder: 2
 isExternal: false
 externalCourseUrl: null
 externalStudentsCount: null
-banner: null
+banner:
+  url: https://img.youtube.com/vi/uFyj0_n1uD8/maxresdefault.jpg
 resources: []
 authors: []
 chapters:

--- a/src/content/courses/js-beginners-series/course.mdx
+++ b/src/content/courses/js-beginners-series/course.mdx
@@ -14,7 +14,8 @@ visibilityOrder: 1
 isExternal: false
 externalCourseUrl: null
 externalStudentsCount: null
-banner: null
+banner:
+  url: https://img.youtube.com/vi/e8CKjkwpadA/maxresdefault.jpg
 resources: []
 authors: []
 chapters:


### PR DESCRIPTION
## Summary

Final course-level FAIL cleanup. Both courses now have banner images sourced from their first video's YouTube `maxresdefault` thumbnail (HTTP 200 verified).

| Course | Banner URL |
|---|---|
| `design-patterns-javascript` | https://img.youtube.com/vi/uFyj0_n1uD8/maxresdefault.jpg |
| `js-beginners-series` | https://img.youtube.com/vi/e8CKjkwpadA/maxresdefault.jpg |

## Audit deltas

| Metric | Before | After |
|---|---|---|
| Course PASS (of 11) | 8 | 10 |
| Course banner FAIL | 2 | 0 |

Only remaining course-level signal is `practical-react-essentials` chapters=0 WARN — structural data issue, separate concern.

## Test plan

- [x] HTTP 200 verified on both thumbnail URLs
- [x] `npm run audit:seo` shows 10 PASS / 1 WARN courses
- [x] No post regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)