### PR TITLE
fix: Submit Project button not working on course pages (#210)

### DIFF
--- a/src/components/SubmissionWrapper.js
+++ b/src/components/SubmissionWrapper.js
@@ -2,7 +2,6 @@ import { useContext, useRef, useState } from 'react'
 import { getApp } from 'firebase/app'
 import { deleteObject, getDownloadURL, getStorage, ref, uploadBytes } from 'firebase/storage'
 import { getFirestore, setDoc, doc, getDoc } from 'firebase/firestore'
-import { logIn } from '../services/AuthService'
 import { getFireStorageFileName } from '../lib/utils/queryParams'
 import { URL_REGEX } from '../lib/regexes'
 import Button from './Button'
@@ -31,11 +30,11 @@ export default function SubmissionWrapper({
   const [submissionFile, setSubmissionFile] = useState(null)
   const [submissionDemoLink, setSubmissionDemoLink] = useState('')
   const supportedFileTypes = ['image/png', 'image/jpeg']
-  const { showLoginPopup } = useContext(AuthContext)
+  const { setShowLoginPopup } = useContext(AuthContext)
 
   const newSubmission = async () => {
     if (!user) {
-      showLoginPopup(true)
+      setShowLoginPopup(true)
       return
     }
     await getEnrollmentDoc({ course: { slug: submissionParams.courseId }, attendee: user }, true)


### PR DESCRIPTION
## Problem
On course pages (e.g. *Learn React in 90 Mins* → Submissions), clicking **Submit Project** did nothing — no modal, no navigation, no network request.

## Root cause
`SubmissionWrapper.js` called `showLoginPopup(true)`, but `AuthContext` exposes:
- `showLoginPopup: boolean`
- `setShowLoginPopup: (show) => void`

Calling the boolean as a function threw `TypeError: showLoginPopup is not a function` inside the click handler, killing it before anything ran. For a logged-out user this swallowed the entire flow. SubmissionWrapper was the **only** file still using the pre-migration function-style API; every other consumer already uses `setShowLoginPopup`.

## Fix
- Destructure and call `setShowLoginPopup` instead.
- Remove the now-unused `logIn` import.

## Verification
- Biome check passes on the changed file.
- Logged-out: button now opens the login modal.
- Logged-in: enrollment + submission dialog flow unchanged.

Fixes #210