### PR TITLE
feat(admin): bulk-delete archived Discord channels button (GH#136)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,16 +1,44 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useToast } from "@/contexts/ToastContext";
 import { AdminStats, Alert } from "@/types/admin";
 import { ADMIN_TOKEN_KEY } from "@/components/admin/AdminAuthGate";
 
+// Types
+
+/** Shape of the response from DELETE /api/mentorship/admin/sessions/delete-archived-channels */
+interface BulkDeleteResult {
+  success: boolean;
+  message: string;
+  deleted: number;
+  failed: number;
+}
+
+// Component
+
 export default function AdminOverviewPage() {
   const toast = useToast();
+
+  // Dashboard stats state
   const [stats, setStats] = useState<AdminStats | null>(null);
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const [loadingStats, setLoadingStats] = useState(true);
 
+  // Bulk-delete channels state
+  /** Whether the confirmation modal is visible */
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  /** Tracks an in-progress delete request */
+  const [deleting, setDeleting] = useState(false);
+  /** Stores the result summary after deletion */
+  const [deleteResult, setDeleteResult] = useState<BulkDeleteResult | null>(
+    null
+  );
+
+  // Keep a ref to the DaisyUI dialog element so we can call showModal / close
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  // ── Fetch stats on mount
   useEffect(() => {
     const fetchStats = async () => {
       try {
@@ -34,11 +62,102 @@ export default function AdminOverviewPage() {
     fetchStats();
   }, [toast]);
 
+  // ── Sync modal open / close with DaisyUI dialog
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (showDeleteModal) {
+      // Reset previous result when re-opening
+      setDeleteResult(null);
+      dialog.showModal();
+    } else {
+      dialog.close();
+    }
+  }, [showDeleteModal]);
+
+  // ── Handlers
+
+  /** Opens the confirmation modal. */
+  const handleOpenDeleteModal = () => setShowDeleteModal(true);
+
+  /** Closes the confirmation modal (also resets state). */
+  const handleCloseDeleteModal = () => setShowDeleteModal(false);
+
+  /**
+   * Sends the DELETE request to the bulk-cleanup API and shows the result.
+   * We keep the modal open after completion so the admin can read the summary.
+   */
+  const handleConfirmDelete = async () => {
+    setDeleting(true);
+    setDeleteResult(null);
+
+    try {
+      const token = localStorage.getItem(ADMIN_TOKEN_KEY);
+      const response = await fetch(
+        "/api/mentorship/admin/sessions/delete-archived-channels",
+        {
+          method: "DELETE",
+          headers: token ? { "x-admin-token": token } : {},
+        }
+      );
+
+      const data: BulkDeleteResult = await response.json();
+
+      if (response.ok && data.success) {
+        setDeleteResult(data);
+        // Success toast with channel count
+        toast.success(
+          `Cleanup complete — ${data.deleted} channel(s) deleted.`
+        );
+      } else {
+        toast.error(data.message || "Failed to delete archived channels.");
+        handleCloseDeleteModal();
+      }
+    } catch (error) {
+      console.error("Error deleting archived channels:", error);
+      toast.error("An unexpected error occurred. Please try again.");
+      handleCloseDeleteModal();
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  // Render
+
   return (
     <div className="space-y-6">
-      <h1 className="text-3xl font-bold">Admin Dashboard</h1>
+      {/* Page header */}
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <h1 className="text-3xl font-bold">Admin Dashboard</h1>
 
-      {/* Alerts Section */}
+        {/* Delete Archived Channels — danger action */}
+        <button
+          id="admin-delete-archived-channels-btn"
+          onClick={handleOpenDeleteModal}
+          className="btn btn-error btn-outline btn-sm gap-2"
+          title="Permanently delete Discord channels for all completed/cancelled sessions"
+        >
+          {/* Trash icon */}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+            />
+          </svg>
+          Delete All Archived Channels
+        </button>
+      </div>
+
+      {/* ── Alerts Section ────────────────────────────────────────────────────── */}
       {alerts.length > 0 && (
         <div className="alert alert-error">
           <svg
@@ -55,9 +174,7 @@ export default function AdminOverviewPage() {
             />
           </svg>
           <div className="flex-1">
-            <h3 className="font-bold">
-              {alerts.length} Low Rating Alert(s)
-            </h3>
+            <h3 className="font-bold">{alerts.length} Low Rating Alert(s)</h3>
             <p className="text-sm">
               Sessions that received 1-star ratings need attention.
             </p>
@@ -73,6 +190,7 @@ export default function AdminOverviewPage() {
       ) : (
         stats && (
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
+            {/* Total Mentors */}
             <div className="stats shadow bg-base-100">
               <div className="stat">
                 <div className="stat-figure text-primary">
@@ -98,6 +216,7 @@ export default function AdminOverviewPage() {
               </div>
             </div>
 
+            {/* Total Mentees */}
             <div className="stats shadow bg-base-100">
               <div className="stat">
                 <div className="stat-figure text-secondary">
@@ -123,6 +242,7 @@ export default function AdminOverviewPage() {
               </div>
             </div>
 
+            {/* Active Matches */}
             <div className="stats shadow bg-base-100">
               <div className="stat">
                 <div className="stat-figure text-success">
@@ -145,12 +265,11 @@ export default function AdminOverviewPage() {
                 <div className="stat-value text-success">
                   {stats.activeMatches}
                 </div>
-                <div className="stat-desc">
-                  of {stats.totalMatches} total
-                </div>
+                <div className="stat-desc">of {stats.totalMatches} total</div>
               </div>
             </div>
 
+            {/* Avg Session Rating */}
             <div className="stats shadow bg-base-100">
               <div className="stat">
                 <div className="stat-figure text-info">
@@ -177,6 +296,7 @@ export default function AdminOverviewPage() {
               </div>
             </div>
 
+            {/* Pending Projects */}
             <div className="stats shadow bg-base-100">
               <div className="stat">
                 <div className="stat-figure text-warning">
@@ -203,6 +323,7 @@ export default function AdminOverviewPage() {
               </div>
             </div>
 
+            {/* Pending Roadmaps */}
             <div className="stats shadow bg-base-100">
               <div className="stat">
                 <div className="stat-figure text-warning">
@@ -231,6 +352,155 @@ export default function AdminOverviewPage() {
           </div>
         )
       )}
+
+      {/* ═══════════════════════════════════════════════════════════════════════
+          Confirmation Modal — Delete All Archived Discord Channels
+          Uses the native HTML <dialog> element wrapped with DaisyUI modal classes.
+          ═══════════════════════════════════════════════════════════════════════ */}
+      <dialog
+        ref={dialogRef}
+        id="admin-delete-channels-modal"
+        className="modal"
+        onClose={handleCloseDeleteModal}
+      >
+        <div className="modal-box max-w-lg">
+          {/* ── Modal header ────────────────────────────────────────────────── */}
+          <h3 className="font-bold text-xl text-error flex items-center gap-2">
+            {/* Warning icon */}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-6 w-6 shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+            Delete All Archived Channels
+          </h3>
+
+          {/* ── Modal body — changes between confirmation prompt and result ───── */}
+          <div className="py-4 space-y-3 text-sm">
+            {deleteResult ? (
+              /* ── Post-deletion result summary ─────────────────────────────── */
+              <div className="space-y-3">
+                <div
+                  className={`alert ${deleteResult.failed === 0 ? "alert-success" : "alert-warning"
+                    }`}
+                >
+                  <span>{deleteResult.message}</span>
+                </div>
+
+                <ul className="list-disc list-inside text-base-content/80 space-y-1">
+                  <li>
+                    <span className="font-semibold text-success">
+                      {deleteResult.deleted}
+                    </span>{" "}
+                    channel(s) successfully deleted from Discord.
+                  </li>
+                  {deleteResult.failed > 0 && (
+                    <li>
+                      <span className="font-semibold text-error">
+                        {deleteResult.failed}
+                      </span>{" "}
+                      channel(s) could not be deleted (see server logs for
+                      details).
+                    </li>
+                  )}
+                </ul>
+              </div>
+            ) : (
+              /* ── Confirmation prompt ──────────────────────────────────────── */
+              <div className="space-y-3">
+                <p>
+                  This action will{" "}
+                  <strong className="text-error">
+                    permanently delete all Discord channels
+                  </strong>{" "}
+                  associated with mentorship sessions that have a status of{" "}
+                  <code className="bg-base-200 px-1 rounded">completed</code> or{" "}
+                  <code className="bg-base-200 px-1 rounded">cancelled</code>.
+                </p>
+                <p>
+                  The action is{" "}
+                  <strong>irreversible</strong> — deleted channels cannot be
+                  recovered.
+                </p>
+                <div className="alert alert-warning text-sm">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="stroke-current shrink-0 h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                    />
+                  </svg>
+                  <span>
+                    Are you sure you want to proceed? This will remove all
+                    message history from those channels on Discord.
+                  </span>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* ── Modal footer / action buttons ─────────────────────────────────── */}
+          <div className="modal-action">
+            {deleteResult ? (
+              /* After deletion: only a "Close" button */
+              <button
+                id="admin-delete-channels-close-btn"
+                className="btn btn-primary"
+                onClick={handleCloseDeleteModal}
+              >
+                Close
+              </button>
+            ) : (
+              /* Before deletion: Cancel + Confirm */
+              <>
+                <button
+                  id="admin-delete-channels-cancel-btn"
+                  className="btn btn-ghost"
+                  onClick={handleCloseDeleteModal}
+                  disabled={deleting}
+                >
+                  Cancel
+                </button>
+                <button
+                  id="admin-delete-channels-confirm-btn"
+                  className="btn btn-error"
+                  onClick={handleConfirmDelete}
+                  disabled={deleting}
+                >
+                  {deleting ? (
+                    <>
+                      <span className="loading loading-spinner loading-sm"></span>
+                      Deleting…
+                    </>
+                  ) : (
+                    "Yes, Delete All"
+                  )}
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Clicking the backdrop closes the dialog */}
+        <form method="dialog" className="modal-backdrop">
+          <button>close</button>
+        </form>
+      </dialog>
     </div>
   );
 }

--- a/src/app/api/mentorship/admin/sessions/delete-archived-channels/route.ts
+++ b/src/app/api/mentorship/admin/sessions/delete-archived-channels/route.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from 'next/server'
+import { db } from '@/lib/firebaseAdmin'
+import {
+    deleteDiscordChannel,
+    isDiscordConfigured,
+} from '@/lib/discord'
+
+/** Result for a single channel deletion attempt. */
+interface ChannelDeletionResult {
+    sessionId: string
+    channelId: string
+    success: boolean
+    error?: string
+}
+
+// DELETE /api/mentorship/admin/sessions/delete-archived-channels
+
+/**
+ * Bulk-deletes all Discord channels belonging to mentorship sessions that are
+ * in a terminal state ("completed" or "cancelled").
+ *
+ * Strategy:
+ *  1. Query Firestore for every session whose status is completed OR cancelled
+ *     and that still has a `discordChannelId` stored on it.
+ *  2. Attempt to delete each Discord channel via the bot (rate-limit safe).
+ *  3. On success, clear `discordChannelId` / `discordChannelUrl` from the
+ *     Firestore document so we never try to delete the same channel again.
+ *  4. Return a summary of how many were deleted vs. how many failed.
+ *
+ * The endpoint is intentionally idempotent — channels that Discord has already
+ * removed return a 404 which our `deleteDiscordChannel` helper treats as success.
+ */
+export async function DELETE() {
+    try {
+        // Guard: Discord must be configured
+        if (!isDiscordConfigured()) {
+            return NextResponse.json(
+                { error: 'Discord integration is not configured on this server.' },
+                { status: 503 }
+            )
+        }
+
+        // Find sessions with a discord channel in a terminal state
+        const [completedSnapshot, cancelledSnapshot] = await Promise.all([
+            db
+                .collection('mentorship_sessions')
+                .where('status', '==', 'completed')
+                .get(),
+            db
+                .collection('mentorship_sessions')
+                .where('status', '==', 'cancelled')
+                .get(),
+        ])
+
+        // Merge both result sets, deduplicate by document ID, and keep only those
+        // that still reference a Discord channel.
+        const sessionDocs = new Map<
+            string,
+            FirebaseFirestore.QueryDocumentSnapshot
+        >()
+
+        for (const doc of [...completedSnapshot.docs, ...cancelledSnapshot.docs]) {
+            const data = doc.data()
+            if (data.discordChannelId) {
+                sessionDocs.set(doc.id, doc)
+            }
+        }
+
+        if (sessionDocs.size === 0) {
+            // Nothing to do – return early with a clear message.
+            return NextResponse.json(
+                {
+                    success: true,
+                    message: 'No archived channels found to delete.',
+                    deleted: 0,
+                    failed: 0,
+                    results: [],
+                },
+                { status: 200 }
+            )
+        }
+
+        // Delete each channel, collecting results
+        const results: ChannelDeletionResult[] = []
+
+        for (const [sessionId, doc] of sessionDocs) {
+            const { discordChannelId } = doc.data() as { discordChannelId: string }
+
+            try {
+                const deleted = await deleteDiscordChannel(
+                    discordChannelId,
+                    'Admin bulk-delete of archived mentorship channels'
+                )
+
+                if (deleted) {
+                    // Clear the channel reference in Firestore
+                    await doc.ref.update({
+                        discordChannelId: null,
+                        discordChannelUrl: null,
+                        channelDeletedAt: new Date(),
+                        channelDeletedBy: 'admin_bulk_cleanup',
+                    })
+
+                    results.push({ sessionId, channelId: discordChannelId, success: true })
+                } else {
+                    results.push({
+                        sessionId,
+                        channelId: discordChannelId,
+                        success: false,
+                        error: 'Discord API returned a failure response',
+                    })
+                }
+            } catch (err) {
+                // Individual failures should not abort the whole batch.
+                const message = err instanceof Error ? err.message : String(err)
+                results.push({
+                    sessionId,
+                    channelId: discordChannelId,
+                    success: false,
+                    error: message,
+                })
+            }
+        }
+
+        // Build summary
+        const deleted = results.filter((r) => r.success).length
+        const failed = results.filter((r) => !r.success).length
+
+        return NextResponse.json(
+            {
+                success: true,
+                message: `Bulk cleanup complete. Deleted: ${deleted}, Failed: ${failed}.`,
+                deleted,
+                failed,
+                results,
+            },
+            { status: 200 }
+        )
+    } catch (error) {
+        console.error('[Admin] Error during bulk channel deletion:', error)
+        return NextResponse.json(
+            { error: 'An unexpected error occurred during bulk channel deletion.' },
+            { status: 500 }
+        )
+    }
+}


### PR DESCRIPTION
Clean reimplementation of #159 on top of current `main`.

## What
Adds an admin-dashboard button + confirmation modal that calls a new `DELETE /api/mentorship/admin/sessions/delete-archived-channels` route, removing Discord channels of completed/cancelled mentorship sessions. Idempotent; clears `discordChannelId`/`discordChannelUrl` after deletion; returns a deleted/failed summary.

## Why a new PR
#159 (by @SyedMuhammadHunain) had the right feature but its branch was 485 commits behind main and also committed:
- `firebase-debug.log` / `firestore-debug.log` (should never be tracked)
- unrelated deps `konva`, `react-konva`, `@radix-ui/react-slot`

This PR keeps **only the 2 feature files** (admin button + new route), rebased clean on main. Credit to @SyedMuhammadHunain for the original implementation.

## Verification
- `tsc --noEmit` clean (only pre-existing `courses.generated.json` generated-artifact warning).
- No new deps.

Supersedes #159. Tracked on VIS-88.

Co-Authored-By: Paperclip <noreply@paperclip.ing>