### PR TITLE
feat(mentorship): show current mentees on mentor profile (VIS-50)

### DIFF
--- a/.planning/quick/260621-vis50-show-current-mentees-on-mentor-profile/260621-vis50-PLAN.md
+++ b/.planning/quick/260621-vis50-show-current-mentees-on-mentor-profile/260621-vis50-PLAN.md
@@ -1,0 +1,82 @@
+---
+phase: quick-260621-vis50
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/components/mentorship/CurrentMenteesSection.tsx
+  - src/app/profile/page.tsx
+autonomous: true
+requirements: [VIS-50, GH-208]
+must_haves:
+  truths:
+    - "A mentor visiting /profile sees a 'Current Mentees' section listing their active mentees"
+    - "Each mentee row shows name, status, and start date"
+    - "Mentors with 0 active mentees see a friendly empty state; 1 or many render correctly"
+    - "Non-mentors do not see the section"
+  artifacts:
+    - path: "src/components/mentorship/CurrentMenteesSection.tsx"
+      provides: "Client component that fetches active mentor matches and renders the mentee list"
+      contains: "Current Mentees"
+    - path: "src/app/profile/page.tsx"
+      provides: "Mentor-gated render of CurrentMenteesSection"
+      contains: "CurrentMenteesSection"
+---
+
+<objective>
+Show a mentor their current active mentees on /profile (VIS-50 / GH-208).
+
+The data already exists: GET /api/mentorship/my-matches?uid=<uid>&role=mentor returns
+`activeMatches` — mentorship_sessions with status 'active' for that mentor, each enriched with the
+mentee's `partnerProfile` (displayName, photoURL, currentRole) and `approvedAt` (start date). The
+gap was purely presentational: /profile never queried or rendered this relationship.
+</objective>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: CurrentMenteesSection component</name>
+  <files>src/components/mentorship/CurrentMenteesSection.tsx</files>
+  <action>
+New client component, props { userId }. On mount fetches
+`/api/mentorship/my-matches?uid=${userId}&role=mentor`, reads `data.activeMatches`
+(MatchWithProfile[]). Renders a DaisyUI card "Current Mentees" with a count badge and a
+2-col grid of mentee rows (ProfileAvatar + displayName + currentRole + status badge + "Since
+<approvedAt>" + Dashboard link to /mentorship/dashboard/<matchId>). Loading skeletons while
+fetching; friendly empty state when zero. Mirrors the existing ActiveMatchesWidget styling.
+  </action>
+  <verify>
+    <automated>npx eslint src/components/mentorship/CurrentMenteesSection.tsx 2>&1 | grep -c "error" | grep -q "^0$" && echo OK</automated>
+  </verify>
+  <done>Component fetches and renders active mentees with name/status/start date; eslint error-free.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Wire into /profile (mentor only)</name>
+  <files>src/app/profile/page.tsx</files>
+  <action>
+Import CurrentMenteesSection. Render it gated on `hasRole(profile, "mentor")`, placed above the
+Skill Level card so mentees-relationship visibility is prominent. Pass profile.uid.
+  </action>
+  <verify>
+    <automated>grep -q "CurrentMenteesSection" src/app/profile/page.tsx && echo OK</automated>
+  </verify>
+  <done>Mentors see the section on /profile; non-mentors do not.</done>
+</task>
+
+</tasks>
+
+<verification>
+- tsc clean for both files; eslint error-free (pre-existing warnings in profile/page.tsx unchanged).
+- 0 / 1 / many active mentees all render correctly (empty state vs grid).
+</verification>
+
+<success_criteria>
+- Mentor on /profile sees their active mentees with name, start date, status.
+- No data-model, API, or new-dependency changes — reuses existing my-matches endpoint.
+</success_criteria>
+
+<output>
+Create 260621-vis50-SUMMARY.md when done.
+</output>

--- a/.planning/quick/260621-vis50-show-current-mentees-on-mentor-profile/260621-vis50-SUMMARY.md
+++ b/.planning/quick/260621-vis50-show-current-mentees-on-mentor-profile/260621-vis50-SUMMARY.md
@@ -1,0 +1,37 @@
+---
+phase: quick-260621-vis50
+plan: 01
+status: complete
+requirements: [VIS-50, GH-208]
+files_modified:
+  - src/components/mentorship/CurrentMenteesSection.tsx (new)
+  - src/app/profile/page.tsx
+---
+
+# VIS-50 — Show current mentees on mentor's profile
+
+## What was built
+Added a **Current Mentees** section to `/profile` for mentors. Each active mentee renders with
+avatar, display name, current role, an `active` status badge, the mentorship start date
+("Since <approvedAt>"), and a link to the pair's dashboard. Empty (0), single, and many-mentee
+states all handled; loading skeletons during fetch.
+
+## Why this was the fix
+This was a presentation gap, not a missing model. `GET /api/mentorship/my-matches?uid=<uid>&role=mentor`
+already returns `activeMatches` (status `active` mentorship_sessions for the mentor) enriched with the
+mentee `partnerProfile` and `approvedAt`. The `/profile` page simply never queried or rendered it.
+The new `CurrentMenteesSection` consumes that existing endpoint — no API, schema, or dependency change.
+
+## Acceptance criteria
+- [x] Mentor visiting /profile sees a list of current active mentees
+- [x] Each mentee shows name, start date, status
+- [x] Works for 0 / 1 / many active mentees
+- [x] Non-mentors do not see the section (gated on `hasRole(profile, "mentor")`)
+
+## Verification
+- `npx tsc --noEmit` — clean for both files.
+- `npx eslint` — 0 errors on new/changed lines (2 pre-existing warnings in profile/page.tsx unchanged).
+- Manual UAT pending reviewer (run app, view /profile as a mentor with active mentee sessions).
+
+## Notes
+GH#206 (book-session gating) references the same mentee↔mentor relationship model this surfaces.

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -10,6 +10,7 @@ import MenteeRegistrationForm from "@/components/mentorship/MenteeRegistrationFo
 import Link from "next/link";
 import { DEFAULT_MAX_MENTEES } from "@/lib/mentorship-constants";
 import MentorAnnouncementCard from "@/components/mentorship/MentorAnnouncementCard";
+import CurrentMenteesSection from "@/components/mentorship/CurrentMenteesSection";
 import AvailabilityManager from "@/components/mentorship/AvailabilityManager";
 import BookingsList from "@/components/mentorship/BookingsList";
 import { authFetch } from "@/lib/apiClient";
@@ -314,6 +315,9 @@ export default function SettingsPage() {
           hasRole(profile, "alumni-ambassador")) && (
           <AmbassadorPublicCardSection />
         )}
