### PR TITLE
feat(books): Mastering Angular Signals v22 landing page + launch link fixes

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,7 +5,7 @@ milestone_name: Agentic Orchestra Upgrade
 status: verifying
 stopped_at: context exhaustion at 81% (2026-06-01)
 last_updated: "2026-06-01T10:10:20.282Z"
-last_activity: 2026-05-23 — Phase 07 Wave 3 (07-03) complete
+last_activity: 2026-06-11 - Completed quick task 260611-n3r: Add LinkedIn profile link to mentor profile page (GitHub issue #195)
 progress:
   total_phases: 9
   completed_phases: 7
@@ -200,6 +200,7 @@ Do not deploy the rules flip before `sync-custom-claims.ts` completes. Dual-clai
 | 260522-b08 | Phase 5 INV-3 leaderboard close-out — daily snapshot pipeline restored (07:00 UTC GH Actions cron writes `leaderboard_snapshots/{cohortId}`; route reads doc with live-compute fallback); `rank` attached to top3 entries; `ownRank` shape renamed to `{ referrals, events, reportsOnTime }`; `graceActive` computed server-side; humanized "Updated N ago" label; SUMMARYs 05-02/05-03 corrected. 7 commits, library 54/54 + API 44/44 tests pass, tsc clean, verifier 8/8 PASS. | 2026-05-22 | 8a890ab | [260522-b08-phase-5-inv-3-leaderboard-daily-snapshot](./quick/260522-b08-phase-5-inv-3-leaderboard-daily-snapshot/) |
 | 260609-ep2 | Fix monthly challenge bugs — submission 500 (undefined demoUrl rejected by Firestore Admin), Participate button now disables + shows "Joined", and challenge dates stored/displayed as UTC to stop Jun 1 → May 31 off-by-one. 3 commits, tsc + lint clean, verified E2E against emulators. | 2026-06-09 | 3a96467 | [260609-ep2-fix-monthly-challenge-bugs-project-submi](./quick/260609-ep2-fix-monthly-challenge-bugs-project-submi/) |
 | 260609-f6n | Challenge participants list with submission status on detail page + snapshot email/discord at join for certificates (no form; public list hides contact info). 2 commits, tsc + lint clean, verified E2E against emulators. | 2026-06-09 | 98fd5bf | [260609-f6n-show-challenge-participants-with-submiss](./quick/260609-f6n-show-challenge-participants-with-submiss/) |
+| 260611-n3r | Add LinkedIn profile link to mentor profile page (GitHub issue #195) — self-view backfill nudge + LinkedIn field promoted to Recommended near Current Role in edit form. Feature pre-existed (quick-058); this closes the adoption/discoverability gap. | 2026-06-11 | b7f9966 | [260611-n3r-add-linkedin-profile-link-to-mentor-prof](./quick/260611-n3r-add-linkedin-profile-link-to-mentor-prof/) |
 | Phase 01 P01 | 2min | 1 tasks | 1 files |
 | Phase 01-foundation-roles-array-migration P02 | 3 min | 3 tasks | 6 files |
 | Phase 01-foundation-roles-array-migration P04 | 2 min | 2 tasks | 3 files |

--- a/.planning/quick/260611-n3r-add-linkedin-profile-link-to-mentor-prof/260611-n3r-PLAN.md
+++ b/.planning/quick/260611-n3r-add-linkedin-profile-link-to-mentor-prof/260611-n3r-PLAN.md
@@ -1,0 +1,150 @@
+---
+phase: quick-260611-n3r
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/app/mentorship/mentors/[username]/MentorProfileClient.tsx
+  - src/components/mentorship/MentorRegistrationForm.tsx
+autonomous: false
+requirements: [GH-195]
+must_haves:
+  truths:
+    - "A mentee viewing a mentor profile with a LinkedIn URL set sees a clickable LinkedIn link/button"
+    - "A mentor viewing their OWN profile WITHOUT a LinkedIn URL sees a nudge prompting them to add one"
+    - "The LinkedIn field in the mentor registration/edit form is discoverable and clearly labelled as publicly shown"
+  artifacts:
+    - path: "src/app/mentorship/mentors/[username]/MentorProfileClient.tsx"
+      provides: "LinkedIn link render + self-view backfill nudge"
+      contains: "linkedinUrl"
+    - path: "src/components/mentorship/MentorRegistrationForm.tsx"
+      provides: "LinkedIn URL input promoted near top of profile fields"
+      contains: "LinkedIn Profile URL"
+  key_links:
+    - from: "MentorProfileClient.tsx"
+      to: "mentor.linkedinUrl"
+      via: "conditional render"
+      pattern: "mentor\\.linkedinUrl"
+---
+
+<objective>
+Make the "View LinkedIn profile" option on a mentor's profile actually appear for mentees (GH-195).
+
+The end-to-end LinkedIn feature already exists and is committed (type field `linkedinUrl`, API
+`src/app/api/mentorship/mentors/[username]/route.ts` returns it, MentorProfileClient renders a
+LinkedIn link when `mentor.linkedinUrl` is set, MentorRegistrationForm has an input + save). The
+real gap is ADOPTION: the field is optional and buried, so most mentors never fill it, and existing
+mentors who registered before the field existed have no LinkedIn shown. The issue reporter saw "no
+LinkedIn option" because the mentor they viewed had an empty `linkedinUrl`.
+
+Purpose: Close the discoverability gap so the already-built feature is visible in practice.
+Output: A prominent LinkedIn field in the mentor edit form + a self-view backfill nudge driving mentors to populate it.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+
+@src/app/mentorship/mentors/[username]/MentorProfileClient.tsx
+@src/components/mentorship/MentorRegistrationForm.tsx
+
+<interfaces>
+<!-- Already-wired contracts — no exploration needed. -->
+
+src/types/mentorship.ts:
+- MentorshipProfile.linkedinUrl?: string  (line 45)
+- MentorProfileDetails.linkedinUrl?: string  (line 81)
+
+src/app/api/mentorship/mentors/[username]/route.ts (line 101-121):
+- Returns `mentor` object including `linkedinUrl: profileData.linkedinUrl`
+
+MentorProfileClient.tsx (lines 556-574):
+- Already renders an `<a href={mentor.linkedinUrl}>` LinkedIn link with SVG icon, gated on `mentor.linkedinUrl`.
+- `useMentorship()` exposes `user`, `profile`. `hasRole(profile, "mentor")` available (imported line 10).
+- `mentor.uid` is the profile owner uid; `user.uid` is the viewer.
+
+MentorRegistrationForm.tsx:
+- `linkedinUrl` state (line 76), submitted in onSubmit payload (line 337) as `linkedinUrl: linkedinUrl.trim()`.
+- Existing LinkedIn input block at lines 761-779 (currently below CV + Max Mentees grid, labelled "Optional").
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add self-view backfill nudge for mentors without a LinkedIn URL</name>
+  <files>src/app/mentorship/mentors/[username]/MentorProfileClient.tsx</files>
+  <action>
+In the Profile Header Info block (right after the existing `{mentor.linkedinUrl && (...)}` LinkedIn
+link render around lines 556-574), add a sibling conditional that shows a nudge ONLY when:
+(a) `mentor.linkedinUrl` is falsy, AND
+(b) the viewer is the profile owner — `user?.uid === mentor.uid`.
+Render a small inline prompt (use existing DaisyUI utility classes consistent with the file, e.g.
+`text-sm text-base-content/60`) reading "Add your LinkedIn profile so mentees can verify your
+experience." with a `<Link href="/profile">` styled as `link link-primary` labelled "Add LinkedIn".
+Do NOT show this nudge to mentees or anonymous viewers — only the owner. Keep the existing public
+LinkedIn link render unchanged.
+  </action>
+  <verify>
+    <automated>npx tsc --noEmit -p tsconfig.json 2>&1 | grep -i "MentorProfileClient" | grep -v "^#" | wc -l | grep -q "^0$" && echo TSC_CLEAN</automated>
+  </verify>
+  <done>Profile owner with empty linkedinUrl sees the "Add LinkedIn" nudge linking to /profile; mentees and owners-with-a-url do not see the nudge; tsc clean.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Promote the LinkedIn field in the mentor edit form</name>
+  <files>src/components/mentorship/MentorRegistrationForm.tsx</files>
+  <action>
+Move the existing "LinkedIn Profile URL" form-control block (currently lines 761-779) up so it sits
+immediately AFTER the "Current Role" field (input around line 447-451) and BEFORE the bio/expertise
+sections — keeping it in the same logical group as the public-facing identity fields. Do not change
+the state binding (`linkedinUrl` / `setLinkedinUrl`) or the onSubmit payload. Update the helper
+label text to emphasise value: "Shown publicly on your mentor profile so mentees can verify your
+experience." Keep it optional (no `required`), but change the `label-text-alt` from "Optional" to
+"Recommended" to encourage completion. Ensure no duplicate LinkedIn block remains at the old location.
+  </action>
+  <verify>
+    <automated>grep -c "LinkedIn Profile URL" src/components/mentorship/MentorRegistrationForm.tsx | grep -q "^1$" && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -i "MentorRegistrationForm" | grep -v "^#" | wc -l | grep -q "^0$" && echo OK</automated>
+  </verify>
+  <done>Exactly one LinkedIn Profile URL block exists, positioned near Current Role, labelled "Recommended" with the verify-experience helper text; state/save wiring unchanged; tsc clean.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <what-built>
+Self-view LinkedIn backfill nudge on the mentor profile page + a promoted, clearer LinkedIn field in
+the mentor edit form. (The underlying display/save was already shipped in quick-058.)
+  </what-built>
+  <how-to-verify>
+1. Run the app (`npm run dev`) with emulators per project convention.
+2. As a mentor whose profile has NO linkedinUrl, visit your own `/mentorship/mentors/<your-username>` — confirm you see the "Add LinkedIn" nudge linking to /profile.
+3. Go to /profile, confirm the LinkedIn field now appears right under Current Role, labelled "Recommended". Enter a LinkedIn URL and save.
+4. Reload your mentor profile — confirm the nudge is gone and the public "LinkedIn Profile" link now renders and opens your LinkedIn in a new tab.
+5. As a different user (mentee) viewing that mentor, confirm you see the LinkedIn link but NOT the nudge.
+  </how-to-verify>
+  <resume-signal>Type "approved" or describe issues</resume-signal>
+</task>
+
+</tasks>
+
+<verification>
+- `npx tsc --noEmit` clean for both modified files.
+- `npm run lint` (or project lint) passes on the two files.
+- Public LinkedIn link still renders for any mentor with linkedinUrl set (regression unchanged).
+</verification>
+
+<success_criteria>
+- Mentees see a working "LinkedIn Profile" link on mentor profiles that have a URL set (already true; unregressed).
+- Mentors without a LinkedIn URL are actively prompted to add one when viewing their own profile.
+- The LinkedIn field in the edit form is discoverable (near top, "Recommended") and clearly described as publicly shown.
+- No data-model, API, or new-dependency changes required.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260611-n3r-add-linkedin-profile-link-to-mentor-prof/260611-n3r-SUMMARY.md` when done.
+Note for SUMMARY: the core feature pre-existed (commit 9aa8bff, quick-058); this task closed the adoption/discoverability gap behind GH-195.
+</output>

--- a/.planning/quick/260611-n3r-add-linkedin-profile-link-to-mentor-prof/260611-n3r-SUMMARY.md
+++ b/.planning/quick/260611-n3r-add-linkedin-profile-link-to-mentor-prof/260611-n3r-SUMMARY.md
@@ -1,0 +1,72 @@
+---
+phase: quick-260611-n3r
+plan: "01"
+subsystem: mentorship-ui
+tags: [mentor-profile, linkedin, discoverability, ux]
+dependency_graph:
+  requires: []
+  provides: [linkedin-backfill-nudge, linkedin-form-promotion]
+  affects: [src/app/mentorship/mentors, src/components/mentorship]
+tech_stack:
+  added: []
+  patterns: [conditional-owner-render, daisyui-form-control]
+key_files:
+  created: []
+  modified:
+    - src/app/mentorship/mentors/[username]/MentorProfileClient.tsx
+    - src/components/mentorship/MentorRegistrationForm.tsx
+decisions:
+  - "Nudge uses user?.uid === mentor.uid (not hasRole) because ownership is the correct gate for self-view"
+  - "Removed JSX comment above LinkedIn block to keep grep -c count at 1 as verified by plan criteria"
+metrics:
+  duration: "~5 min"
+  completed: "2026-06-11"
+  tasks: 2
+  files: 2
+---
+
+# Phase quick-260611-n3r Plan 01: Add LinkedIn Profile Link to Mentor Profile Summary
+
+**One-liner:** Closed LinkedIn adoption gap (GH-195) — self-view backfill nudge on mentor profile + LinkedIn field promoted above bio in edit form.
+
+## What Was Built
+
+The core LinkedIn display/save feature pre-existed (quick-058, commit 9aa8bff). This plan closed the **discoverability gap**:
+
+1. **Self-view backfill nudge** (`MentorProfileClient.tsx`): Mentors viewing their own profile without a LinkedIn URL now see an inline prompt "Add your LinkedIn profile so mentees can verify your experience." with a `<Link href="/profile">Add LinkedIn</Link>`. Nudge is strictly owner-only (`user?.uid === mentor.uid`) and only shown when `linkedinUrl` is falsy. Public LinkedIn link render (for mentees seeing profiles that have a URL) is unchanged.
+
+2. **Promoted LinkedIn field** (`MentorRegistrationForm.tsx`): Moved the LinkedIn URL input from below the CV/Max Mentees grid to immediately after the "Current Role" field — placing it in the first logical group of identity/credibility fields. Changed `label-text-alt` from "Optional" to "Recommended". Updated helper text to "Shown publicly on your mentor profile so mentees can verify your experience." State binding (`linkedinUrl`/`setLinkedinUrl`) and onSubmit payload wiring unchanged.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Removed JSX comment to satisfy plan's grep-count gate**
+- **Found during:** Task 2 verification
+- **Issue:** `{/* LinkedIn Profile URL */}` comment + label span both matched `grep -c "LinkedIn Profile URL"`, yielding 2 instead of the expected 1
+- **Fix:** Removed the JSX comment above the LinkedIn block; label span alone is the one match
+- **Files modified:** `src/components/mentorship/MentorRegistrationForm.tsx`
+- **Commit:** ce789d1
+
+## Commits
+
+| Task | Commit | Message |
+|------|--------|---------|
+| 1 | eb61819 | feat(quick-260611-n3r-01): add self-view LinkedIn backfill nudge on mentor profile |
+| 2 | ce789d1 | feat(quick-260611-n3r-01): promote LinkedIn field near Current Role in mentor edit form |
+
+## Known Stubs
+
+None — no placeholder text or empty data sources. The nudge wires directly to `user?.uid` and `mentor.uid` (live context values); the form wires to existing `linkedinUrl` state.
+
+## Threat Flags
+
+None — no new network endpoints, auth paths, or schema changes introduced.
+
+## Self-Check: PASSED
+
+- [x] `src/app/mentorship/mentors/[username]/MentorProfileClient.tsx` modified (eb61819)
+- [x] `src/components/mentorship/MentorRegistrationForm.tsx` modified (ce789d1)
+- [x] TSC clean for both files
+- [x] Exactly 1 "LinkedIn Profile URL" occurrence in MentorRegistrationForm.tsx
+- [x] Commits verified in git log

--- a/src/app/books/mastering-angular-signals/page.tsx
+++ b/src/app/books/mastering-angular-signals/page.tsx
@@ -186,7 +186,7 @@ export default function MasteringAngularSignalsBookPage() {
               "Foreword by the Angular team at Google",
               "Edited by GDE Sonu Kapoor",
               "★ 4.6 on Amazon",
-              "12M+ install library author",
+              "14M+ install library author",
             ].map((badge) => (
               <span
                 key={badge}

--- a/src/app/books/mastering-angular-signals/page.tsx
+++ b/src/app/books/mastering-angular-signals/page.tsx
@@ -2,128 +2,296 @@ import { Metadata } from "next";
 // @ts-ignore
 import siteMetadata from "@/data/siteMetadata";
 import Image from "next/image";
+import { buildBookLd, buildFaqLd, FaqItem } from "@/lib/seo/bookSchema";
+
+const BOOK_TITLE = "Mastering Angular Signals";
+const BOOK_SUBTITLE =
+  "A Practical Guide to Modern Reactivity, Performance, and Migration";
+const AUTHOR_NAME = "Muhammad Ahsan Ayaz";
+const AUTHOR_CREDS =
+  "Google Developer Expert (GDE) in AI & Angular, Speaker, Software Architect, author of four books";
+const AUTHOR_URL = "https://codewithahsan.dev";
+const GITHUB_REPO = "https://github.com/AhsanAyaz/modern-angular-signals-book";
+const AMAZON_LINK = "https://www.amazon.com/dp/B0FF9LSHJN/";
+const LEANPUB_LINK = "https://leanpub.com/mastering-angular-signals/c/GO2026";
+const BOOK_IMAGE = "/static/images/books/mastering-angular-signals-3d.png";
+const PAGE_PATH = "/books/mastering-angular-signals";
+
+const SITE_URL: string = siteMetadata.siteUrl || "https://codewithahsan.dev";
+const PAGE_URL = `${SITE_URL}${PAGE_PATH}`;
+const PAGE_DESCRIPTION =
+  "Mastering Angular Signals by Muhammad Ahsan Ayaz — the definitive, hands-on guide to Angular v22 Signals: signal/computed/effect, linkedSignal, resource & httpResource, Signal Forms, zoneless change detection, testing, and migrating RxJS/NgRx codebases.";
+
+const FAQ_ITEMS: FaqItem[] = [
+  {
+    question: "Which version of Angular does the book cover?",
+    answer:
+      "The book is updated for Angular v22 and covers the now-stable Signals APIs — including signal(), computed(), effect(), linkedSignal(), resource()/rxResource()/httpResource(), and Signal Forms — along with zoneless change detection and OnPush-by-default.",
+  },
+  {
+    question: "Is this book good for migrating from RxJS or NgRx?",
+    answer:
+      "Yes. Migration is a core focus. A dedicated chapter walks through interoperability (toSignal/toObservable, takeUntilDestroyed) and a practical, step-by-step plan for moving RxJS- and NgRx-heavy applications to a signal-based architecture.",
+  },
+  {
+    question: "Do I need prior experience with Angular Signals?",
+    answer:
+      "No. The book starts from the fundamentals (signal, computed, effect) and progressively builds to advanced patterns, testing strategies, and performance optimization, so it works for both newcomers to Signals and experienced Angular developers.",
+  },
+  {
+    question: "What formats are available and where can I buy it?",
+    answer:
+      "It is available as a Kindle eBook and paperback on Amazon, and as a DRM-free PDF/EPUB on Leanpub. Both editions are kept up to date for Angular v22.",
+  },
+  {
+    question: "Is the example code available?",
+    answer:
+      "Yes. A complete, runnable code repository accompanies the book on GitHub, with one app per chapter so you can follow along and experiment.",
+  },
+];
+
+const REVIEWS: { name: string; quote: string }[] = [
+  {
+    name: "Gary Brock",
+    quote:
+      "A transformative resource for Angular developers, demystifying Signals with clear, practical explanations and real-world examples — plus a comprehensive migration roadmap that saves invaluable time.",
+  },
+  {
+    name: "Quincy",
+    quote:
+      "I finally understand how to replace my messy RxJS code with simpler, cleaner logic. The migration roadmap alone saved me hours.",
+  },
+  {
+    name: "duncan faulkner",
+    quote:
+      "A really great book on Angular Signals — really good explanations of what the methods and properties do, with great code examples. If you want to learn signals, this is a must-read.",
+  },
+];
 
 export const metadata: Metadata = {
-  title: `Mastering Angular Signals by Muhammad Ahsan Ayaz - ${siteMetadata.author}`,
-  description:
-    "Unlock the power of Angular Signals! A comprehensive guide by Muhammad Ahsan Ayaz covering core concepts, advanced patterns, testing, and migration strategies for building performant and reactive Angular applications.",
+  title: `Mastering Angular Signals (Angular v22) by ${AUTHOR_NAME}`,
+  description: PAGE_DESCRIPTION,
+  keywords: [
+    "Angular Signals",
+    "Angular Signals book",
+    "Angular v22",
+    "RxJS to Signals migration",
+    "Angular zoneless",
+    "Signal Forms",
+    "Angular resource API",
+    "Muhammad Ahsan Ayaz",
+  ],
+  alternates: { canonical: PAGE_URL },
+  openGraph: {
+    title: `Mastering Angular Signals — ${BOOK_SUBTITLE}`,
+    description: PAGE_DESCRIPTION,
+    url: PAGE_URL,
+    type: "book",
+    images: [{ url: BOOK_IMAGE, width: 250, height: 350, alt: BOOK_TITLE }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `Mastering Angular Signals (Angular v22)`,
+    description: PAGE_DESCRIPTION,
+    images: [BOOK_IMAGE],
+  },
 };
 
-export default function ModernAngularSignalsBookPage() {
-  const bookTitle = "Mastering Angular Signals";
-  const authorName = "Muhammad Ahsan Ayaz";
-  const authorCreds =
-    "GDE in Angular, Speaker, Software Architect, Author of Angular Cookbook";
-  const githubRepo = "https://github.com/AhsanAyaz/modern-angular-signals-book";
-  const ctaLink = "https://www.amazon.com/dp/B0FF9LSHJN/";
-  const ctaText = "Get your copy";
+export default function MasteringAngularSignalsBookPage() {
+  const bookLd = buildBookLd({
+    name: `${BOOK_TITLE}: ${BOOK_SUBTITLE}`,
+    description: PAGE_DESCRIPTION,
+    url: PAGE_URL,
+    baseUrl: SITE_URL,
+    imageUrl: `${SITE_URL}${BOOK_IMAGE}`,
+    authorName: AUTHOR_NAME,
+    authorUrl: AUTHOR_URL,
+    isbn: "9798289015785",
+    datePublished: "2025-06-20",
+    inLanguage: "en",
+    ratingValue: 4.6,
+    reviewCount: 15,
+    offers: [
+      {
+        name: "Paperback",
+        price: "29.99",
+        priceCurrency: "USD",
+        url: AMAZON_LINK,
+      },
+      {
+        name: "Kindle",
+        price: "10.59",
+        priceCurrency: "USD",
+        url: AMAZON_LINK,
+      },
+      { name: "Leanpub (PDF/EPUB)", url: LEANPUB_LINK },
+    ],
+  });
+  const faqLd = buildFaqLd(FAQ_ITEMS);
 
-  const ctaButton = () => (
-    <div className="not-prose">
+  const ctaButtons = () => (
+    <div className="not-prose flex flex-col sm:flex-row gap-3 justify-center">
       <a
-        href={ctaLink}
+        href={AMAZON_LINK}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center justify-center px-6 py-3 border border-transparent !font-medium rounded-md shadow !text-white bg-primary hover:brightness-90 dark:bg-primary dark:hover:brightness-90"
+        className="inline-flex items-center justify-center px-6 py-3 border border-transparent !font-medium rounded-md shadow !text-white bg-primary hover:brightness-90"
       >
-        {ctaText}
+        Get it on Amazon
+      </a>
+      <a
+        href={LEANPUB_LINK}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center justify-center px-6 py-3 !font-medium rounded-md border border-primary !text-primary hover:bg-primary hover:!text-white"
+      >
+        Get it on Leanpub
       </a>
     </div>
   );
 
   return (
     <div className="page-padding">
+      {bookLd ? (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(bookLd) }}
+        />
+      ) : null}
+      {faqLd ? (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        />
+      ) : null}
+
       <div className="divide-y divide-gray-200 dark:divide-gray-700">
         <div className="pt-6 pb-8 space-y-2 md:space-y-5">
+          <p className="text-center text-sm font-semibold uppercase tracking-wide text-primary">
+            Updated for Angular v22
+          </p>
           <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-base-content sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 text-center">
-            {bookTitle}
+            {BOOK_TITLE}
           </h1>
           <p className="text-center text-lg leading-7 text-gray-500 dark:text-gray-400">
-            A Practical Guide to Modern Reactivity, Performance, and Migration
+            {BOOK_SUBTITLE}
           </p>
           <p className="text-center text-sm leading-5 text-gray-500 dark:text-gray-400">
-            By {authorName} - {authorCreds}
+            By {AUTHOR_NAME} — {AUTHOR_CREDS}. Foreword by Mark Thompson
+            (Angular team, Google). Edited by Sonu Kapoor (GDE).
           </p>
-          <div className="flex justify-center mt-6">{ctaButton()}</div>
+          <p className="text-center text-sm leading-5 text-gray-500 dark:text-gray-400">
+            ★ 4.6 average rating on Amazon
+          </p>
+          <div className="flex justify-center mt-6">{ctaButtons()}</div>
         </div>
 
         <div className="prose dark:prose-invert max-w-none pt-8 pb-8">
           <div className="flex flex-col items-center md:flex-row md:items-start md:space-x-8">
             <div className="flex-shrink-0 mb-4 md:mb-0">
               <Image
-                src={"/static/images/books/mastering-angular-signals-3d.png"}
-                alt={bookTitle}
+                src={BOOK_IMAGE}
+                alt={BOOK_TITLE}
                 width={250}
                 height={350}
                 className="rounded-md shadow-lg"
               />
             </div>
             <div className="flex-grow">
-              <h2>About This Book</h2>
+              <h2>End state-management headaches in Angular</h2>
               <p>
-                Angular Signals represent a fundamental shift in how we build
-                reactive applications. This book is your comprehensive guide to
-                mastering this powerful new reactivity model, enabling you to
-                build more efficient, maintainable, and performant Angular
-                applications.
+                Tired of wrestling with{" "}
+                <code>ExpressionChangedAfterItHasBeenChecked</code>, tangled
+                RxJS chains, and slow, unpredictable change detection? Angular
+                Signals are the fix — and this book is your complete, practical
+                path to mastering them.
               </p>
               <p>
-                Authored by Muhammad Ahsan Ayaz, a Google Developer Expert in
-                Angular and seasoned Software Architect,{" "}
-                <em>Mastering Angular Signals</em> distills practical knowledge
-                from years of experience working with Angular.
+                Authored by <strong>{AUTHOR_NAME}</strong>, a Google Developer
+                Expert in AI &amp; Angular and seasoned Software Architect,{" "}
+                <em>Mastering Angular Signals</em> distills years of real-world
+                experience into a hands-on guide — with a foreword from the
+                Angular team at Google.
               </p>
 
-              <h3>What You Will Learn</h3>
-              <p>
-                Journey from the foundational building blocks to advanced
-                techniques. This book covers:
-              </p>
+              <h3>This book is for you if you:</h3>
               <ul>
                 <li>
-                  The core concepts: <code>signal()</code>,{" "}
-                  <code>computed()</code>, and <code>effect()</code>
+                  Are struggling to understand when and how to use Angular
+                  Signals effectively.
                 </li>
                 <li>
-                  Managing asynchronous operations with <code>resource()</code>{" "}
-                  and <code>rxResource()</code>
+                  Want to build modern, <strong>zoneless applications</strong>{" "}
+                  but don&apos;t know where to start.
                 </li>
                 <li>
-                  Seamless component communication using signal-based{" "}
-                  <code>input()</code>, <code>output()</code>, and{" "}
-                  <code>model()</code> APIs
-                </li>
-                <li>Effective strategies for testing your Signal-based code</li>
-                <li>
-                  Practical techniques for migrating existing RxJS-heavy
-                  applications
+                  Need a clear, practical plan to{" "}
+                  <strong>migrate an existing RxJS or NgRx codebase</strong>.
                 </li>
                 <li>
-                  Performance considerations and architectural best practices
+                  Are ready to write simpler, cleaner, and dramatically more
+                  performant Angular code.
                 </li>
               </ul>
 
-              <div className="flex justify-center my-6"> {ctaButton()} </div>
+              <div className="flex justify-center my-6">{ctaButtons()}</div>
 
-              <h3>Dive into Practical Examples</h3>
-              <p>
-                Build confidence with hands-on examples demonstrating real-world
-                scenarios, including:
-              </p>
+              <h3>What you will learn</h3>
               <ul>
-                <li>Managing component state and user input</li>
-                <li>Handling data fetching from APIs</li>
-                <li>Building interactive lists with DOM interaction</li>
-                <li>Implementing notification panels and shopping carts</li>
+                <li>
+                  The core building blocks: <code>signal()</code>,{" "}
+                  <code>computed()</code>, and <code>effect()</code>.
+                </li>
+                <li>
+                  Writable derived state with <code>linkedSignal()</code> and
+                  async data with <code>resource()</code>,{" "}
+                  <code>rxResource()</code>, and <code>httpResource()</code>.
+                </li>
+                <li>
+                  Signal-based components with <code>input()</code>,{" "}
+                  <code>output()</code>, <code>model()</code>, and signal
+                  queries — plus Signal Forms and Angular Aria.
+                </li>
+                <li>
+                  Interop and a step-by-step strategy for migrating RxJS/NgRx
+                  code to Signals.
+                </li>
+                <li>
+                  Testing Signal-based code, plus performance and zoneless
+                  best practices.
+                </li>
               </ul>
-              <p>A dedicated code repository is available on GitHub:</p>
+
+              <h3>What readers are saying</h3>
+              {REVIEWS.map((r) => (
+                <blockquote key={r.name}>
+                  <p>“{r.quote}”</p>
+                  <p>
+                    <strong>— {r.name}</strong> (Amazon review)
+                  </p>
+                </blockquote>
+              ))}
+
+              <h3>Follow along with real code</h3>
               <p>
-                <a href={githubRepo} target="_blank" rel="noopener noreferrer">
-                  {githubRepo}
+                Every example is backed by a complete, runnable repository, with
+                one app per chapter:
+              </p>
+              <p>
+                <a href={GITHUB_REPO} target="_blank" rel="noopener noreferrer">
+                  {GITHUB_REPO}
                 </a>
               </p>
 
-              <div className="flex justify-center my-6"> {ctaButton()}</div>
+              <h3>Frequently asked questions</h3>
+              {FAQ_ITEMS.map((f) => (
+                <div key={f.question}>
+                  <h4>{f.question}</h4>
+                  <p>{f.answer}</p>
+                </div>
+              ))}
+
+              <div className="flex justify-center my-6">{ctaButtons()}</div>
             </div>
           </div>
         </div>

--- a/src/app/books/mastering-angular-signals/page.tsx
+++ b/src/app/books/mastering-angular-signals/page.tsx
@@ -41,7 +41,7 @@ const FAQ_ITEMS: FaqItem[] = [
   {
     question: "What formats are available and where can I buy it?",
     answer:
-      "It is available as a Kindle eBook and paperback on Amazon, and as a DRM-free PDF/EPUB on Leanpub. Both editions are kept up to date for Angular v22.",
+      "It is available as a DRM-free PDF/EPUB on Leanpub, and as a Kindle eBook and paperback on Amazon. Both editions are kept up to date for Angular v22.",
   },
   {
     question: "Is the example code available?",
@@ -112,6 +112,7 @@ export default function MasteringAngularSignalsBookPage() {
     ratingValue: 4.6,
     reviewCount: 15,
     offers: [
+      { name: "Leanpub (PDF/EPUB)", url: LEANPUB_LINK },
       {
         name: "Paperback",
         price: "29.99",
@@ -124,28 +125,27 @@ export default function MasteringAngularSignalsBookPage() {
         priceCurrency: "USD",
         url: AMAZON_LINK,
       },
-      { name: "Leanpub (PDF/EPUB)", url: LEANPUB_LINK },
     ],
   });
   const faqLd = buildFaqLd(FAQ_ITEMS);
 
   const ctaButtons = () => (
-    <div className="not-prose flex flex-col sm:flex-row gap-3 justify-center">
-      <a
-        href={AMAZON_LINK}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex items-center justify-center px-6 py-3 border border-transparent !font-medium rounded-md shadow !text-white bg-primary hover:brightness-90"
-      >
-        Get it on Amazon
-      </a>
+    <div className="not-prose flex flex-col sm:flex-row gap-3 justify-center items-center">
       <a
         href={LEANPUB_LINK}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center justify-center px-6 py-3 !font-medium rounded-md border border-primary !text-primary hover:bg-primary hover:!text-white"
+        className="inline-flex items-center justify-center px-6 py-3 border border-transparent !font-medium rounded-md shadow !text-white bg-primary hover:brightness-90"
       >
         Get it on Leanpub
+      </a>
+      <a
+        href={AMAZON_LINK}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center justify-center px-6 py-3 !font-medium rounded-md border border-primary !text-primary hover:bg-primary hover:!text-white"
+      >
+        Also on Amazon
       </a>
     </div>
   );

--- a/src/app/books/mastering-angular-signals/page.tsx
+++ b/src/app/books/mastering-angular-signals/page.tsx
@@ -117,7 +117,7 @@ export default function MasteringAngularSignalsBookPage() {
       { name: "Leanpub (PDF/EPUB)", url: LEANPUB_LINK },
       {
         name: "Paperback",
-        price: "29.99",
+        price: "24.99",
         priceCurrency: "USD",
         url: AMAZON_LINK,
       },

--- a/src/app/books/mastering-angular-signals/page.tsx
+++ b/src/app/books/mastering-angular-signals/page.tsx
@@ -13,7 +13,9 @@ const AUTHOR_CREDS =
 const AUTHOR_URL = "https://codewithahsan.dev";
 const GITHUB_REPO = "https://github.com/AhsanAyaz/modern-angular-signals-book";
 const AMAZON_LINK = "https://www.amazon.com/dp/B0FF9LSHJN/";
-const LEANPUB_LINK = "https://leanpub.com/mastering-angular-signals/c/GO2026";
+// Default to the clean Leanpub URL (suggested price). For a time-boxed launch,
+// temporarily swap to a coupon link, e.g. `.../mastering-angular-signals/c/V22LAUNCH`.
+const LEANPUB_LINK = "https://leanpub.com/mastering-angular-signals";
 const BOOK_IMAGE = "/static/images/books/mastering-angular-signals-3d.png";
 const PAGE_PATH = "/books/mastering-angular-signals";
 
@@ -121,7 +123,7 @@ export default function MasteringAngularSignalsBookPage() {
       },
       {
         name: "Kindle",
-        price: "10.59",
+        price: "9.99",
         priceCurrency: "USD",
         url: AMAZON_LINK,
       },
@@ -177,12 +179,23 @@ export default function MasteringAngularSignalsBookPage() {
             {BOOK_SUBTITLE}
           </p>
           <p className="text-center text-sm leading-5 text-gray-500 dark:text-gray-400">
-            By {AUTHOR_NAME} — {AUTHOR_CREDS}. Foreword by Mark Thompson
-            (Angular team, Google). Edited by Sonu Kapoor (GDE).
+            By {AUTHOR_NAME} — {AUTHOR_CREDS}.
           </p>
-          <p className="text-center text-sm leading-5 text-gray-500 dark:text-gray-400">
-            ★ 4.6 average rating on Amazon
-          </p>
+          <div className="not-prose flex flex-wrap justify-center gap-2 pt-1">
+            {[
+              "Foreword by the Angular team at Google",
+              "Edited by GDE Sonu Kapoor",
+              "★ 4.6 on Amazon",
+              "12M+ install library author",
+            ].map((badge) => (
+              <span
+                key={badge}
+                className="inline-flex items-center rounded-full border border-primary/40 bg-primary/5 px-3 py-1 text-xs font-medium text-primary"
+              >
+                {badge}
+              </span>
+            ))}
+          </div>
           <div className="flex justify-center mt-6">{ctaButtons()}</div>
         </div>
 
@@ -236,29 +249,67 @@ export default function MasteringAngularSignalsBookPage() {
 
               <div className="flex justify-center my-6">{ctaButtons()}</div>
 
+              <h3>New &amp; stable in Angular v22 — and covered in depth</h3>
+              <p>
+                The APIs that make Angular v22 different aren&apos;t previews
+                here — they&apos;re taught with runnable examples:
+              </p>
+              <div className="not-prose flex flex-wrap gap-2 my-4">
+                {[
+                  "Signal Forms (no ControlValueAccessor)",
+                  "Angular Aria (headless a11y)",
+                  "@Service() decorator",
+                  "injectAsync()",
+                  "stable resource() / httpResource()",
+                  "linkedSignal()",
+                ].map((chip) => (
+                  <span
+                    key={chip}
+                    className="inline-flex items-center rounded-md bg-base-200 px-3 py-1 text-sm font-medium text-base-content"
+                  >
+                    {chip}
+                  </span>
+                ))}
+              </div>
+
               <h3>What you will learn</h3>
               <ul>
                 <li>
                   The core building blocks: <code>signal()</code>,{" "}
-                  <code>computed()</code>, and <code>effect()</code>.
+                  <code>computed()</code>, and <code>effect()</code> — with the
+                  mental model that makes them click.
                 </li>
                 <li>
                   Writable derived state with <code>linkedSignal()</code> and
-                  async data with <code>resource()</code>,{" "}
-                  <code>rxResource()</code>, and <code>httpResource()</code>.
+                  async data — <code>resource()</code>, <code>rxResource()</code>,
+                  and <code>httpResource()</code> — for loading, errors, and
+                  refetch, without RxJS boilerplate.
                 </li>
                 <li>
-                  Signal-based components with <code>input()</code>,{" "}
-                  <code>output()</code>, <code>model()</code>, and signal
-                  queries — plus Signal Forms and Angular Aria.
+                  Signal-driven components: <code>input()</code>,{" "}
+                  <code>output()</code>, <code>model()</code>, and signal queries
+                  (<code>viewChild</code>/<code>viewChildren</code>).
                 </li>
                 <li>
-                  Interop and a step-by-step strategy for migrating RxJS/NgRx
-                  code to Signals.
+                  <strong>Signal Forms &amp; Angular Aria</strong> (new and
+                  stable in v22) — type-safe, declarative forms with no{" "}
+                  <code>ControlValueAccessor</code>, plus headless, accessible UI
+                  primitives.
                 </li>
                 <li>
-                  Testing Signal-based code, plus performance and zoneless
-                  best practices.
+                  The new v22 dependency injection — the <code>@Service()</code>{" "}
+                  decorator and <code>injectAsync()</code> for code-split, lazy
+                  services.
+                </li>
+                <li>
+                  A step-by-step strategy for migrating{" "}
+                  <strong>RxJS/NgRx</strong> code to Signals (
+                  <code>toSignal</code>/<code>toObservable</code>,{" "}
+                  <code>takeUntilDestroyed</code>).
+                </li>
+                <li>
+                  Testing Signal-based code, plus zoneless and OnPush
+                  performance best practices.
                 </li>
               </ul>
 

--- a/src/app/mentorship/mentors/[username]/MentorProfileClient.tsx
+++ b/src/app/mentorship/mentors/[username]/MentorProfileClient.tsx
@@ -572,6 +572,14 @@ export default function MentorProfileClient({
                   LinkedIn Profile
                 </a>
               )}
+              {!mentor.linkedinUrl && user?.uid === mentor.uid && (
+                <p className="mt-2 text-sm text-base-content/60">
+                  Add your LinkedIn profile so mentees can verify your experience.{" "}
+                  <Link href="/profile" className="link link-primary">
+                    Add LinkedIn
+                  </Link>
+                </p>
+              )}
 
               {/* Stats */}
               <div className="flex flex-wrap gap-4 mt-4">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -19,7 +19,7 @@ export default function Hero() {
         {/* Text Content */}
         <div className="space-y-8">
           <a
-            href="https://leanpub.com/mastering-angular-signals/c/GO2026"
+            href="https://leanpub.com/mastering-angular-signals"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-accent/30 bg-accent/10 text-accent text-xs font-mono"
@@ -28,7 +28,7 @@ export default function Hero() {
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent opacity-75"></span>
               <span className="relative inline-flex rounded-full h-2 w-2 bg-accent"></span>
             </span>
-            Featured: Mastering Angular Signals (book)
+            New: Mastering Angular Signals — Angular v22 Edition
           </a>
 
           <h1 className="text-5xl md:text-7xl font-bold tracking-tight leading-tight text-base-content">

--- a/src/components/books/BookCard.tsx
+++ b/src/components/books/BookCard.tsx
@@ -2,6 +2,8 @@
 
 import React from "react";
 import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import Button from "../Button";
 
 import BookInterestModal from "./BookInterestModal";
@@ -15,6 +17,7 @@ export interface Book {
   description: string;
   link?: string | null;
   amazonLink?: string | null;
+  pageUrl?: string | null;
   btnText?: string;
   actionType?: "link" | "interest-form";
 }
@@ -25,10 +28,13 @@ interface BookCardProps {
 
 const BookCard: React.FC<BookCardProps> = ({ book }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const router = useRouter();
 
   const handleClick = () => {
     if (book.actionType === "interest-form") {
       setIsModalOpen(true);
+    } else if (book.pageUrl) {
+      router.push(book.pageUrl);
     } else {
       window.open(book.link || book.amazonLink || "", "_blank");
     }
@@ -59,7 +65,13 @@ const BookCard: React.FC<BookCardProps> = ({ book }) => {
             )}
           </div>
           <h5 className="text-lg sm:text-xl mb-1 sm:mb-2 line-clamp-1 text-center font-bold text-base-content">
-            {book.title}
+            {book.pageUrl ? (
+              <Link href={book.pageUrl} className="hover:text-primary">
+                {book.title}
+              </Link>
+            ) : (
+              book.title
+            )}
           </h5>
           <h6 className="text-sm sm:text-base mb-3 text-center text-base-content/70">
             {book.edition}

--- a/src/components/mentorship/MentorRegistrationForm.tsx
+++ b/src/components/mentorship/MentorRegistrationForm.tsx
@@ -459,6 +459,25 @@ export default function MentorRegistrationForm({
           </label>
         </div>
 
+        <div className="form-control">
+          <label className="label">
+            <span className="label-text font-semibold">LinkedIn Profile URL</span>
+            <span className="label-text-alt text-base-content/60">Recommended</span>
+          </label>
+          <input
+            type="url"
+            placeholder="https://linkedin.com/in/your-profile"
+            className="input input-bordered w-full"
+            value={linkedinUrl}
+            onChange={(e) => setLinkedinUrl(e.target.value)}
+          />
+          <label className="label">
+            <span className="label-text-alt text-base-content/60">
+              Shown publicly on your mentor profile so mentees can verify your experience.
+            </span>
+          </label>
+        </div>
+
         {/* Discord Username */}
         <div className="form-control">
           <label className="label">
@@ -756,26 +775,6 @@ export default function MentorRegistrationForm({
             <span>10</span>
           </div>
         </div>
-      </div>
-
-      {/* LinkedIn Profile URL */}
-      <div className="form-control">
-        <label className="label">
-          <span className="label-text font-semibold">LinkedIn Profile URL</span>
-          <span className="label-text-alt text-base-content/60">Optional</span>
-        </label>
-        <input
-          type="url"
-          placeholder="https://linkedin.com/in/your-profile"
-          className="input input-bordered w-full"
-          value={linkedinUrl}
-          onChange={(e) => setLinkedinUrl(e.target.value)}
-        />
-        <label className="label">
-          <span className="label-text-alt text-base-content/60">
-            Shown publicly on your mentor profile
-          </span>
-        </label>
       </div>
 
       {/* Availability */}

--- a/src/data/booksData.js
+++ b/src/data/booksData.js
@@ -14,12 +14,13 @@ const booksData = [
   {
     id: 3,
     title: "Mastering Angular Signals",
+    edition: "Angular v22 Edition",
     description:
       "A Practical Guide to Modern Reactivity, Performance, and Migration.",
     amazonLink: "https://www.amazon.com/dp/B0FF9LSHJN/",
     imageUrl: "/static/images/books/mastering-angular-signals-3d.png",
     author: "Ahsan Ayaz",
-    link: "https://leanpub.com/mastering-angular-signals/c/GO2026",
+    link: "https://leanpub.com/mastering-angular-signals",
     pageUrl: "/books/mastering-angular-signals",
     btnText: "Learn more",
     actionType: "link",

--- a/src/data/booksData.js
+++ b/src/data/booksData.js
@@ -16,11 +16,12 @@ const booksData = [
     title: "Mastering Angular Signals",
     description:
       "A Practical Guide to Modern Reactivity, Performance, and Migration.",
-    amazonLink: null,
+    amazonLink: "https://www.amazon.com/dp/B0FF9LSHJN/",
     imageUrl: "/static/images/books/mastering-angular-signals-3d.png",
     author: "Ahsan Ayaz",
     link: "https://leanpub.com/mastering-angular-signals/c/GO2026",
-    btnText: "Get your copy",
+    pageUrl: "/books/mastering-angular-signals",
+    btnText: "Learn more",
     actionType: "link",
   },
   {

--- a/src/lib/seo/bookSchema.ts
+++ b/src/lib/seo/bookSchema.ts
@@ -1,0 +1,127 @@
+// Book JSON-LD builders. Centralizes the shape so pages (and any audit script)
+// agree on what gets emitted for a book landing page. See:
+//   - https://schema.org/Book
+//   - https://developers.google.com/search/docs/appearance/structured-data/faqpage
+
+const SITE_NAME = "Code with Ahsan";
+
+export interface BookOfferInput {
+  price?: string; // e.g. "29.99"
+  priceCurrency?: string; // e.g. "USD"
+  url: string;
+  availability?: string; // schema.org availability URL or short form
+  name?: string; // e.g. "Paperback", "Kindle", "Leanpub (PDF/EPUB)"
+}
+
+export interface BookSchemaInput {
+  name: string;
+  description: string;
+  url: string;
+  baseUrl: string;
+  imageUrl?: string;
+  authorName?: string;
+  authorUrl?: string;
+  isbn?: string;
+  datePublished?: string; // ISO date
+  inLanguage?: string; // e.g. "en"
+  ratingValue?: number; // e.g. 4.6
+  reviewCount?: number; // e.g. 15
+  offers?: BookOfferInput[];
+}
+
+function normalizeAvailability(value?: string): string {
+  if (!value) return "https://schema.org/InStock";
+  if (value.startsWith("http")) return value;
+  return `https://schema.org/${value}`;
+}
+
+export function buildBookLd(
+  input: BookSchemaInput
+): Record<string, unknown> | null {
+  const name = (input.name || "").trim();
+  const description = (input.description || "").trim();
+  if (!name || !description) return null;
+
+  const ld: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Book",
+    name,
+    description,
+    url: input.url,
+    bookFormat: "https://schema.org/Paperback",
+    publisher: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      url: input.baseUrl,
+    },
+  };
+
+  if (input.imageUrl) ld.image = input.imageUrl;
+  if (input.inLanguage) ld.inLanguage = input.inLanguage;
+  if (input.isbn) ld.isbn = input.isbn;
+  if (input.datePublished) ld.datePublished = input.datePublished;
+
+  if (input.authorName) {
+    const author: Record<string, unknown> = {
+      "@type": "Person",
+      name: input.authorName,
+    };
+    if (input.authorUrl) author.url = input.authorUrl;
+    ld.author = author;
+  }
+
+  if (
+    typeof input.ratingValue === "number" &&
+    typeof input.reviewCount === "number" &&
+    input.reviewCount > 0
+  ) {
+    ld.aggregateRating = {
+      "@type": "AggregateRating",
+      ratingValue: input.ratingValue,
+      reviewCount: input.reviewCount,
+      bestRating: 5,
+      worstRating: 1,
+    };
+  }
+
+  if (input.offers && input.offers.length > 0) {
+    ld.offers = input.offers.map((o) => {
+      const offer: Record<string, unknown> = {
+        "@type": "Offer",
+        url: o.url,
+        availability: normalizeAvailability(o.availability),
+      };
+      if (o.price) offer.price = o.price;
+      if (o.priceCurrency) offer.priceCurrency = o.priceCurrency;
+      if (o.name) offer.name = o.name;
+      return offer;
+    });
+  }
+
+  return ld;
+}
+
+export interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+export function buildFaqLd(items: FaqItem[]): Record<string, unknown> | null {
+  const valid = (items || []).filter(
+    (i) => (i.question || "").trim() && (i.answer || "").trim()
+  );
+  if (valid.length === 0) return null;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: valid.map((i) => ({
+      "@type": "Question",
+      name: i.question.trim(),
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: i.answer.trim(),
+      },
+    })),
+  };
+}


### PR DESCRIPTION
## Summary
Book landing page + SEO work for the **Mastering Angular Signals — Angular v22 Edition** relaunch, plus the launch link fixes.

### Book landing / v22 relaunch
- New `/books/mastering-angular-signals` landing page with Book + FAQ JSON-LD schema
- Leanpub set as the primary CTA (higher royalty), Amazon secondary
- Books list links to the internal landing page
- Sharpened positioning + 14M+ install stat
- **Launch link fixes:** retired `GO2026` coupon → evergreen Leanpub URL (books list + homepage hero pill); hero pill copy → "New: Mastering Angular Signals — Angular v22 Edition"; added "Angular v22 Edition" to the list entry; paperback JSON-LD price `29.99` → `24.99`

### ⚠️ Also included (unrelated — flag for review)
This branch also carries 4 commits for the **mentor-profile LinkedIn** feature (GitHub #195): add LinkedIn field near Current Role, self-view backfill nudge, worktree merge. If you'd rather ship those separately, cherry-pick them out before merge.

## Test locally
- `npm run dev` → check homepage hero pill, `/books`, and `/books/mastering-angular-signals` (links resolve to Leanpub/Amazon, prices correct).
