### PR TITLE
feat(mentorship): show current mentees on mentor profile (VIS-51)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -29,7 +29,7 @@ Milestone: v7.0 Agentic Orchestra Upgrade — Phase 07 executing (Wave 1 done)
 Phase: 07 (agent-safety-observability-callbacks) — EXECUTING
 Plan: 3 of 4 ✅ (07-01 PII ✅, 07-02 tool-cache ✅, 07-03 lifecycle logging ✅) — 07-04 pending (HUMAN-GATED)
 Status: 07-03 GREEN (13 lifecycle tests + 14 cache + 16 PII = 175 total pass; 12 LlmAgent attachments; wrapper-skip verified for SequentialAgent + ParallelAgent)
-Last activity: 2026-06-09 — Completed quick task 260609-f6n: challenge participants list with submission status + cert contact snapshot
+Last activity: 2026-06-21 — Completed quick task 260621-lli: VIS-51 show current mentees on mentor's /profile
 
 ## Next Moves (queued, not in flight)
 
@@ -201,6 +201,7 @@ Do not deploy the rules flip before `sync-custom-claims.ts` completes. Dual-clai
 | 260609-ep2 | Fix monthly challenge bugs — submission 500 (undefined demoUrl rejected by Firestore Admin), Participate button now disables + shows "Joined", and challenge dates stored/displayed as UTC to stop Jun 1 → May 31 off-by-one. 3 commits, tsc + lint clean, verified E2E against emulators. | 2026-06-09 | 3a96467 | [260609-ep2-fix-monthly-challenge-bugs-project-submi](./quick/260609-ep2-fix-monthly-challenge-bugs-project-submi/) |
 | 260609-f6n | Challenge participants list with submission status on detail page + snapshot email/discord at join for certificates (no form; public list hides contact info). 2 commits, tsc + lint clean, verified E2E against emulators. | 2026-06-09 | 98fd5bf | [260609-f6n-show-challenge-participants-with-submiss](./quick/260609-f6n-show-challenge-participants-with-submiss/) |
 | 260611-n3r | Add LinkedIn profile link to mentor profile page (GitHub issue #195) — self-view backfill nudge + LinkedIn field promoted to Recommended near Current Role in edit form. Feature pre-existed (quick-058); this closes the adoption/discoverability gap. | 2026-06-11 | b7f9966 | [260611-n3r-add-linkedin-profile-link-to-mentor-prof](./quick/260611-n3r-add-linkedin-profile-link-to-mentor-prof/) |
+| 260621-lli | VIS-51 (GH#208) Show current mentees on mentor's /profile — new CurrentMenteesCard fetches active matches via /api/mentorship/my-matches; shows name, start date, Active status; handles 0/1/many. tsc + biome clean. | 2026-06-21 | 966c15e | [260621-lli-vis-51-show-current-mentees-section-on-m](./quick/260621-lli-vis-51-show-current-mentees-section-on-m/) |
 | Phase 01 P01 | 2min | 1 tasks | 1 files |
 | Phase 01-foundation-roles-array-migration P02 | 3 min | 3 tasks | 6 files |
 | Phase 01-foundation-roles-array-migration P04 | 2 min | 2 tasks | 3 files |

--- a/.planning/quick/260621-lli-vis-51-show-current-mentees-section-on-m/260621-lli-PLAN.md
+++ b/.planning/quick/260621-lli-vis-51-show-current-mentees-section-on-m/260621-lli-PLAN.md
@@ -1,0 +1,49 @@
+---
+quick_id: 260621-lli
+slug: vis-51-show-current-mentees-section-on-m
+description: VIS-51 Show current mentees on mentor's profile
+date: 2026-06-21
+status: planned
+---
+
+# Quick Task 260621-lli: Show current mentees on mentor's /profile
+
+## Context
+
+Paperclip issue VIS-51 (GH#208). Mentors visiting `/profile` cannot see their
+current active mentees. The data already exists — `GET /api/mentorship/my-matches?uid=&role=mentor`
+returns `activeMatches[]` with `partnerProfile` (the mentee) and `approvedAt`.
+`/mentorship/my-matches` already renders this, but `/profile` has no mentee list.
+
+## Acceptance Criteria (from issue)
+
+- Mentor on `/profile` sees a list of their current active mentees
+- Each mentee shows name, start date, status
+- Works for mentors with 0, 1, or many active mentees
+
+## Tasks
+
+### Task 1 — Add CurrentMenteesCard component
+- **files:** `src/components/mentorship/CurrentMenteesCard.tsx` (new)
+- **action:** Client component. Props `{ userId: string }`. Fetch
+  `/api/mentorship/my-matches?uid=${userId}&role=mentor`, read `activeMatches`.
+  Render a card "🎓 Current Mentees" with a count badge. For each mentee row:
+  `ProfileAvatar` (photoURL/displayName), name, "Mentoring since {approvedAt}"
+  start date, and an "Active" success badge. Link each row to
+  `/mentorship/dashboard/{match.id}`. Loading skeleton; empty state for 0
+  mentees with a link to `/mentorship/my-matches`.
+- **verify:** `npx tsc --noEmit` passes for the new file; component renders
+  with 0 and N matches.
+- **done:** Component exists, typed, reuses `MatchWithProfile` + `ProfileAvatar`.
+
+### Task 2 — Wire card into /profile for mentors
+- **files:** `src/app/profile/page.tsx`
+- **action:** Import `CurrentMenteesCard`. Render it for mentors
+  (`hasRole(profile, "mentor")`) above the Time Slot Availability section,
+  passing `userId={profile.uid}`.
+- **verify:** `npm run check` (Biome) + `npx tsc --noEmit` clean.
+- **done:** Mentors see the mentees card on `/profile`; mentees do not.
+
+## Out of scope
+- No API changes (endpoint already returns required data).
+- No pending/completed lists (issue asks for active mentees only).

--- a/.planning/quick/260621-lli-vis-51-show-current-mentees-section-on-m/260621-lli-SUMMARY.md
+++ b/.planning/quick/260621-lli-vis-51-show-current-mentees-section-on-m/260621-lli-SUMMARY.md
@@ -1,0 +1,48 @@
+---
+quick_id: 260621-lli
+slug: vis-51-show-current-mentees-section-on-m
+description: VIS-51 Show current mentees on mentor's profile
+date: 2026-06-21
+status: complete
+commit: 966c15e
+---
+
+# Quick Task 260621-lli — Summary
+
+## What changed
+
+Mentors visiting `/profile` now see a **Current Mentees** section listing their
+active mentees. Previously the page only showed profile-edit forms, calendar,
+availability, and bookings — no mentee list (VIS-51 / GH#208).
+
+## Implementation
+
+- **New:** `src/components/mentorship/CurrentMenteesCard.tsx` — client component,
+  prop `{ userId }`. Fetches `GET /api/mentorship/my-matches?uid=&role=mentor`,
+  reads `activeMatches`. Each mentee row renders `ProfileAvatar`, display name,
+  optional current role, "Mentoring since {approvedAt}" start date, and an
+  "Active" badge, linking to `/mentorship/dashboard/{matchId}`. Includes a
+  loading skeleton and a 0-mentees empty state.
+- **Edited:** `src/app/profile/page.tsx` — imports the card and renders it for
+  mentors (`hasRole(profile, "mentor")`) above the Time Slot Availability
+  section.
+
+No API changes — the existing endpoint already returns name, start date
+(`approvedAt`), and status, and is the same source `/mentorship/my-matches` uses.
+
+## Acceptance criteria
+
+- [x] Mentor on `/profile` sees a list of current active mentees
+- [x] Mentee row shows name, start date, status
+- [x] Handles 0 / 1 / many mentees (empty state + count badge + list)
+
+## Verification
+
+- `npx tsc --noEmit` — no errors in changed files
+- `npx biome check` on both files — exit 0
+- Logic mirrors the proven `/mentorship/my-matches` page (same endpoint/fields)
+
+## Follow-up
+
+- GH#206 (book-session gating) references the mentee-mentor relationship model;
+  unblocked by this since the relationship is now surfaced on the profile.

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -12,6 +12,7 @@ import { DEFAULT_MAX_MENTEES } from "@/lib/mentorship-constants";
 import MentorAnnouncementCard from "@/components/mentorship/MentorAnnouncementCard";
 import AvailabilityManager from "@/components/mentorship/AvailabilityManager";
 import BookingsList from "@/components/mentorship/BookingsList";
+import CurrentMenteesCard from "@/components/mentorship/CurrentMenteesCard";
 import { authFetch } from "@/lib/apiClient";
 import { TimeSlotAvailability, UnavailableDate } from "@/types/mentorship";
 import { hasRole } from "@/lib/permissions";
@@ -415,6 +416,11 @@ export default function SettingsPage() {
           )}
         </div>
       </div>
+
+      {/* Current Mentees Section - Mentors Only */}
+      {hasRole(profile, "mentor") && (
+        <CurrentMenteesCard userId={profile.uid} />
+      )}
 
       {/* Availability Management Section - Mentors Only */}
       {hasRole(profile, "mentor") && (

--- a/src/components/mentorship/CurrentMenteesCard.tsx
+++ b/src/components/mentorship/CurrentMenteesCard.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import ProfileAvatar from "@/components/ProfileAvatar";
+import { MatchWithProfile } from "@/types/mentorship";
+
+interface CurrentMenteesCardProps {
+  /** The logged-in mentor's uid */
+  userId: string;
+}
+
+/**
+ * Shows the logged-in mentor's current (active) mentees on their profile.
+ * Reuses GET /api/mentorship/my-matches which returns activeMatches with the
+ * mentee attached as `partnerProfile`. Handles 0, 1, or many mentees.
+ */
+export default function CurrentMenteesCard({ userId }: CurrentMenteesCardProps) {
+  const [mentees, setMentees] = useState<MatchWithProfile[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchMentees = async () => {
+      try {
+        const res = await fetch(
+          `/api/mentorship/my-matches?uid=${userId}&role=mentor`,
+        );
+        if (res.ok) {
+          const data = await res.json();
+          if (!cancelled) setMentees(data.activeMatches || []);
+        }
+      } catch (error) {
+        console.error("Failed to load current mentees:", error);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    if (userId) fetchMentees();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  return (
+    <div className="card bg-base-100 shadow-xl">
+      <div className="card-body">
+        <div className="flex items-center justify-between">
+          <h3 className="card-title">
+            🎓 Current Mentees
+            {!loading && mentees.length > 0 && (
+              <span className="badge badge-success badge-sm">
+                {mentees.length}
+              </span>
+            )}
+          </h3>
+          {mentees.length > 0 && (
+            <Link
+              href="/mentorship/my-matches"
+              className="btn btn-ghost btn-xs text-primary"
+            >
+              View All
+            </Link>
+          )}
+        </div>
+
+        <p className="text-sm text-base-content/70">
+          Mentees you are actively mentoring.
+        </p>
+
+        <div className="divider"></div>
+
+        {loading ? (
+          <div className="space-y-3">
+            {[1, 2].map((i) => (
+              <div
+                key={i}
+                className="h-16 bg-base-200 rounded-box animate-pulse"
+              ></div>
+            ))}
+          </div>
+        ) : mentees.length === 0 ? (
+          <div className="text-center py-8 bg-base-200/50 rounded-box">
+            <div className="text-4xl mb-2">🌱</div>
+            <p className="text-base-content/70">
+              You don&apos;t have any active mentees yet.
+            </p>
+            <p className="text-sm text-base-content/50 mt-1">
+              When you accept mentee requests, they&apos;ll appear here.
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {mentees.map((match) => (
+              <li key={match.id}>
+                <Link
+                  href={`/mentorship/dashboard/${match.id}`}
+                  className="flex items-center gap-4 p-3 bg-base-200/50 rounded-box hover:bg-base-200 transition-colors"
+                >
+                  <ProfileAvatar
+                    photoURL={match.partnerProfile?.photoURL}
+                    displayName={match.partnerProfile?.displayName}
+                    size="lg"
+                    ring
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="font-bold truncate">
+                      {match.partnerProfile?.displayName || "Unknown"}
+                    </div>
+                    {match.partnerProfile?.currentRole && (
+                      <div className="text-xs text-base-content/60 truncate">
+                        {match.partnerProfile.currentRole}
+                      </div>
+                    )}
+                    <div className="text-xs text-base-content/50 mt-0.5">
+                      Mentoring since{" "}
+                      {match.approvedAt
+                        ? new Date(match.approvedAt).toLocaleDateString()
+                        : "N/A"}
+                    </div>
+                  </div>
+                  <span className="badge badge-success badge-sm shrink-0">
+                    Active
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Mentors visiting `/profile` now see a **Current Mentees** section listing their active mentees. Fixes GH#208 / VIS-51.

## Changes
- **New** `src/components/mentorship/CurrentMenteesCard.tsx` — fetches `GET /api/mentorship/my-matches?uid=&role=mentor`, renders each active mentee's avatar, name, current role, start date (`approvedAt`), and an **Active** badge. Links to the mentorship dashboard. Loading skeleton + empty state.
- **Edit** `src/app/profile/page.tsx` — renders the card for mentors (`hasRole(profile, "mentor")`) above the Time Slot Availability section.

No API changes — the endpoint already returned the needed data (same source `/mentorship/my-matches` uses).

## Acceptance criteria
- [x] Mentor on `/profile` sees a list of current active mentees
- [x] Mentee row shows name, start date, status
- [x] Handles 0 / 1 / many mentees

## Verification
- `npx tsc --noEmit` — clean on changed files
- `npx biome check` — exit 0

## Notes
Unblocks GH#206 (book-session gating), which references the mentee-mentor relationship now surfaced on the profile.

Co-Authored-By: Paperclip <noreply@paperclip.ing>