### PR TITLE
fix(mentorship): personalize mentor-accept Discord DM copy (GH#119)

### DIFF
--- a/src/app/api/mentorship/match/route.ts
+++ b/src/app/api/mentorship/match/route.ts
@@ -426,10 +426,16 @@ export async function PUT(request: NextRequest) {
             if (menteeData?.discordUsername && mentorProfileData) {
               // We CAN fire-and-forget this one as it's less critical,
               // BUT for Vercel reliability it's safer to await or Promise.all if we had multiple
+              const menteeName =
+                menteeData.displayName ||
+                menteeData.email?.split("@")[0] ||
+                "there";
               await sendDirectMessage(
                 menteeData.discordUsername,
                 `🎉 Great news! **${mentorProfileData.displayName}** has accepted your mentorship request!\n\n` +
-                  `Your private channel is ready: ${result.channelUrl}`
+                  `Hi ${menteeName},\n\n` +
+                  `You recently requested mentorship from **${mentorProfileData.displayName}** on CodeWithAhsan. ` +
+                  `Your private channel is ready — click here and start asking your queries: ${result.channelUrl}`
               ).catch((err) => console.error("Discord DM failed:", err));
             }
           }


### PR DESCRIPTION
## Summary
Updates the Discord DM sent to a mentee when a mentor accepts their mentorship request, per the wording requested in #119.

**Before:**
> 🎉 Great news! **Mentor** has accepted your mentorship request!
> Your private channel is ready: <url>

**After:**
> 🎉 Great news! **Mentor** has accepted your mentorship request!
>
> Hi <mentee name>,
>
> You recently requested mentorship from **Mentor** on CodeWithAhsan. Your private channel is ready — click here and start asking your queries: <url>

Mentee name falls back to email handle, then "there" if unavailable.

## Test
- `npx tsc --noEmit` — no new errors from this change (pre-existing generated-json / .next validator errors unrelated).

Closes #119

Co-Authored-By: Paperclip <noreply@paperclip.ing>