### PR TITLE
fix(projects): darken difficulty filter select background (GH#202)

### DIFF
--- a/src/components/projects/ProjectFilters.tsx
+++ b/src/components/projects/ProjectFilters.tsx
@@ -51,7 +51,7 @@ export default function ProjectFilters({
           <span className="label-text font-semibold">Difficulty Level</span>
         </label>
         <select
-          className="select select-bordered w-full"
+          className="select select-bordered w-full bg-base-200"
           value={difficultyFilter}
           onChange={(e) =>
             setDifficultyFilter(e.target.value as ProjectDifficulty | "all")


### PR DESCRIPTION
## What
The **Difficulty Level** dropdown on the Discover Projects page rendered with a light/white background that clashed with the dark theme (see #202). Added `bg-base-200` so the select matches the surrounding search input and project cards.

## Why
Closes #202 — reported via Loupe (severity: minor).

## Change
- `src/components/projects/ProjectFilters.tsx`: add `bg-base-200` to the difficulty `<select>` className.

## Verify
1. Go to `/projects` (Discover Projects).
2. Confirm the **Difficulty Level** dropdown background is dark (base-200), consistent with the search box and cards — no longer white.
3. Open the dropdown; options still readable in both light and dark themes.

🤖 Triaged + prepared by CTO automation (VIS-96).