### PR TITLE
fix(admin): bound archived-channel bulk delete + robust client parsing (GH#249)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -13,6 +13,10 @@ interface BulkDeleteResult {
   message: string;
   deleted: number;
   failed: number;
+  /** Channels still awaiting deletion beyond this run's batch cap. */
+  remaining?: number;
+  /** True when another invocation is needed to finish the cleanup. */
+  hasMore?: boolean;
 }
 
 // Component
@@ -31,9 +35,7 @@ export default function AdminOverviewPage() {
   /** Tracks an in-progress delete request */
   const [deleting, setDeleting] = useState(false);
   /** Stores the result summary after deletion */
-  const [deleteResult, setDeleteResult] = useState<BulkDeleteResult | null>(
-    null
-  );
+  const [deleteResult, setDeleteResult] = useState<BulkDeleteResult | null>(null);
 
   // Keep a ref to the DaisyUI dialog element so we can call showModal / close
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -94,22 +96,41 @@ export default function AdminOverviewPage() {
 
     try {
       const token = localStorage.getItem(ADMIN_TOKEN_KEY);
-      const response = await fetch(
-        "/api/mentorship/admin/sessions/delete-archived-channels",
-        {
-          method: "DELETE",
-          headers: token ? { "x-admin-token": token } : {},
-        }
-      );
+      const response = await fetch("/api/mentorship/admin/sessions/delete-archived-channels", {
+        method: "DELETE",
+        headers: token ? { "x-admin-token": token } : {},
+      });
 
-      const data: BulkDeleteResult = await response.json();
+      // The endpoint can return an HTML error page (e.g. a 504 if the batch
+      // ever times out) rather than JSON — parse defensively so we surface a
+      // meaningful message instead of a generic "unexpected error".
+      const raw = await response.text();
+      let data: BulkDeleteResult | null = null;
+      try {
+        data = raw ? (JSON.parse(raw) as BulkDeleteResult) : null;
+      } catch {
+        data = null;
+      }
+
+      if (!data) {
+        toast.error(
+          `Server returned an unexpected response (status ${response.status}). Please try again.`
+        );
+        handleCloseDeleteModal();
+        return;
+      }
 
       if (response.ok && data.success) {
         setDeleteResult(data);
-        // Success toast with channel count
-        toast.success(
-          `Cleanup complete — ${data.deleted} channel(s) deleted.`
-        );
+        if (data.hasMore) {
+          // More archived channels remain than fit in one run — tell the admin
+          // to click again to continue the cleanup.
+          toast.success(
+            `Deleted ${data.deleted} channel(s). ${data.remaining ?? 0} remaining — click again to continue.`
+          );
+        } else {
+          toast.success(`Cleanup complete — ${data.deleted} channel(s) deleted.`);
+        }
       } else {
         toast.error(data.message || "Failed to delete archived channels.");
         handleCloseDeleteModal();
@@ -175,9 +196,7 @@ export default function AdminOverviewPage() {
           </svg>
           <div className="flex-1">
             <h3 className="font-bold">{alerts.length} Low Rating Alert(s)</h3>
-            <p className="text-sm">
-              Sessions that received 1-star ratings need attention.
-            </p>
+            <p className="text-sm">Sessions that received 1-star ratings need attention.</p>
           </div>
         </div>
       )}
@@ -210,9 +229,7 @@ export default function AdminOverviewPage() {
                   </svg>
                 </div>
                 <div className="stat-title">Total Mentors</div>
-                <div className="stat-value text-primary">
-                  {stats.totalMentors}
-                </div>
+                <div className="stat-value text-primary">{stats.totalMentors}</div>
               </div>
             </div>
 
@@ -236,9 +253,7 @@ export default function AdminOverviewPage() {
                   </svg>
                 </div>
                 <div className="stat-title">Total Mentees</div>
-                <div className="stat-value text-secondary">
-                  {stats.totalMentees}
-                </div>
+                <div className="stat-value text-secondary">{stats.totalMentees}</div>
               </div>
             </div>
 
@@ -262,9 +277,7 @@ export default function AdminOverviewPage() {
                   </svg>
                 </div>
                 <div className="stat-title">Active Matches</div>
-                <div className="stat-value text-success">
-                  {stats.activeMatches}
-                </div>
+                <div className="stat-value text-success">{stats.activeMatches}</div>
                 <div className="stat-desc">of {stats.totalMatches} total</div>
               </div>
             </div>
@@ -289,9 +302,7 @@ export default function AdminOverviewPage() {
                   </svg>
                 </div>
                 <div className="stat-title">Avg Session Rating</div>
-                <div className="stat-value text-info">
-                  {stats.averageRating.toFixed(1)}
-                </div>
+                <div className="stat-value text-info">{stats.averageRating.toFixed(1)}</div>
                 <div className="stat-desc">out of 5 stars</div>
               </div>
             </div>
@@ -316,9 +327,7 @@ export default function AdminOverviewPage() {
                   </svg>
                 </div>
                 <div className="stat-title">Pending Projects</div>
-                <div className="stat-value text-warning">
-                  {stats.pendingProjects}
-                </div>
+                <div className="stat-value text-warning">{stats.pendingProjects}</div>
                 <div className="stat-desc">awaiting review</div>
               </div>
             </div>
@@ -343,9 +352,7 @@ export default function AdminOverviewPage() {
                   </svg>
                 </div>
                 <div className="stat-title">Pending Roadmaps</div>
-                <div className="stat-value text-warning">
-                  {stats.pendingRoadmaps}
-                </div>
+                <div className="stat-value text-warning">{stats.pendingRoadmaps}</div>
                 <div className="stat-desc">awaiting review</div>
               </div>
             </div>
@@ -390,26 +397,32 @@ export default function AdminOverviewPage() {
               /* ── Post-deletion result summary ─────────────────────────────── */
               <div className="space-y-3">
                 <div
-                  className={`alert ${deleteResult.failed === 0 ? "alert-success" : "alert-warning"
-                    }`}
+                  className={`alert ${
+                    deleteResult.failed === 0 ? "alert-success" : "alert-warning"
+                  }`}
                 >
                   <span>{deleteResult.message}</span>
                 </div>
 
                 <ul className="list-disc list-inside text-base-content/80 space-y-1">
                   <li>
-                    <span className="font-semibold text-success">
-                      {deleteResult.deleted}
-                    </span>{" "}
+                    <span className="font-semibold text-success">{deleteResult.deleted}</span>{" "}
                     channel(s) successfully deleted from Discord.
                   </li>
                   {deleteResult.failed > 0 && (
                     <li>
-                      <span className="font-semibold text-error">
-                        {deleteResult.failed}
+                      <span className="font-semibold text-error">{deleteResult.failed}</span>{" "}
+                      channel(s) could not be deleted (see server logs for details).
+                    </li>
+                  )}
+                  {deleteResult.hasMore && (
+                    <li>
+                      <span className="font-semibold text-warning">
+                        {deleteResult.remaining ?? 0}
                       </span>{" "}
-                      channel(s) could not be deleted (see server logs for
-                      details).
+                      archived channel(s) still remaining — click{" "}
+                      <span className="font-semibold">Delete All Archived Channels</span> again to
+                      continue.
                     </li>
                   )}
                 </ul>
@@ -419,16 +432,13 @@ export default function AdminOverviewPage() {
               <div className="space-y-3">
                 <p>
                   This action will{" "}
-                  <strong className="text-error">
-                    permanently delete all Discord channels
-                  </strong>{" "}
+                  <strong className="text-error">permanently delete all Discord channels</strong>{" "}
                   associated with mentorship sessions that have a status of{" "}
                   <code className="bg-base-200 px-1 rounded">completed</code> or{" "}
                   <code className="bg-base-200 px-1 rounded">cancelled</code>.
                 </p>
                 <p>
-                  The action is{" "}
-                  <strong>irreversible</strong> — deleted channels cannot be
+                  The action is <strong>irreversible</strong> — deleted channels cannot be
                   recovered.
                 </p>
                 <div className="alert alert-warning text-sm">
@@ -446,8 +456,8 @@ export default function AdminOverviewPage() {
                     />
                   </svg>
                   <span>
-                    Are you sure you want to proceed? This will remove all
-                    message history from those channels on Discord.
+                    Are you sure you want to proceed? This will remove all message history from
+                    those channels on Discord.
                   </span>
                 </div>
               </div>
@@ -457,14 +467,34 @@ export default function AdminOverviewPage() {
           {/* ── Modal footer / action buttons ─────────────────────────────────── */}
           <div className="modal-action">
             {deleteResult ? (
-              /* After deletion: only a "Close" button */
-              <button
-                id="admin-delete-channels-close-btn"
-                className="btn btn-primary"
-                onClick={handleCloseDeleteModal}
-              >
-                Close
-              </button>
+              /* After deletion: Close, plus Continue when more batches remain */
+              <>
+                <button
+                  id="admin-delete-channels-close-btn"
+                  className="btn btn-ghost"
+                  onClick={handleCloseDeleteModal}
+                  disabled={deleting}
+                >
+                  Close
+                </button>
+                {deleteResult.hasMore && (
+                  <button
+                    id="admin-delete-channels-continue-btn"
+                    className="btn btn-error"
+                    onClick={handleConfirmDelete}
+                    disabled={deleting}
+                  >
+                    {deleting ? (
+                      <>
+                        <span className="loading loading-spinner loading-sm"></span>
+                        Deleting…
+                      </>
+                    ) : (
+                      "Continue Deleting"
+                    )}
+                  </button>
+                )}
+              </>
             ) : (
               /* Before deletion: Cancel + Confirm */
               <>

--- a/src/app/api/mentorship/admin/sessions/delete-archived-channels/route.ts
+++ b/src/app/api/mentorship/admin/sessions/delete-archived-channels/route.ts
@@ -1,16 +1,29 @@
-import { NextResponse } from 'next/server'
-import { db } from '@/lib/firebaseAdmin'
-import {
-    deleteDiscordChannel,
-    isDiscordConfigured,
-} from '@/lib/discord'
+import { NextResponse } from "next/server";
+import { db } from "@/lib/firebaseAdmin";
+import { verifyAdminRequest } from "@/lib/adminAuth";
+import { deleteDiscordChannel, isDiscordConfigured } from "@/lib/discord";
+
+// Deleting Discord channels is a slow, sequential, rate-limited operation. Give
+// the function generous headroom and never let the platform cache it.
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+/**
+ * Maximum number of channels processed in a single invocation. Discord deletes
+ * are sequential and rate-limited, so an unbounded batch over a large archived
+ * set can exceed the serverless time limit — the function then dies mid-flight
+ * and the platform returns an HTML 504, which the client can't parse as JSON
+ * (surfacing a generic "unexpected error"). Capping the batch keeps every run
+ * bounded; the client re-invokes while `hasMore` is true. (GH#249)
+ */
+const MAX_CHANNELS_PER_RUN = 25;
 
 /** Result for a single channel deletion attempt. */
 interface ChannelDeletionResult {
-    sessionId: string
-    channelId: string
-    success: boolean
-    error?: string
+  sessionId: string;
+  channelId: string;
+  success: boolean;
+  error?: string;
 }
 
 // DELETE /api/mentorship/admin/sessions/delete-archived-channels
@@ -30,117 +43,132 @@ interface ChannelDeletionResult {
  * The endpoint is intentionally idempotent — channels that Discord has already
  * removed return a 404 which our `deleteDiscordChannel` helper treats as success.
  */
-export async function DELETE() {
-    try {
-        // Guard: Discord must be configured
-        if (!isDiscordConfigured()) {
-            return NextResponse.json(
-                { error: 'Discord integration is not configured on this server.' },
-                { status: 503 }
-            )
-        }
-
-        // Find sessions with a discord channel in a terminal state
-        const [completedSnapshot, cancelledSnapshot] = await Promise.all([
-            db
-                .collection('mentorship_sessions')
-                .where('status', '==', 'completed')
-                .get(),
-            db
-                .collection('mentorship_sessions')
-                .where('status', '==', 'cancelled')
-                .get(),
-        ])
-
-        // Merge both result sets, deduplicate by document ID, and keep only those
-        // that still reference a Discord channel.
-        const sessionDocs = new Map<
-            string,
-            FirebaseFirestore.QueryDocumentSnapshot
-        >()
-
-        for (const doc of [...completedSnapshot.docs, ...cancelledSnapshot.docs]) {
-            const data = doc.data()
-            if (data.discordChannelId) {
-                sessionDocs.set(doc.id, doc)
-            }
-        }
-
-        if (sessionDocs.size === 0) {
-            // Nothing to do – return early with a clear message.
-            return NextResponse.json(
-                {
-                    success: true,
-                    message: 'No archived channels found to delete.',
-                    deleted: 0,
-                    failed: 0,
-                    results: [],
-                },
-                { status: 200 }
-            )
-        }
-
-        // Delete each channel, collecting results
-        const results: ChannelDeletionResult[] = []
-
-        for (const [sessionId, doc] of sessionDocs) {
-            const { discordChannelId } = doc.data() as { discordChannelId: string }
-
-            try {
-                const deleted = await deleteDiscordChannel(
-                    discordChannelId,
-                    'Admin bulk-delete of archived mentorship channels'
-                )
-
-                if (deleted) {
-                    // Clear the channel reference in Firestore
-                    await doc.ref.update({
-                        discordChannelId: null,
-                        discordChannelUrl: null,
-                        channelDeletedAt: new Date(),
-                        channelDeletedBy: 'admin_bulk_cleanup',
-                    })
-
-                    results.push({ sessionId, channelId: discordChannelId, success: true })
-                } else {
-                    results.push({
-                        sessionId,
-                        channelId: discordChannelId,
-                        success: false,
-                        error: 'Discord API returned a failure response',
-                    })
-                }
-            } catch (err) {
-                // Individual failures should not abort the whole batch.
-                const message = err instanceof Error ? err.message : String(err)
-                results.push({
-                    sessionId,
-                    channelId: discordChannelId,
-                    success: false,
-                    error: message,
-                })
-            }
-        }
-
-        // Build summary
-        const deleted = results.filter((r) => r.success).length
-        const failed = results.filter((r) => !r.success).length
-
-        return NextResponse.json(
-            {
-                success: true,
-                message: `Bulk cleanup complete. Deleted: ${deleted}, Failed: ${failed}.`,
-                deleted,
-                failed,
-                results,
-            },
-            { status: 200 }
-        )
-    } catch (error) {
-        console.error('[Admin] Error during bulk channel deletion:', error)
-        return NextResponse.json(
-            { error: 'An unexpected error occurred during bulk channel deletion.' },
-            { status: 500 }
-        )
+export async function DELETE(request: Request) {
+  try {
+    // Guard: destructive endpoint — require a valid admin session.
+    if (!(await verifyAdminRequest(request))) {
+      return NextResponse.json(
+        { success: false, error: "Admin authentication required." },
+        { status: 401 }
+      );
     }
+
+    // Guard: Discord must be configured
+    if (!isDiscordConfigured()) {
+      return NextResponse.json(
+        { error: "Discord integration is not configured on this server." },
+        { status: 503 }
+      );
+    }
+
+    // Find sessions with a discord channel in a terminal state
+    const [completedSnapshot, cancelledSnapshot] = await Promise.all([
+      db.collection("mentorship_sessions").where("status", "==", "completed").get(),
+      db.collection("mentorship_sessions").where("status", "==", "cancelled").get(),
+    ]);
+
+    // Merge both result sets, deduplicate by document ID, and keep only those
+    // that still reference a Discord channel.
+    const sessionDocs = new Map<string, FirebaseFirestore.QueryDocumentSnapshot>();
+
+    for (const doc of [...completedSnapshot.docs, ...cancelledSnapshot.docs]) {
+      const data = doc.data();
+      if (data.discordChannelId) {
+        sessionDocs.set(doc.id, doc);
+      }
+    }
+
+    if (sessionDocs.size === 0) {
+      // Nothing to do – return early with a clear message.
+      return NextResponse.json(
+        {
+          success: true,
+          message: "No archived channels found to delete.",
+          deleted: 0,
+          failed: 0,
+          remaining: 0,
+          hasMore: false,
+          results: [],
+        },
+        { status: 200 }
+      );
+    }
+
+    // Process at most MAX_CHANNELS_PER_RUN this invocation to keep runtime
+    // bounded. Anything beyond the cap is reported via `remaining` so the
+    // client can re-invoke until `hasMore` is false.
+    const eligible = [...sessionDocs.entries()];
+    const batch = eligible.slice(0, MAX_CHANNELS_PER_RUN);
+    const remaining = eligible.length - batch.length;
+
+    // Delete each channel, collecting results
+    const results: ChannelDeletionResult[] = [];
+
+    for (const [sessionId, doc] of batch) {
+      const { discordChannelId } = doc.data() as { discordChannelId: string };
+
+      try {
+        const deleted = await deleteDiscordChannel(
+          discordChannelId,
+          "Admin bulk-delete of archived mentorship channels"
+        );
+
+        if (deleted) {
+          // Clear the channel reference in Firestore
+          await doc.ref.update({
+            discordChannelId: null,
+            discordChannelUrl: null,
+            channelDeletedAt: new Date(),
+            channelDeletedBy: "admin_bulk_cleanup",
+          });
+
+          results.push({ sessionId, channelId: discordChannelId, success: true });
+        } else {
+          results.push({
+            sessionId,
+            channelId: discordChannelId,
+            success: false,
+            error: "Discord API returned a failure response",
+          });
+        }
+      } catch (err) {
+        // Individual failures should not abort the whole batch.
+        const message = err instanceof Error ? err.message : String(err);
+        results.push({
+          sessionId,
+          channelId: discordChannelId,
+          success: false,
+          error: message,
+        });
+      }
+    }
+
+    // Build summary
+    const deleted = results.filter((r) => r.success).length;
+    const failed = results.filter((r) => !r.success).length;
+    const hasMore = remaining > 0;
+
+    const message = hasMore
+      ? `Deleted ${deleted}, failed ${failed}. ${remaining} archived channel(s) remaining — run again to continue.`
+      : `Bulk cleanup complete. Deleted: ${deleted}, Failed: ${failed}.`;
+
+    return NextResponse.json(
+      {
+        success: true,
+        message,
+        deleted,
+        failed,
+        remaining,
+        hasMore,
+        results,
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("[Admin] Error during bulk channel deletion:", error);
+    return NextResponse.json(
+      { error: "An unexpected error occurred during bulk channel deletion." },
+      { status: 500 }
+    );
+  }
 }


### PR DESCRIPTION
Closes #249

## Problem

QA (Maham, ClickUp \`86cactzk9\`) hit **"An unexpected error occurred. Please try again."** when clicking **Delete All Archived Channels** on the production admin dashboard. The bulk delete never completed.

## Root cause

The route deletes Discord channels **sequentially** with rate-limit backoff and had **no time bound**. Over a large archived set (this instance has ~975 sessions) the serverless function exceeds its execution limit and the platform returns an **HTML 504** page. The client then calls \`response.json()\` on that non-JSON body, which throws into the generic \`catch\` → the vague toast.

Secondary finding: the destructive endpoint was **unauthenticated** — it ignored the \`x-admin-token\` the client already sends.

## Fix

**Route** (\`.../delete-archived-channels/route.ts\`)
- Cap each invocation at \`MAX_CHANNELS_PER_RUN = 25\`; report \`remaining\` + \`hasMore\` so the client re-invokes until the backlog is drained. Keeps every run bounded regardless of dataset size.
- Add \`export const maxDuration = 300\` + \`dynamic = "force-dynamic"\`.
- Add \`verifyAdminRequest\` guard (matches the challenges admin routes) → 401 for non-admins. Still idempotent.

**Client** (\`src/app/admin/page.tsx\`)
- Parse the response defensively (read text, then \`JSON.parse\`); on a non-JSON/timeout body show a specific message with the HTTP status instead of the generic catch.
- Handle \`hasMore\`: success toast reports remaining count, modal shows a **Continue Deleting** button + a remaining-count line.

## Verification
- \`npx tsc --noEmit\` → 0 errors
- \`npx eslint\` on both changed files → clean
- Prettier/lint-staged applied on commit

## UAT steps
1. Log in as **admin** → open admin dashboard. Confirm **Delete All Archived Channels** button visible; a non-admin (no valid \`x-admin-token\`) calling the route gets **401**.
2. Click the button → confirmation modal appears. Confirm → verify completed/cancelled session channels get deleted, \`discordChannelId\`/\`discordChannelUrl\` cleared, summary shows deleted/failed counts. **No "unexpected error" toast.**
3. **Large backlog:** with >25 archived channels, first run deletes 25 and shows "*N remaining — click again to continue*" with a **Continue Deleting** button. Click it until \`remaining\` reaches 0.
4. **Negative — no archived channels:** reports 0 deleted gracefully.
5. **Negative — missing Discord creds:** clear 503 message, no crash.
6. **Idempotent:** run twice → second run deletes 0.

🤖 Triaged + fixed by CTO automation (VIS-122).