+
+      {/* Current Mentees Section - Mentors Only (VIS-50) */}
+      {hasRole(profile, "mentor") && <CurrentMenteesSection userId={profile.uid} />}
 
       {/* Skill Level Card */}
       <div className="card bg-base-100 shadow-xl">

--- a/src/components/mentorship/CurrentMenteesSection.tsx
+++ b/src/components/mentorship/CurrentMenteesSection.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { MatchWithProfile } from "@/types/mentorship";
+import ProfileAvatar from "@/components/ProfileAvatar";
+
+interface CurrentMenteesSectionProps {
+  userId: string;
+}
+
+function formatStartDate(value: unknown): string | null {
+  if (!value) return null;
+  const date = new Date(value as string);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function MenteeRow({ match }: { match: MatchWithProfile }) {
+  const startDate = formatStartDate(match.approvedAt);
+  const status = match.status || "active";
+
+  return (
+    <div className="flex items-center gap-4 p-4 bg-base-200/50 rounded-box hover:bg-base-200 transition-colors">
+      <ProfileAvatar
+        photoURL={match.partnerProfile?.photoURL}
+        displayName={match.partnerProfile?.displayName}
+        size="lg"
+        ring
+      />
+      <div className="flex-1 min-w-0">
+        <div className="font-bold truncate">
+          {match.partnerProfile?.displayName || "Mentee"}
+        </div>
+        <div className="text-xs text-base-content/60 truncate">
+          {match.partnerProfile?.currentRole || "Developer"}
+        </div>
+        <div className="flex flex-wrap items-center gap-2 mt-2">
+          <span className="badge badge-success badge-sm capitalize">{status}</span>
+          {startDate && (
+            <span className="text-xs text-base-content/60">
+              Since {startDate}
+            </span>
+          )}
+          <Link
+            href={`/mentorship/dashboard/${match.id}`}
+            className="btn btn-primary btn-xs"
+          >
+            Dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function CurrentMenteesSection({
+  userId,
+}: CurrentMenteesSectionProps) {
+  const [mentees, setMentees] = useState<MatchWithProfile[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!userId) return;
+    let cancelled = false;
+    fetch(`/api/mentorship/my-matches?uid=${userId}&role=mentor`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (cancelled) return;
+        setMentees(data.activeMatches || []);
+      })
+      .catch((err) => {
+        if (!cancelled) console.error("Failed to load mentees:", err);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  return (
+    <div className="card bg-base-100 shadow-xl">
+      <div className="card-body">
+        <div className="flex justify-between items-center">
+          <h3 className="card-title flex items-center gap-2">
+            <span className="text-2xl">🤝</span> Current Mentees
+            {mentees.length > 0 && (
+              <span className="badge badge-success badge-sm">
+                {mentees.length}
+              </span>
+            )}
+          </h3>
+          <Link
+            href="/mentorship/my-matches"
+            className="btn btn-ghost btn-xs text-primary"
+          >
+            View All
+          </Link>
+        </div>
+        <p className="text-sm text-base-content/70">
+          Mentees you are actively mentoring.
+        </p>
+
+        <div className="divider"></div>
+
+        {loading ? (
+          <div className="grid md:grid-cols-2 gap-4">
+            {[1, 2].map((i) => (
+              <div
+                key={i}
+                className="h-24 bg-base-200 rounded-box animate-pulse"
+              ></div>
+            ))}
+          </div>
+        ) : mentees.length === 0 ? (
+          <div className="text-center py-8 bg-base-200/50 rounded-box">
+            <div className="text-4xl mb-2">🌱</div>
+            <p className="text-base-content/70">
+              You don&apos;t have any active mentees yet.
+            </p>
+          </div>
+        ) : (
+          <div className="grid md:grid-cols-2 gap-4">
+            {mentees.map((match) => (
+              <MenteeRow key={match.id} match={match} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a **Current Mentees** section to `/profile` for mentors (VIS-50 / closes #208).

Each active mentee renders with avatar, name, current role, an `active` status badge, the mentorship start date ("Since <approvedAt>"), and a link to the pair's dashboard.

## Why
Presentation gap, not a missing model. `GET /api/mentorship/my-matches?uid=<uid>&role=mentor` already returns `activeMatches` enriched with the mentee `partnerProfile` and `approvedAt`; `/profile` simply never rendered it. No API, schema, or dependency changes.

## Acceptance criteria
- [x] Mentor on /profile sees their active mentees
- [x] Each mentee shows name, start date, status
- [x] Works for 0 / 1 / many mentees (empty state + grid)
- [x] Non-mentors do not see the section

## Verification
- `tsc --noEmit` clean; `eslint` 0 errors on changed lines.
- Manual UAT: run app, view /profile as a mentor with active mentee sessions.

Co-Authored-By: Paperclip <noreply@paperclip.ing>