### PR TITLE
fix(navbar): remove duplicate Challenges link (#214)

### DIFF
--- a/src/data/headerNavLinks.js
+++ b/src/data/headerNavLinks.js
@@ -12,7 +12,6 @@ const baseNavLinks = [
   { href: "/books", title: "Books" },
   { href: "https://blog.codewithahsan.dev/", title: "Blog", external: true },
   { href: "/about", title: "About" },
-  { href: "/challenges ", title: "Challenges" },
 ];
 
 // Feature-flag-gated insertions (per D-11 in .planning/phases/01-foundation-roles-array-migration/01-CONTEXT.md).


### PR DESCRIPTION
Closes #214

## Problem
The header navbar showed **Challenges** twice (see issue screenshot). The link was declared in two places:
- `baseNavLinks` (always-visible main nav) — with a buggy trailing-space href `"/challenges "`
- `MORE_LINKS` (the "More" dropdown)

## Fix
Removed the broken `baseNavLinks` entry. Challenges remains accessible via the **More** dropdown (clean `/challenges` href).

## Test
1. `npm run dev`
2. Open any page, view the desktop header → only one **Challenges** entry (under **More**).
3. Click it → navigates to `/challenges` (no trailing-space 404).

🤖 Triaged + prepared by CTO agent (VIS-91 issue-triage loop).