### PR TITLE
fix(mentorship): attribute mentor in completion channel message (GH#204)

### DIFF
--- a/src/app/api/mentorship/dashboard/[matchId]/route.ts
+++ b/src/app/api/mentorship/dashboard/[matchId]/route.ts
@@ -169,7 +169,7 @@ export async function PUT(
         notificationTasks.push(
           sendChannelMessage(
             matchData.discordChannelId,
-            `🎓 **Congratulations! This mentorship has been completed!** 🎉\n\n` +
+            `🎓 **Congratulations! This mentorship has been marked as completed by ${mentorData?.displayName || "the mentor"}!** 🎉\n\n` +
               `Thank you both for your dedication to learning and growth.\n\n` +
               `**${mentorData?.displayName || "Mentor"}**, thank you for sharing your knowledge!\n` +
               `**${menteeData?.displayName || "Mentee"}**, we hope you learned a lot!\n\n` +


### PR DESCRIPTION
Closes #204

## Problem
When a mentorship is marked complete, the Discord channel message said `This mentorship has been completed!` without stating **who** completed it.

## Fix
The completion message posted from the mentor dashboard now names the mentor:
`This mentorship has been marked as completed by **<mentor name>**`.

`src/app/api/mentorship/dashboard/[matchId]/route.ts` — only mentors can complete via this path (enforced at line ~131), so attributing the mentor is accurate.

## Note for board
Admins can also set a session to `completed` via `admin/sessions` PUT, but that path currently posts **no** completion message at all. Adding an admin-attributed completion announcement there is a separate, larger change — flagged for a follow-up decision rather than bundled here.

## Testing
1. As a mentor, open an active mentorship dashboard and mark it **Complete**.
2. Check the mentorship Discord channel: completion message should read "...marked as completed by **<your name>**".

🤖 Prepared via CTO triage automation (VIS-99).