### PR TITLE
fix(ambassador): surface referralCode + timezone in profile GET (GH#238)

### DIFF
--- a/src/app/api/ambassador/profile/route.ts
+++ b/src/app/api/ambassador/profile/route.ts
@@ -354,6 +354,12 @@ export async function GET(request: NextRequest) {
   ) {
     body.cohortPresentationVideoEmbedType = subdoc.cohortPresentationVideoEmbedType;
   }
+  // REF-01 / D-04: the client reads `referralCode` and `timezone` off this
+  // response (AmbassadorPublicCardSection). They were omitted from the
+  // projection, so accepted ambassadors never saw their referral code (GH#238)
+  // and the timezone select fell back to UTC. Surface both (self-scoped read).
+  copyString("referralCode", "referralCode");
+  copyString("timezone", "timezone");
 
   return NextResponse.json(body);
 }


### PR DESCRIPTION
## What
Accepted ambassadors could not see their referral code on `/profile` — the card always showed *"Your referral code is being generated — check back shortly after acceptance is confirmed."* (see #238).

## Root cause
The `GET /api/ambassador/profile` projection builds its response body from the ambassador subdoc but **omitted `referralCode` and `timezone`**. The client (`AmbassadorPublicCardSection`) reads `body.referralCode` and `body.timezone` — so the code was never delivered (placeholder shown forever) and the timezone select fell back to UTC, even though both values exist on the subdoc (assigned at acceptance, REF-01 / D-04).

## Change
- `src/app/api/ambassador/profile/route.ts`: add `referralCode` and `timezone` to the self-scoped GET projection.

Read-only, scoped to the authenticated user's own subdoc (`ctx.uid`). No auth/permission/write changes.

## Verify (UAT)
1. Log in as an **accepted ambassador** (one whose application status is `accepted`).
2. Go to `/profile`, scroll to **Your Referral Code**.
3. **Expected:** the actual code shows as a badge with a **Copy code** button and a shareable `/?ref=CODE` link — not the "being generated" placeholder.
4. Confirm the **timezone** select reflects the saved timezone (not defaulting to UTC) if one was set.
5. Regression: an applicant who is **not yet accepted** (no `referralCode` on subdoc) should still see the placeholder.

⚠️ Touches a data API route — held for board/owner approval before merge per VIS-96 gate.

🤖 Triaged + prepared by CTO automation (VIS-96).