### PR TITLE
fix(mentorship): Book-a-Session gating QA fixes (VIS-94)

### DIFF
--- a/src/app/mentorship/mentors/[username]/MentorProfileClient.tsx
+++ b/src/app/mentorship/mentors/[username]/MentorProfileClient.tsx
@@ -504,7 +504,13 @@ export default function MentorProfileClient({
   // requestStatus === "active" means the viewer has an active mentorship_sessions doc with this mentor.
   const canBook = requestStatus === "active";
   const bookGateTooltip =
-    "Only active mentees of this mentor can book a session. Request mentorship first.";
+    requestStatus === "pending"
+      ? "Your mentorship request is pending. You can book a session once your mentor accepts it."
+      : requestStatus === "completed"
+        ? "Your mentorship has completed. Request mentorship again to book another session."
+        : requestStatus === "declined"
+          ? "Your mentorship request was declined, so booking is unavailable."
+          : "Only active mentees of this mentor can book a session. Request mentorship first.";
 
   return (
     <div className="space-y-6">
@@ -818,7 +824,10 @@ export default function MentorProfileClient({
                     Book a Session
                   </Link>
                 ) : (
-                  <span className="tooltip" data-tip={bookGateTooltip}>
+                  <span
+                    className="tooltip tooltip-top inline-block before:max-w-[16rem] before:whitespace-normal"
+                    data-tip={bookGateTooltip}
+                  >
                     <button
                       type="button"
                       className="btn btn-primary btn-sm btn-disabled"
@@ -881,7 +890,10 @@ export default function MentorProfileClient({
                   View Available Slots
                 </Link>
               ) : (
-                <span className="tooltip" data-tip={bookGateTooltip}>
+                <span
+                  className="tooltip tooltip-top inline-block before:max-w-[16rem] before:whitespace-normal"
+                  data-tip={bookGateTooltip}
+                >
                   <button
                     type="button"
                     className="btn btn-primary btn-sm btn-disabled"


### PR DESCRIPTION
## VIS-94 — QA fixes for Book-a-Session gating (VIS-57)

Fixes the 3 QA failures logged on [ClickUp 86cactyxz](https://app.clickup.com/t/86cactyxz). Origin: VIS-57 / GH#206 (#229).

### Changes
- **Tooltip misalignment (bug 2):** the disabled button is now wrapped in an `inline-block` tooltip with an explicit `tooltip-top` position and a wrapping bubble (`before:max-w-[16rem] before:whitespace-normal`). The arrow centers on the button and the long message no longer overflows.
- **No feedback after requesting (bug 3):** `bookGateTooltip` is now state-aware — pending / completed / declined / non-mentee each get a distinct explanation, so a mentee who has requested mentorship understands why booking is still gated instead of seeing a generic message.
- **Hidden vs disabled (bug 1):** the button is rendered **disabled** (not hidden) for non-active viewers, reinforced by the `inline-block` wrapper. The active-mentee enablement path (`canBook = requestStatus === "active"`) is unchanged — active mentees get the live booking link.

### Scope
Presentational + copy only. No change to `canBook` gating logic or server-side enforcement.

### UAT
1. Open any mentor profile that **has time slots** while logged out → "Book a Session" button shows **disabled** (greyed), not hidden. Hover → tooltip appears, arrow centered on the button, text wraps inside the bubble (no overflow).
2. Log in as a **mentee who is not matched** with this mentor → button still disabled with tooltip "Only active mentees of this mentor can book a session. Request mentorship first."
3. Click **Request Mentorship** → status becomes pending. Hover the Book button → tooltip now reads "Your mentorship request is pending. You can book a session once your mentor accepts it."
4. Have the mentor **accept** the request (status → active) → "Book a Session" / "View Available Slots" becomes an **enabled** link to `/mentorship/book/<mentorId>`.
5. Repeat on a mentor whose availability shows the **Availability card** variant and the standalone **Book a Session card** variant — both gate identically.

Co-Authored-By: Paperclip <noreply@paperclip.ing>
