### PR TITLE
fix(ambassador): decrement cohort acceptedCount on alumni/offboard (GH#253)

### DIFF
--- a/src/app/api/ambassador/members/[uid]/alumni/route.test.ts
+++ b/src/app/api/ambassador/members/[uid]/alumni/route.test.ts
@@ -21,6 +21,7 @@ vi.mock("firebase-admin/firestore", () => ({
     serverTimestamp: () => "SERVER_TS",
     arrayRemove: (v: string) => ({ __op: "arrayRemove", v }),
     arrayUnion: (v: string) => ({ __op: "arrayUnion", v }),
+    increment: (n: number) => ({ __op: "increment", n }),
   },
 }));
 
@@ -34,11 +35,13 @@ vi.mock("@/lib/firebaseAdmin", () => {
     collection: vi.fn().mockReturnValue({ doc: vi.fn().mockReturnValue(subdocRef) }),
   };
   const publicAmbDoc = { id: "pa-doc" };
+  const cohortDoc = { id: "c1" };
   return {
     db: {
       collection: vi.fn((name: string) => {
         if (name === "mentorship_profiles") return { doc: vi.fn().mockReturnValue(profileRef) };
         if (name === "public_ambassadors") return { doc: vi.fn().mockReturnValue(publicAmbDoc) };
+        if (name === "cohorts") return { doc: vi.fn().mockReturnValue(cohortDoc) };
         return { doc: vi.fn().mockReturnValue({}) };
       }),
       batch: vi.fn(() => ({ update: updateMock, delete: deleteMock, commit: commitMock })),
@@ -94,8 +97,8 @@ describe("POST /api/ambassador/members/[uid]/alumni", () => {
         expect(["arrayUnion", "arrayRemove"]).toContain(roles.__op);
       }
     }
-    // Total updateMock call count: 1 union + 1 remove + subdoc update + public_ambassadors update = 4
-    expect(updateMock.mock.calls.length).toBe(4);
+    // Total updateMock call count: 1 union + 1 remove + subdoc update + public_ambassadors update + cohort decrement = 5
+    expect(updateMock.mock.calls.length).toBe(5);
   });
 
   it("ALUMNI-03: public_ambassadors is UPDATED (active:false) NOT DELETED", async () => {
@@ -108,6 +111,16 @@ describe("POST /api/ambassador/members/[uid]/alumni", () => {
       return payload?.active === false && Object.keys(payload).length === 1;
     });
     expect(publicUpdates.length).toBe(1);
+  });
+
+  it("GH#253: decrements cohort acceptedCount on alumni transition", async () => {
+    await POST(makeReq(), { params: { uid: "u1" } });
+    const decrements = updateMock.mock.calls.filter((args) => {
+      const payload = args[1] as Record<string, unknown>;
+      const field = payload?.acceptedCount as { __op?: string; n?: number } | undefined;
+      return field?.__op === "increment" && field.n === -1;
+    });
+    expect(decrements.length).toBe(1);
   });
 
   it("returns 409 if subdoc.active is already false", async () => {

--- a/src/app/api/ambassador/members/[uid]/alumni/route.ts
+++ b/src/app/api/ambassador/members/[uid]/alumni/route.ts
@@ -7,6 +7,7 @@
  *   (2) profile.roles arrayRemove("ambassador")
  *   (3) subdoc { active: false, endedAt: serverTimestamp }
  *   (4) public_ambassadors/{uid} update { active: false }   <- NOT deleted (ALUMNI-03)
+ *   (5) cohorts/{cohortId} acceptedCount decrement(-1)      <- keeps count in sync (GH#253)
  *
  * Pitfall 1: arrayUnion + arrayRemove on the same field require two
  * sequential batch.update calls — Firestore disallows both transforms
@@ -17,10 +18,8 @@ import { db } from "@/lib/firebaseAdmin";
 import { FieldValue } from "firebase-admin/firestore";
 import { isAmbassadorProgramEnabled } from "@/lib/features";
 import { requireAdmin } from "@/lib/ambassador/adminAuth";
-import {
-  PUBLIC_AMBASSADORS_COLLECTION,
-  type AmbassadorSubdoc,
-} from "@/types/ambassador";
+import { PUBLIC_AMBASSADORS_COLLECTION, type AmbassadorSubdoc } from "@/types/ambassador";
+import { AMBASSADOR_COHORTS_COLLECTION } from "@/lib/ambassador/constants";
 import { syncAmbassadorClaim } from "@/lib/ambassador/acceptance";
 import { createLogger } from "@/lib/logger";
 
@@ -28,7 +27,7 @@ const logger = createLogger("ambassador/members/[uid]/alumni");
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { uid: string } | Promise<{ uid: string }> },
+  { params }: { params: { uid: string } | Promise<{ uid: string }> }
 ) {
   if (!isAmbassadorProgramEnabled()) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -51,7 +50,7 @@ export async function POST(
   if (subdoc.active === false) {
     return NextResponse.json(
       { error: "Ambassador already transitioned out of active state" },
-      { status: 409 },
+      { status: 409 }
     );
   }
 
@@ -75,6 +74,10 @@ export async function POST(
   // (4) Public projection — flip to inactive but DO NOT delete (ALUMNI-03).
   batch.update(db.collection(PUBLIC_AMBASSADORS_COLLECTION).doc(uid), {
     active: false,
+  });
+  // (5) Decrement cohort acceptedCount to keep it in sync (GH#253).
+  batch.update(db.collection(AMBASSADOR_COHORTS_COLLECTION).doc(subdoc.cohortId), {
+    acceptedCount: FieldValue.increment(-1),
   });
   await batch.commit();
 

--- a/src/app/api/ambassador/members/[uid]/offboard/route.test.ts
+++ b/src/app/api/ambassador/members/[uid]/offboard/route.test.ts
@@ -47,7 +47,8 @@ vi.mock("@/lib/firebaseAdmin", () => {
       collection: vi.fn((name: string) => {
         if (name === "mentorship_profiles") return { doc: vi.fn().mockReturnValue(profileRef) };
         if (name === "cohorts") return { doc: vi.fn().mockReturnValue(cohortRef) };
-        if (name === "public_ambassadors") return { doc: vi.fn().mockReturnValue({ id: "pa-doc" }) };
+        if (name === "public_ambassadors")
+          return { doc: vi.fn().mockReturnValue({ id: "pa-doc" }) };
         return { doc: vi.fn().mockReturnValue({}) };
       }),
       batch: vi.fn(() => ({ update: updateMock, delete: deleteMock, commit: commitMock })),
@@ -59,6 +60,7 @@ vi.mock("firebase-admin/firestore", () => ({
     serverTimestamp: () => "SERVER_TS",
     arrayRemove: (v: string) => ({ __op: "arrayRemove", v }),
     arrayUnion: (v: string) => ({ __op: "arrayUnion", v }),
+    increment: (n: number) => ({ __op: "increment", n }),
   },
 }));
 
@@ -127,5 +129,17 @@ describe("POST /api/ambassador/members/[uid]/offboard", () => {
     vi.mocked(sendAmbassadorOffboardingEmail).mockResolvedValue(true);
     await POST(makeReq(), { params: { uid: "u1" } });
     expect(deleteMock).toHaveBeenCalled();
+  });
+
+  it("GH#253: decrements cohort acceptedCount on offboard", async () => {
+    vi.mocked(removeDiscordRole).mockResolvedValue(true);
+    vi.mocked(sendAmbassadorOffboardingEmail).mockResolvedValue(true);
+    await POST(makeReq(), { params: { uid: "u1" } });
+    const decrements = updateMock.mock.calls.filter((args) => {
+      const payload = args[1] as Record<string, unknown>;
+      const field = payload?.acceptedCount as { __op?: string; n?: number } | undefined;
+      return field?.__op === "increment" && field.n === -1;
+    });
+    expect(decrements.length).toBe(1);
   });
 });

--- a/src/app/api/ambassador/members/[uid]/offboard/route.ts
+++ b/src/app/api/ambassador/members/[uid]/offboard/route.ts
@@ -3,7 +3,8 @@
  * POST /api/ambassador/members/[uid]/offboard
  *
  * Admin-triggered 2-strike removal. Atomic Firestore batch first
- * (roles strip + subdoc active:false + offboardedAt + delete public projection),
+ * (roles strip + subdoc active:false + offboardedAt + delete public projection +
+ * cohort acceptedCount decrement (GH#253)),
  * then Discord role removal + offboarding email as soft post-commit steps.
  *
  * INVARIANT (ALUMNI-02): does NOT add "alumni-ambassador" to roles.
@@ -28,7 +29,7 @@ const logger = createLogger("ambassador/members/[uid]/offboard");
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { uid: string } | Promise<{ uid: string }> },
+  { params }: { params: { uid: string } | Promise<{ uid: string }> }
 ) {
   if (!isAmbassadorProgramEnabled()) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -50,17 +51,11 @@ export async function POST(
   }
   const subdoc = subdocSnap.data() as AmbassadorSubdoc;
   if (subdoc.active === false) {
-    return NextResponse.json(
-      { error: "Ambassador is already inactive" },
-      { status: 409 },
-    );
+    return NextResponse.json({ error: "Ambassador is already inactive" }, { status: 409 });
   }
 
   const profile = (profileSnap.data() ?? {}) as { displayName?: string; email?: string };
-  const cohortSnap = await db
-    .collection(AMBASSADOR_COHORTS_COLLECTION)
-    .doc(subdoc.cohortId)
-    .get();
+  const cohortSnap = await db.collection(AMBASSADOR_COHORTS_COLLECTION).doc(subdoc.cohortId).get();
   const cohort = cohortSnap.exists ? (cohortSnap.data() as CohortDoc) : null;
 
   // Atomic Firestore batch — hard failure boundary.
@@ -74,16 +69,17 @@ export async function POST(
     updatedAt: FieldValue.serverTimestamp(),
   });
   batch.delete(db.collection(PUBLIC_AMBASSADORS_COLLECTION).doc(uid));
+  // Decrement cohort acceptedCount to keep it in sync (GH#253).
+  batch.update(db.collection(AMBASSADOR_COHORTS_COLLECTION).doc(subdoc.cohortId), {
+    acceptedCount: FieldValue.increment(-1),
+  });
   await batch.commit();
 
   // Soft step 1: Discord role removal (DISC-05).
   let discordRemoved = false;
   if (subdoc.discordMemberId) {
     try {
-      discordRemoved = await removeDiscordRole(
-        subdoc.discordMemberId,
-        DISCORD_AMBASSADOR_ROLE_ID,
-      );
+      discordRemoved = await removeDiscordRole(subdoc.discordMemberId, DISCORD_AMBASSADOR_ROLE_ID);
     } catch (e) {
       logger.error("removeDiscordRole threw unexpectedly", { uid, error: e });
       discordRemoved = false;
@@ -97,7 +93,7 @@ export async function POST(
       emailSent = await sendAmbassadorOffboardingEmail(
         profile.email,
         profile.displayName,
-        cohort.name,
+        cohort.name
       );
     } catch (e) {
       logger.error("sendAmbassadorOffboardingEmail threw unexpectedly", { uid, error: e });


### PR DESCRIPTION
## Problem

The `acceptedCount` field on cohort docs is a denormalized counter that was only incremented (on acceptance) but never decremented when ambassadors were removed via:

- `/api/ambassador/members/[uid]/alumni` — graceful term completion
- `/api/ambassador/members/[uid]/offboard` — 2-strike removal

This caused the counter to drift: e.g., 7 accepted over time, 4 removed, 3 active — but cohort doc showed `acceptedCount: 7`. The drifted count also affects gating in `applications.ts` where `acceptedCount >= maxSize` blocks new accepted applications.

Fixes: https://github.com/AhsanAyaz/code-with-ahsan/issues/253

## Fix

Add `FieldValue.increment(-1)` on `cohorts/{cohortId}` inside the atomic Firestore batch in both routes. The `cohortId` is already available from the ambassador subdoc.

## Tests

- Updated `alumni/route.test.ts`: count of batch `.update()` calls 4 → 5; added `GH#253` decrement assertion.
- Updated `offboard/route.test.ts`: added `increment` to FieldValue mock; added `GH#253` decrement assertion.
- All 12 tests pass.

## Manual remediation note

Existing production cohort docs with drifted `acceptedCount` will need a one-time corrective write (set `acceptedCount` to the actual count of `accepted` applications for that cohort). This PR prevents future drift only.