### PR TITLE
fix(admin): align challenges empty-state banner horizontally (GH#196)

### DIFF
--- a/src/app/admin/challenges/page.tsx
+++ b/src/app/admin/challenges/page.tsx
@@ -76,7 +76,7 @@ export default function AdminChallengesPage() {
         </div>
       ) : challenges.length === 0 ? (
         <div className="alert alert-info shadow-lg">
-          <div>
+          <div className="flex items-center gap-2">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-current flex-shrink-0 w-6 h-6"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
             <span>No challenges found. Create one to get started!</span>
           </div>


### PR DESCRIPTION
Closes #196

## Problem
On the admin challenges page, the empty-state info banner displayed its icon and text stacked vertically instead of on one horizontal row.

## Fix
The DaisyUI `alert` wrapped its icon (`svg`) and message (`span`) in a plain block `div`, which stacked them. Added `flex items-center gap-2` to that wrapper so they sit side-by-side.

`src/app/admin/challenges/page.tsx` — empty-state alert only (shown when no challenges exist).

## Testing
- Admin → Challenges page with **no challenges** created.
- Banner icon + "No challenges found..." text now appear horizontally aligned.

🤖 Prepared via CTO triage automation (VIS-99).