### PR TITLE
feat(challenges): add mandatory LinkedIn post URL field to submission form

### DIFF
--- a/src/app/api/challenges/[id]/submissions/route.ts
+++ b/src/app/api/challenges/[id]/submissions/route.ts
@@ -8,7 +8,7 @@ import {
 } from "@/services/ChallengeService";
 import { verifyAuth } from "@/lib/auth";
 import { getChallengeParticipantProfile } from "@/lib/challengeProfiles";
-import { validateGitHubUrl } from "@/lib/validation/urls";
+import { validateGitHubUrl, isValidLinkedInUrl } from "@/lib/validation/urls";
 
 function isValidHttpUrl(url: string) {
   try {
@@ -78,7 +78,7 @@ export async function POST(
     }
 
     const body = await request.json();
-    const { repoUrl, demoUrl, description } = body;
+    const { repoUrl, demoUrl, linkedinUrl, description } = body;
 
     if (!repoUrl || typeof repoUrl !== "string") {
       return NextResponse.json(
@@ -92,6 +92,20 @@ export async function POST(
     } catch {
       return NextResponse.json(
         { error: "Repository URL must be a valid GitHub repository URL" },
+        { status: 400 },
+      );
+    }
+
+    if (!linkedinUrl || typeof linkedinUrl !== "string") {
+      return NextResponse.json(
+        { error: "LinkedIn post URL is required" },
+        { status: 400 },
+      );
+    }
+
+    if (!isValidLinkedInUrl(linkedinUrl)) {
+      return NextResponse.json(
+        { error: "LinkedIn post URL must be a valid LinkedIn URL" },
         { status: 400 },
       );
     }
@@ -123,6 +137,7 @@ export async function POST(
       userAvatar,
       repoUrl,
       demoUrl: demoUrl || undefined,
+      linkedinUrl: linkedinUrl.trim(),
       description: description || "",
     });
 

--- a/src/app/challenges/[id]/submit/page.tsx
+++ b/src/app/challenges/[id]/submit/page.tsx
@@ -3,7 +3,7 @@
 import { useContext, useEffect, useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { ExternalLink, Github, Send } from "lucide-react";
+import { ExternalLink, Github, Linkedin, Send } from "lucide-react";
 import { AuthContext } from "@/contexts/AuthContext";
 import { useToast } from "@/contexts/ToastContext";
 import { useMentorship } from "@/contexts/MentorshipContext";
@@ -32,6 +32,7 @@ export default function SubmitChallengePage() {
   const [error, setError] = useState<string | null>(null);
   const [repoUrl, setRepoUrl] = useState("");
   const [demoUrl, setDemoUrl] = useState("");
+  const [linkedinUrl, setLinkedinUrl] = useState("");
   const [description, setDescription] = useState("");
   const [joined, setJoined] = useState(false);
   const [participantCount, setParticipantCount] = useState<number | null>(null);
@@ -151,6 +152,7 @@ export default function SubmitChallengePage() {
           body: JSON.stringify({
             repoUrl: repoUrl.trim(),
             demoUrl: demoUrl.trim() || undefined,
+            linkedinUrl: linkedinUrl.trim(),
             description: description.trim(),
           }),
         },
@@ -330,6 +332,31 @@ export default function SubmitChallengePage() {
               onChange={(event) => setDemoUrl(event.target.value)}
               disabled={submitting || !user}
             />
+          </label>
+
+          <label className="form-control w-full inline-block">
+            <div className="label">
+              <span className="label-text font-semibold flex items-center gap-2">
+                <Linkedin className="w-4 h-4" aria-hidden="true" />
+                LinkedIn Post URL
+              </span>
+            </div>
+            <input
+              type="url"
+              required
+              pattern="https://([\w-]+\.)?linkedin\.com/.+"
+              title="Enter a valid LinkedIn post URL (https://www.linkedin.com/...)"
+              className="input input-bordered w-full"
+              placeholder="https://www.linkedin.com/posts/your-post"
+              value={linkedinUrl}
+              onChange={(event) => setLinkedinUrl(event.target.value)}
+              disabled={submitting || !user}
+            />
+            <div className="label">
+              <span className="label-text-alt text-base-content/60">
+                Share your project on LinkedIn, then paste the post link here.
+              </span>
+            </div>
           </label>
 
           <label className="form-control w-full inline-block">

--- a/src/components/challenges/SubmissionGallery.tsx
+++ b/src/components/challenges/SubmissionGallery.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, Github } from "lucide-react";
+import { ExternalLink, Github, Linkedin } from "lucide-react";
 import ProfileAvatar from "@/components/ProfileAvatar";
 import type { Submission } from "@/types/challenges";
 
@@ -77,6 +77,17 @@ export default function SubmissionGallery({
                 >
                   <ExternalLink className="w-4 h-4" aria-hidden="true" />
                   Demo
+                </a>
+              )}
+              {submission.linkedinUrl && (
+                <a
+                  href={submission.linkedinUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn btn-sm btn-outline"
+                >
+                  <Linkedin className="w-4 h-4" aria-hidden="true" />
+                  LinkedIn
                 </a>
               )}
             </div>

--- a/src/lib/validation/urls.ts
+++ b/src/lib/validation/urls.ts
@@ -28,3 +28,33 @@ export function validateGitHubUrl(url?: string): string | undefined {
 export function isValidGitHubUrl(url: string): boolean {
   return githubRepoSchema.safeParse(url).success;
 }
+
+// Matches LinkedIn post/activity URLs on linkedin.com (any subdomain), e.g.
+// https://www.linkedin.com/posts/username_slug-activity-123-abc/
+// https://www.linkedin.com/feed/update/urn:li:activity:123/
+// Does NOT match: non-linkedin hosts or http:// URLs.
+const linkedinPostSchema = z
+  .string()
+  .url("Must be a valid URL")
+  .regex(
+    /^https:\/\/([\w-]+\.)?linkedin\.com\/.+/i,
+    "Must be a valid LinkedIn post URL (https://www.linkedin.com/...)"
+  );
+
+/**
+ * Validates a LinkedIn post URL.
+ * @param url - The URL to validate
+ * @returns The validated URL string
+ * @throws ZodError if URL is invalid
+ */
+export function validateLinkedInUrl(url: string): string {
+  return linkedinPostSchema.parse(url.trim());
+}
+
+/**
+ * Check if a string is a valid LinkedIn post URL without throwing.
+ * @returns true if valid, false otherwise
+ */
+export function isValidLinkedInUrl(url: string): boolean {
+  return linkedinPostSchema.safeParse(url).success;
+}

--- a/src/services/ChallengeService.ts
+++ b/src/services/ChallengeService.ts
@@ -90,6 +90,7 @@ function normalizeSubmission(
     userAvatar: data.userAvatar,
     repoUrl: data.repoUrl || "",
     demoUrl: data.demoUrl,
+    linkedinUrl: data.linkedinUrl || "",
     description: data.description || "",
     submittedAt: toIsoString(data.submittedAt as FirestoreDateValue),
     status: data.status || "approved",

--- a/src/types/challenges.ts
+++ b/src/types/challenges.ts
@@ -48,6 +48,7 @@ export interface Submission {
   userAvatar?: string;
   repoUrl: string;
   demoUrl?: string;
+  linkedinUrl: string;
   description: string;
   submittedAt: string; // ISO date string
   status: SubmissionStatus;


### PR DESCRIPTION
## What
Adds a **mandatory LinkedIn post URL** field to the monthly learning challenge submission form (GH #213 / VIS-56).

## Why
Participants must share their project on LinkedIn before submitting.

## Changes
- `types/challenges.ts` — `linkedinUrl: string` on `Submission`
- `lib/validation/urls.ts` — `validateLinkedInUrl` / `isValidLinkedInUrl` (https + linkedin.com host + non-empty path)
- `submit/page.tsx` — required field with client-side `pattern` validation + Linkedin icon
- `submissions/route.ts` — server requires + validates `linkedinUrl`
- `ChallengeService.ts` — persists + normalizes `linkedinUrl` (graceful fallback for legacy docs)
- `SubmissionGallery.tsx` — surfaces a LinkedIn link button (guarded)

## AC
- [x] Form has a LinkedIn post URL field
- [x] Field is mandatory — form cannot submit without it (client `required` + server 400)
- [x] URL validated as a valid LinkedIn URL (client `pattern` + server `isValidLinkedInUrl`)

## Verification
- `tsc --noEmit` clean
- `eslint` on changed files clean
- LinkedIn regex unit-checked against real post/feed URL shapes + negative cases

Closes #213