### PR TITLE
fix(navbar): increase desktop menu item font size (#169)

### DIFF
--- a/src/components/LayoutWrapper.tsx
+++ b/src/components/LayoutWrapper.tsx
@@ -59,7 +59,7 @@ const LayoutWrapper = ({ children }: { children: ReactNode }) => {
               <Link
                 key={link.title}
                 href={link.href}
-                className={`btn btn-ghost${isActive(link.href) ? " btn-active" : ""}`}
+                className={`btn btn-ghost text-base${isActive(link.href) ? " btn-active" : ""}`}
                 {...(link.external
                   ? { target: "_blank", rel: "noopener noreferrer" }
                   : {})}
@@ -70,7 +70,7 @@ const LayoutWrapper = ({ children }: { children: ReactNode }) => {
             {/* More Dropdown */}
             <div className="relative" ref={moreRef}>
               <button
-                className="btn btn-ghost"
+                className="btn btn-ghost text-base"
                 onClick={() => setMoreOpen(!moreOpen)}
               >
                 More


### PR DESCRIPTION
Closes #169

## Problem
Desktop header menu items were small (default daisyUI `btn` = `text-sm`). User asked to increase the font size.

## Fix
Added `text-base` to the main nav links and the **More** button in `LayoutWrapper.tsx`.

## Test
1. `npm run dev`
2. View the desktop header (≥ md breakpoint).
3. Menu items (Mentorship, Projects, … and More) render at `text-base` — visibly larger than before, alignment/height unchanged.

🤖 Triaged + prepared by CTO agent (VIS-91 issue-triage loop).