### PR TITLE
feat(seo): omit course suffix from SERP title when it overflows 70 chars

### DIFF
--- a/scripts/content/audit-seo.js
+++ b/scripts/content/audit-seo.js
@@ -60,12 +60,16 @@ function checkLength(value, passAt, warnAt, label) {
 }
 
 function checkTitle(title, courseName) {
-  // Effective SERP title is "<post title> - <course name>" (set in page metadata).
-  // Score on the effective string so short post titles like "Introduction" don't
-  // false-fail when the course suffix already brings the SERP title above 30 chars.
-  const effective = courseName
-    ? `${(title || "").trim()} - ${(courseName || "").trim()}`
-    : (title || "").trim();
+  // Mirror src/lib/seo/serpTitle.ts: append course name only when the
+  // combined string fits POST_TITLE_MAX, else fall back to post title alone.
+  // Keeps the audit aligned with what page metadata actually emits.
+  const t = (title || "").trim();
+  const c = (courseName || "").trim();
+  let effective = t;
+  if (c) {
+    const combined = `${t} - ${c}`;
+    effective = combined.length <= POST_TITLE_MAX ? combined : t;
+  }
   const len = effective.length;
   if (len >= POST_TITLE_MIN && len <= POST_TITLE_MAX)
     return { status: "pass", value: len };

--- a/src/__tests__/lib/seo/serpTitle.test.ts
+++ b/src/__tests__/lib/seo/serpTitle.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { buildSerpTitle, SERP_TITLE_MAX } from "@/lib/seo/serpTitle";
+
+describe("buildSerpTitle", () => {
+  it("appends course name when combined fits the budget", () => {
+    const out = buildSerpTitle("Intro", "Short Course");
+    expect(out).toBe("Intro - Short Course");
+    expect(out.length).toBeLessThanOrEqual(SERP_TITLE_MAX);
+  });
+
+  it("omits course name when combined exceeds the budget", () => {
+    const longCourse = "A".repeat(60);
+    const out = buildSerpTitle("Some Post Title", longCourse);
+    expect(out).toBe("Some Post Title");
+  });
+
+  it("returns post title alone when course name is empty", () => {
+    expect(buildSerpTitle("Just A Title", "")).toBe("Just A Title");
+    expect(buildSerpTitle("Just A Title", "   ")).toBe("Just A Title");
+  });
+
+  it("trims whitespace on inputs", () => {
+    expect(buildSerpTitle("  Title  ", "  Course  ")).toBe("Title - Course");
+  });
+
+  it("respects a custom max", () => {
+    const out = buildSerpTitle("Hello", "World", 20);
+    expect(out).toBe("Hello - World");
+    const overflow = buildSerpTitle("Hello", "Long Course Name Here", 20);
+    expect(overflow).toBe("Hello");
+  });
+
+  it("keeps combined when length is exactly the max", () => {
+    const title = "A".repeat(10);
+    const course = "B".repeat(10);
+    const out = buildSerpTitle(title, course, 23);
+    expect(out.length).toBe(23);
+    expect(out).toBe(`${title} - ${course}`);
+  });
+});

--- a/src/app/courses/[course]/[post]/page.tsx
+++ b/src/app/courses/[course]/[post]/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/content/contentProvider";
 import { buildVideoObjectLd } from "@/lib/seo/videoSchema";
 import { buildBreadcrumbLd } from "@/lib/seo/breadcrumbSchema";
+import { buildSerpTitle } from "@/lib/seo/serpTitle";
 
 const BASE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.codewithahsan.dev";
@@ -76,14 +77,16 @@ export async function generateMetadata({
 
   const { post, course } = data;
 
+  const serpTitle = buildSerpTitle(post.title, course.name);
+
   return {
-    title: `${post.title} - ${course.name}`,
+    title: serpTitle,
     description: post.description || siteMetadata.description,
     alternates: {
       canonical: `${BASE_URL}/courses/${courseSlug}/${postSlug}`,
     },
     openGraph: {
-      title: `${post.title} - ${course.name}`,
+      title: serpTitle,
       description: post.description || siteMetadata.description,
       images:
         post.thumbnail || course.banner

--- a/src/content/courses.generated.json
+++ b/src/content/courses.generated.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-29T15:25:46.768Z",
+  "generatedAt": "2026-05-29T16:00:34.981Z",
   "source": "mdx",
   "count": 11,
   "courses": [
@@ -3983,7 +3983,7 @@
             {
               "id": 4756,
               "slug": "web-development-bootcamp-day-2-5",
-              "title": "2. HTML Basics",
+              "title": "2. HTML Basics: Tags, Headings & Structure",
               "description": "Day 2: HTML basics — document structure, headings, paragraphs, lists, images, and links — the building blocks for the portfolio site you'll style with CSS in later days.",
               "type": "video",
               "videoUrl": "https://www.youtube.com/watch?v=NqDEt2FbvCA&t=2622s&index=2",

--- a/src/content/courses/web-dev-bootcamp/posts/000-000-web-development-bootcamp-day-2-5.mdx
+++ b/src/content/courses/web-dev-bootcamp/posts/000-000-web-development-bootcamp-day-2-5.mdx
@@ -1,7 +1,7 @@
 ---
 id: 4756
 slug: web-development-bootcamp-day-2-5
-title: 2. HTML Basics
+title: "2. HTML Basics: Tags, Headings & Structure"
 description: "Day 2: HTML basics — document structure, headings, paragraphs, lists, images, and links — the building blocks for the portfolio site you'll style with CSS in later days."
 type: video
 videoUrl: 'https://www.youtube.com/watch?v=NqDEt2FbvCA&t=2622s&index=2'

--- a/src/lib/seo/serpTitle.ts
+++ b/src/lib/seo/serpTitle.ts
@@ -1,0 +1,21 @@
+// Build effective SERP title for a course post.
+// When `${title} - ${courseName}` exceeds the SERP budget, drop the course
+// suffix instead of letting Google truncate it mid-word. Keeps the post-level
+// signal intact for the snippet that actually fits.
+//
+// Audit `scripts/content/audit-seo.js` mirrors this contract so PASS/FAIL
+// reflects what ships to Google.
+
+export const SERP_TITLE_MAX = 70;
+
+export function buildSerpTitle(
+  postTitle: string,
+  courseName: string,
+  max: number = SERP_TITLE_MAX
+): string {
+  const title = (postTitle || "").trim();
+  const course = (courseName || "").trim();
+  if (!course) return title;
+  const combined = `${title} - ${course}`;
+  return combined.length <= max ? combined : title;
+}


### PR DESCRIPTION
## Summary

Adds `buildSerpTitle` helper that emits the post title alone when `\${post.title} - \${course.name}` exceeds 70 chars (Google's truncation threshold). Single code change closes 73 of 74 post-title FAILs without touching post content.

Audit script is mirrored to the helper so PASS/FAIL reflects what page metadata actually emits.

## Why

Previous format `\${post.title} - \${course.name}` produced 80–113 char SERP titles for 4 courses whose `course.name` was already 55-62 chars. Google truncated mid-word; trimming post titles to fit the residual 5-12 char budget was not viable.

## Changes

| File | Change |
|---|---|
| `src/lib/seo/serpTitle.ts` | New `buildSerpTitle` helper |
| `src/__tests__/lib/seo/serpTitle.test.ts` | 6 vitest cases |
| `src/app/courses/[course]/[post]/page.tsx` | Use helper for `metadata.title` + `openGraph.title` |
| `scripts/content/audit-seo.js` | `checkTitle` mirrors helper logic |
| `web-development-bootcamp-day-2-5.mdx` | Title "2. HTML Basics" (14, FAIL) → "2. HTML Basics: Tags, Headings & Structure" (43, PASS) — only residual after helper |

## Audit deltas

| Metric | Before | After |
|---|---|---|
| Post title FAILs | 74 | **0** |
| Total post FAILs | 75 | **1** (residual = media FAIL on `web-dev-basics/html-assignment`, separate concern) |

## Test plan

- [x] `npm test -- src/__tests__/lib/seo/serpTitle.test.ts` → 6/6 pass
- [x] `npx tsc --noEmit` → clean
- [x] `npm run audit:seo` → 0 title FAILs
- [ ] Manual: spot-check rendered `<title>` on a long-course post (e.g. `/courses/react-19-crash-course.../--introduction--roadmap`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)