### PR TITLE
fix(challenges): auto-derive status from dates + admin submissions view (GH#255, GH#256)

### DIFF
--- a/src/app/admin/challenges/[id]/submissions/page.tsx
+++ b/src/app/admin/challenges/[id]/submissions/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { ADMIN_TOKEN_KEY } from "@/components/admin/AdminAuthGate";
+import type { Challenge, Submission } from "@/types/challenges";
+
+export default function AdminChallengeSubmissionsPage() {
+  const params = useParams();
+  const [challenge, setChallenge] = useState<Challenge | null>(null);
+  const [submissions, setSubmissions] = useState<Submission[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const token = localStorage.getItem(ADMIN_TOKEN_KEY);
+        const res = await fetch(`/api/admin/challenges/${params.id}/submissions`, {
+          headers: token ? { "x-admin-token": token } : {},
+        });
+        if (!res.ok) {
+          const data = await res.json();
+          throw new Error(data.error || "Failed to load submissions");
+        }
+        const data = await res.json();
+        setChallenge(data.challenge);
+        setSubmissions(data.submissions);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Something went wrong");
+      } finally {
+        setLoading(false);
+      }
+    };
+    if (params.id) fetchData();
+  }, [params.id]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Link href="/admin/challenges" className="btn btn-ghost btn-sm">
+          ← Challenges
+        </Link>
+        {challenge && <h1 className="text-2xl font-bold">Submissions — {challenge.title}</h1>}
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <span className="loading loading-spinner loading-lg text-primary" />
+        </div>
+      ) : error ? (
+        <div className="alert alert-error">{error}</div>
+      ) : submissions.length === 0 ? (
+        <div className="alert alert-info">No submissions yet for this challenge.</div>
+      ) : (
+        <div className="overflow-x-auto bg-base-100 shadow-xl rounded-box">
+          <table className="table w-full">
+            <thead>
+              <tr>
+                <th>User</th>
+                <th>Repo</th>
+                <th>Demo</th>
+                <th>LinkedIn</th>
+                <th>Status</th>
+                <th>Score</th>
+                <th>Submitted At</th>
+              </tr>
+            </thead>
+            <tbody>
+              {submissions.map((s) => (
+                <tr key={s.id}>
+                  <td>
+                    <div className="flex items-center gap-2">
+                      {s.userAvatar && (
+                        <div className="avatar">
+                          <div className="w-8 rounded-full">
+                            <img src={s.userAvatar} alt={s.userName} />
+                          </div>
+                        </div>
+                      )}
+                      <span className="font-medium">{s.userName}</span>
+                    </div>
+                  </td>
+                  <td>
+                    <a
+                      href={s.repoUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="link link-primary text-sm"
+                    >
+                      {s.repoUrl.replace("https://github.com/", "")}
+                    </a>
+                  </td>
+                  <td>
+                    {s.demoUrl ? (
+                      <a
+                        href={s.demoUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="link link-secondary text-sm"
+                      >
+                        Demo
+                      </a>
+                    ) : (
+                      <span className="text-base-content/40 text-sm">—</span>
+                    )}
+                  </td>
+                  <td>
+                    <a
+                      href={s.linkedinUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="link link-primary text-sm"
+                    >
+                      Post
+                    </a>
+                  </td>
+                  <td>
+                    <span
+                      className={`badge ${
+                        s.status === "approved"
+                          ? "badge-success"
+                          : s.status === "pending"
+                            ? "badge-warning"
+                            : "badge-error"
+                      }`}
+                    >
+                      {s.status}
+                    </span>
+                  </td>
+                  <td>{s.score}</td>
+                  <td className="text-sm text-base-content/70">
+                    {new Date(s.submittedAt).toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {!loading && submissions.length > 0 && (
+        <p className="text-sm text-base-content/60">
+          {submissions.length} submission{submissions.length !== 1 ? "s" : ""} total
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/challenges/page.tsx
+++ b/src/app/admin/challenges/page.tsx
@@ -1,10 +1,10 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import Link from 'next/link';
-import { Challenge } from '@/types/challenges';
-import { ADMIN_TOKEN_KEY } from '@/components/admin/AdminAuthGate';
-import { useToast } from '@/contexts/ToastContext';
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { Challenge } from "@/types/challenges";
+import { ADMIN_TOKEN_KEY } from "@/components/admin/AdminAuthGate";
+import { useToast } from "@/contexts/ToastContext";
 
 /**
  * Admin Dashboard - Challenges List.
@@ -20,15 +20,15 @@ export default function AdminChallengesPage() {
     const fetchChallenges = async () => {
       try {
         const token = localStorage.getItem(ADMIN_TOKEN_KEY);
-        const res = await fetch('/api/admin/challenges', {
-          headers: token ? { 'x-admin-token': token } : {},
+        const res = await fetch("/api/admin/challenges", {
+          headers: token ? { "x-admin-token": token } : {},
         });
         if (res.ok) {
           const data = await res.json();
           setChallenges(data.challenges);
         }
       } catch (error) {
-        console.error('Failed to fetch challenges', error);
+        console.error("Failed to fetch challenges", error);
       } finally {
         setLoading(false);
       }
@@ -44,20 +44,20 @@ export default function AdminChallengesPage() {
     try {
       const token = localStorage.getItem(ADMIN_TOKEN_KEY);
       const res = await fetch(`/api/admin/challenges/${id}`, {
-        method: 'DELETE',
-        headers: token ? { 'x-admin-token': token } : {},
+        method: "DELETE",
+        headers: token ? { "x-admin-token": token } : {},
       });
 
       if (res.ok) {
-        toast.success('Challenge deleted!');
+        toast.success("Challenge deleted!");
         setChallenges(challenges.filter((c) => c.id !== id));
       } else {
         const error = await res.json();
-        toast.error(error.error || 'Failed to delete challenge');
+        toast.error(error.error || "Failed to delete challenge");
       }
     } catch (error) {
-      console.error('Error deleting challenge:', error);
-      toast.error('Something went wrong');
+      console.error("Error deleting challenge:", error);
+      toast.error("Something went wrong");
     }
   };
 
@@ -77,7 +77,19 @@ export default function AdminChallengesPage() {
       ) : challenges.length === 0 ? (
         <div className="alert alert-info shadow-lg">
           <div className="flex items-center gap-2">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-current flex-shrink-0 w-6 h-6"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              className="stroke-current flex-shrink-0 w-6 h-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              ></path>
+            </svg>
             <span>No challenges found. Create one to get started!</span>
           </div>
         </div>
@@ -97,29 +109,49 @@ export default function AdminChallengesPage() {
               {challenges.map((challenge) => (
                 <tr key={challenge.id}>
                   <td>
-                     <div className="font-bold">{challenge.title}</div>
-                     <div className="text-sm opacity-50">{challenge.topic}</div>
+                    <div className="font-bold">{challenge.title}</div>
+                    <div className="text-sm opacity-50">{challenge.topic}</div>
                   </td>
                   <td>
-                     <span className={`badge ${
-                       challenge.status === 'active' ? 'badge-success' :
-                       challenge.status === 'upcoming' ? 'badge-warning' : 'badge-ghost'
-                     }`}>
-                       {challenge.status}
-                     </span>
+                    <span
+                      className={`badge ${
+                        challenge.status === "active"
+                          ? "badge-success"
+                          : challenge.status === "upcoming"
+                            ? "badge-warning"
+                            : "badge-ghost"
+                      }`}
+                    >
+                      {challenge.status}
+                    </span>
                   </td>
                   <td>{challenge.difficulty}</td>
                   <td>
-                     <div className="text-sm">
-                       Start: {new Date(challenge.startDate).toLocaleDateString(undefined, { timeZone: 'UTC' })}
-                     </div>
-                     <div className="text-sm">
-                       End: {new Date(challenge.endDate).toLocaleDateString(undefined, { timeZone: 'UTC' })}
-                     </div>
+                    <div className="text-sm">
+                      Start:{" "}
+                      {new Date(challenge.startDate).toLocaleDateString(undefined, {
+                        timeZone: "UTC",
+                      })}
+                    </div>
+                    <div className="text-sm">
+                      End:{" "}
+                      {new Date(challenge.endDate).toLocaleDateString(undefined, {
+                        timeZone: "UTC",
+                      })}
+                    </div>
                   </td>
                   <td>
                     <div className="flex gap-2">
-                      <Link href={`/admin/challenges/${challenge.id}/edit`} className="btn btn-sm btn-outline">
+                      <Link
+                        href={`/admin/challenges/${challenge.id}/submissions`}
+                        className="btn btn-sm btn-outline btn-info"
+                      >
+                        Submissions
+                      </Link>
+                      <Link
+                        href={`/admin/challenges/${challenge.id}/edit`}
+                        className="btn btn-sm btn-outline"
+                      >
                         Edit
                       </Link>
                       <button

--- a/src/app/api/admin/challenges/[id]/submissions/route.ts
+++ b/src/app/api/admin/challenges/[id]/submissions/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAllSubmissionsForChallenge, getChallenge } from "@/services/ChallengeService";
+import { verifyAdminRequest } from "@/lib/adminAuth";
+
+/**
+ * GET /api/admin/challenges/[id]/submissions
+ * Retrieves all submissions (all statuses) for a challenge.
+ * Admin-only — uses verifyAdminRequest.
+ */
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    if (!(await verifyAdminRequest(request))) {
+      return NextResponse.json({ error: "Admin authentication required" }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const challenge = await getChallenge(id);
+    if (!challenge) {
+      return NextResponse.json({ error: "Challenge not found" }, { status: 404 });
+    }
+
+    const submissions = await getAllSubmissionsForChallenge(id);
+    return NextResponse.json({ challenge, submissions }, { status: 200 });
+  } catch (error) {
+    console.error("Error fetching admin submissions:", error);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/src/services/ChallengeService.ts
+++ b/src/services/ChallengeService.ts
@@ -19,12 +19,7 @@ const SUBMISSIONS_COLLECTION = "submissions";
 const LEADERBOARD_COLLECTION = "leaderboard";
 const CHALLENGE_PARTICIPANTS_COLLECTION = "challenge_participants";
 
-type FirestoreDateValue =
-  | string
-  | Date
-  | { toDate: () => Date }
-  | null
-  | undefined;
+type FirestoreDateValue = string | Date | { toDate: () => Date } | null | undefined;
 
 /**
  * Error thrown when a user attempts to submit multiple projects
@@ -55,10 +50,18 @@ function toIsoString(value: FirestoreDateValue): string {
   return value.toDate().toISOString();
 }
 
-function normalizeChallenge(
-  doc: FirebaseFirestore.DocumentSnapshot,
-): Challenge {
+function deriveChallengeStatus(startDate: string, endDate: string): ChallengeStatus {
+  const now = new Date();
+  if (now < new Date(startDate)) return "upcoming";
+  if (now > new Date(endDate)) return "past";
+  return "active";
+}
+
+function normalizeChallenge(doc: FirebaseFirestore.DocumentSnapshot): Challenge {
   const data = doc.data() as Partial<Challenge>;
+
+  const startDate = toIsoString(data.startDate as FirestoreDateValue);
+  const endDate = toIsoString(data.endDate as FirestoreDateValue);
 
   return {
     id: doc.id,
@@ -66,9 +69,9 @@ function normalizeChallenge(
     description: data.description || "",
     topic: data.topic || "General",
     difficulty: data.difficulty || "intermediate",
-    startDate: toIsoString(data.startDate as FirestoreDateValue),
-    endDate: toIsoString(data.endDate as FirestoreDateValue),
-    status: data.status || "upcoming",
+    startDate,
+    endDate,
+    status: deriveChallengeStatus(startDate, endDate),
     brief: data.brief || "",
     deliverables: Array.isArray(data.deliverables) ? data.deliverables : [],
     resources: Array.isArray(data.resources) ? data.resources : [],
@@ -77,9 +80,7 @@ function normalizeChallenge(
   };
 }
 
-function normalizeSubmission(
-  doc: FirebaseFirestore.DocumentSnapshot,
-): Submission {
+function normalizeSubmission(doc: FirebaseFirestore.DocumentSnapshot): Submission {
   const data = doc.data() as Partial<Submission>;
 
   return {
@@ -98,9 +99,7 @@ function normalizeSubmission(
   };
 }
 
-function normalizeParticipant(
-  doc: FirebaseFirestore.DocumentSnapshot,
-): ChallengeParticipant {
+function normalizeParticipant(doc: FirebaseFirestore.DocumentSnapshot): ChallengeParticipant {
   const data = doc.data() as Partial<ChallengeParticipant>;
 
   return {
@@ -118,12 +117,12 @@ function normalizeParticipant(
 /**
  * Records a user's participation in a specific challenge.
  * This is a required step before they can submit a project.
- * 
+ *
  * @param participantData The user and challenge IDs.
  * @returns The new participant record.
  */
 export async function joinChallenge(
-  participantData: Omit<ChallengeParticipant, "id" | "joinedAt">,
+  participantData: Omit<ChallengeParticipant, "id" | "joinedAt">
 ): Promise<ChallengeParticipant> {
   const docId = `${participantData.challengeId}_${participantData.userId}`;
   const docRef = db.collection(CHALLENGE_PARTICIPANTS_COLLECTION).doc(docId);
@@ -160,13 +159,11 @@ export async function joinChallenge(
 
 /**
  * Gets the total number of users who have joined a specific challenge.
- * 
+ *
  * @param challengeId The ID of the challenge.
  * @returns The count of participants.
  */
-export async function getChallengeParticipantsCount(
-  challengeId: string,
-): Promise<number> {
+export async function getChallengeParticipantsCount(challengeId: string): Promise<number> {
   const snapshot = await db
     .collection(CHALLENGE_PARTICIPANTS_COLLECTION)
     .where("challengeId", "==", challengeId)
@@ -177,18 +174,16 @@ export async function getChallengeParticipantsCount(
 
 /**
  * Checks if a specific user has joined a specific challenge.
- * 
+ *
  * @param challengeId The ID of the challenge.
  * @param userId The ID of the user.
  * @returns True if the user has joined, false otherwise.
  */
 export async function isChallengeParticipant(
   challengeId: string,
-  userId: string,
+  userId: string
 ): Promise<boolean> {
-  const docRef = db
-    .collection(CHALLENGE_PARTICIPANTS_COLLECTION)
-    .doc(`${challengeId}_${userId}`);
+  const docRef = db.collection(CHALLENGE_PARTICIPANTS_COLLECTION).doc(`${challengeId}_${userId}`);
 
   const doc = await docRef.get();
   return doc.exists;
@@ -203,13 +198,10 @@ export async function isChallengeParticipant(
  * @returns Participants with their submission status.
  */
 export async function getChallengeParticipantsWithStatus(
-  challengeId: string,
+  challengeId: string
 ): Promise<ChallengeParticipantStatus[]> {
   const [participantsSnap, submissions] = await Promise.all([
-    db
-      .collection(CHALLENGE_PARTICIPANTS_COLLECTION)
-      .where("challengeId", "==", challengeId)
-      .get(),
+    db.collection(CHALLENGE_PARTICIPANTS_COLLECTION).where("challengeId", "==", challengeId).get(),
     getSubmissionsForChallenge(challengeId),
   ]);
 
@@ -235,15 +227,9 @@ export async function getChallengeParticipantsWithStatus(
 }
 
 function monthRange(yearMonth?: string) {
-  const current = yearMonth
-    ? new Date(`${yearMonth}-01T00:00:00.000Z`)
-    : new Date();
-  const start = new Date(
-    Date.UTC(current.getUTCFullYear(), current.getUTCMonth(), 1),
-  );
-  const end = new Date(
-    Date.UTC(current.getUTCFullYear(), current.getUTCMonth() + 1, 1),
-  );
+  const current = yearMonth ? new Date(`${yearMonth}-01T00:00:00.000Z`) : new Date();
+  const start = new Date(Date.UTC(current.getUTCFullYear(), current.getUTCMonth(), 1));
+  const end = new Date(Date.UTC(current.getUTCFullYear(), current.getUTCMonth() + 1, 1));
 
   return {
     month: `${start.getUTCFullYear()}-${String(start.getUTCMonth() + 1).padStart(2, "0")}`,
@@ -256,12 +242,12 @@ function monthRange(yearMonth?: string) {
 
 /**
  * Creates a new Challenge in Firestore.
- * 
+ *
  * @param challengeData The data for the new challenge.
  * @returns The created Challenge object including its generated ID.
  */
 export async function createChallenge(
-  challengeData: Omit<Challenge, "id" | "createdAt" | "updatedAt">,
+  challengeData: Omit<Challenge, "id" | "createdAt" | "updatedAt">
 ): Promise<Challenge> {
   const docRef = db.collection(CHALLENGES_COLLECTION).doc();
   const now = new Date().toISOString();
@@ -279,14 +265,11 @@ export async function createChallenge(
 
 /**
  * Updates an existing Challenge in Firestore.
- * 
+ *
  * @param id The ID of the challenge to update.
  * @param updates Partial challenge data to apply.
  */
-export async function updateChallenge(
-  id: string,
-  updates: Partial<Challenge>,
-): Promise<void> {
+export async function updateChallenge(id: string, updates: Partial<Challenge>): Promise<void> {
   const docRef = db.collection(CHALLENGES_COLLECTION).doc(id);
   await docRef.update({
     ...updates,
@@ -296,7 +279,7 @@ export async function updateChallenge(
 
 /**
  * Deletes a Challenge from Firestore.
- * 
+ *
  * @param id The ID of the challenge to delete.
  */
 export async function deleteChallenge(id: string): Promise<void> {
@@ -306,7 +289,7 @@ export async function deleteChallenge(id: string): Promise<void> {
 
 /**
  * Retrieves a single Challenge by its ID.
- * 
+ *
  * @param id The ID of the challenge.
  * @returns The Challenge object or null if not found.
  */
@@ -324,13 +307,11 @@ export async function getChallenge(id: string): Promise<Challenge | null> {
 /**
  * Retrieves a list of Challenges, optionally filtered by status.
  * Results are ordered by start date descending.
- * 
+ *
  * @param status Optional status to filter by (e.g. "active").
  * @returns An array of Challenges.
  */
-export async function getChallenges(
-  status?: ChallengeStatus,
-): Promise<Challenge[]> {
+export async function getChallenges(status?: ChallengeStatus): Promise<Challenge[]> {
   let query: FirebaseFirestore.Query = db.collection(CHALLENGES_COLLECTION);
 
   if (status) {
@@ -352,18 +333,16 @@ export async function getChallenges(
  * 2. Prevents duplicate submissions.
  * 3. Creates the submission record.
  * 4. Updates or creates the user's global leaderboard entry.
- * 
+ *
  * @param submissionData The data for the new submission.
  * @returns The created Submission object.
  */
 export async function createSubmission(
-  submissionData: Omit<Submission, "id" | "submittedAt" | "status" | "score">,
+  submissionData: Omit<Submission, "id" | "submittedAt" | "status" | "score">
 ): Promise<Submission> {
   const docId = `${submissionData.challengeId}_${submissionData.userId}`;
   const docRef = db.collection(SUBMISSIONS_COLLECTION).doc(docId);
-  const leaderboardRef = db
-    .collection(LEADERBOARD_COLLECTION)
-    .doc(submissionData.userId);
+  const leaderboardRef = db.collection(LEADERBOARD_COLLECTION).doc(submissionData.userId);
 
   const submission: Submission = {
     ...submissionData,
@@ -416,7 +395,9 @@ export async function createSubmission(
         totalPoints: FieldValue.increment(CHALLENGE_SUBMISSION_SCORE),
         challengesCompleted: FieldValue.increment(1),
         username: submission.userName,
-        ...(submission.userAvatar !== undefined ? { userAvatar: submission.userAvatar } : { userAvatar: FieldValue.delete() }),
+        ...(submission.userAvatar !== undefined
+          ? { userAvatar: submission.userAvatar }
+          : { userAvatar: FieldValue.delete() }),
       });
     }
   });
@@ -427,13 +408,11 @@ export async function createSubmission(
 /**
  * Retrieves all approved submissions for a specific challenge.
  * Results are ordered by submission date descending.
- * 
+ *
  * @param challengeId The ID of the challenge.
  * @returns An array of Submissions.
  */
-export async function getSubmissionsForChallenge(
-  challengeId: string,
-): Promise<Submission[]> {
+export async function getSubmissionsForChallenge(challengeId: string): Promise<Submission[]> {
   const query = db
     .collection(SUBMISSIONS_COLLECTION)
     .where("challengeId", "==", challengeId)
@@ -445,15 +424,32 @@ export async function getSubmissionsForChallenge(
 }
 
 /**
+ * Retrieves ALL submissions for a challenge regardless of status.
+ * For admin use only — do not expose on public endpoints.
+ *
+ * @param challengeId The ID of the challenge.
+ * @returns An array of Submissions ordered by submission date descending.
+ */
+export async function getAllSubmissionsForChallenge(challengeId: string): Promise<Submission[]> {
+  const query = db
+    .collection(SUBMISSIONS_COLLECTION)
+    .where("challengeId", "==", challengeId)
+    .orderBy("submittedAt", "desc");
+
+  const snapshot = await query.get();
+  return snapshot.docs.map((doc) => normalizeSubmission(doc));
+}
+
+/**
  * Generates a mini-leaderboard specific to a single challenge.
- * 
+ *
  * @param challengeId The ID of the challenge.
  * @param limit The maximum number of entries to return.
  * @returns An array of LeaderboardEntries.
  */
 export async function getLeaderboardForChallenge(
   challengeId: string,
-  limit: number = 10,
+  limit: number = 10
 ): Promise<LeaderboardEntry[]> {
   const submissions = await getSubmissionsForChallenge(challengeId);
   return buildLeaderboardFromSubmissions(submissions, limit);
@@ -465,7 +461,7 @@ export async function getLeaderboardForChallenge(
  * Manually updates a user's global leaderboard entry.
  * Primarily used via transaction within `createSubmission`, but exposed
  * here for potential admin adjustments or other point-awarding systems.
- * 
+ *
  * @param userId The ID of the user.
  * @param username The display name of the user.
  * @param userAvatar The avatar URL of the user.
@@ -475,7 +471,7 @@ export async function updateLeaderboardEntry(
   userId: string,
   username: string,
   userAvatar: string | undefined,
-  pointsToAdd: number,
+  pointsToAdd: number
 ): Promise<void> {
   const docRef = db.collection(LEADERBOARD_COLLECTION).doc(userId);
 
@@ -505,17 +501,12 @@ export async function updateLeaderboardEntry(
 /**
  * Retrieves the global all-time leaderboard.
  * Results are ordered by total points descending.
- * 
+ *
  * @param limit The maximum number of entries to return (default 50).
  * @returns An array of LeaderboardEntries.
  */
-export async function getLeaderboard(
-  limit: number = 50,
-): Promise<LeaderboardEntry[]> {
-  const query = db
-    .collection(LEADERBOARD_COLLECTION)
-    .orderBy("totalPoints", "desc")
-    .limit(limit);
+export async function getLeaderboard(limit: number = 50): Promise<LeaderboardEntry[]> {
+  const query = db.collection(LEADERBOARD_COLLECTION).orderBy("totalPoints", "desc").limit(limit);
 
   const snapshot = await query.get();
   return snapshot.docs.map((doc) => doc.data() as LeaderboardEntry);
@@ -524,14 +515,14 @@ export async function getLeaderboard(
 /**
  * Dynamically calculates a monthly leaderboard by aggregating all
  * submissions created within a specific month.
- * 
+ *
  * @param yearMonth Optional YYYY-MM string. Defaults to the current UTC month.
  * @param limit The maximum number of entries to return (default 50).
  * @returns An object containing the month string and the calculated leaderboard.
  */
 export async function getMonthlyLeaderboard(
   yearMonth?: string,
-  limit: number = 50,
+  limit: number = 50
 ): Promise<{ month: string; leaderboard: LeaderboardEntry[] }> {
   const { month, startIso, endIso } = monthRange(yearMonth);
   const snapshot = await db


### PR DESCRIPTION
## Summary

- **GH#255** — Challenge status stayed `active` after `endDate` passed because the `status` field was stored in Firestore and never auto-updated. Fixed by computing status dynamically in `normalizeChallenge` using `startDate`/`endDate` on every read (`upcoming` if before start, `past` if after end, `active` in between).

- **GH#256** — Admin had no way to view project submissions per challenge. Added:
  - `GET /api/admin/challenges/[id]/submissions` (admin-auth protected, returns all statuses)
  - `/admin/challenges/[id]/submissions` page with a table of user, repo, demo, LinkedIn, status, score, and submitted-at
  - "Submissions" button in the admin challenges list for each row

## Test plan

- [ ] Create a challenge with `endDate` in the past → verify it shows `past` status (not `active`) on `/challenges`
- [ ] Create a challenge with `startDate` in the future → verify it shows `upcoming`
- [ ] On admin `/admin/challenges`, click "Submissions" → lands on submissions page for that challenge
- [ ] With no submissions, page shows "No submissions yet" message
- [ ] After a learner submits, page shows their submission details (repo, demo, LinkedIn, score)

Closes #255
Closes #256