### PR TITLE
fix(deploy): cap maxDuration at 60s for hobby plan

### DIFF
--- a/src/app/api/mentorship/admin/sessions/delete-archived-channels/route.ts
+++ b/src/app/api/mentorship/admin/sessions/delete-archived-channels/route.ts
@@ -4,9 +4,11 @@ import { verifyAdminRequest } from "@/lib/adminAuth";
 import { deleteDiscordChannel, isDiscordConfigured } from "@/lib/discord";
 
 // Deleting Discord channels is a slow, sequential, rate-limited operation. Give
-// the function generous headroom and never let the platform cache it.
+// the function as much headroom as the plan allows (Vercel hobby caps at 60s)
+// and never let the platform cache it. The per-run batch cap below keeps each
+// invocation comfortably within this budget; the client re-invokes for the rest.
 export const dynamic = "force-dynamic";
-export const maxDuration = 300;
+export const maxDuration = 60;
 
 /**
  * Maximum number of channels processed in a single invocation. Discord deletes


### PR DESCRIPTION
## Problem

Every production deploy since #259 has **failed** at the "Deploying outputs..." stage:

> Builder returned invalid maxDuration value for Serverless Function \"api/mentorship/admin/sessions/delete-archived-channels\". Serverless Functions must have a maxDuration between 1 and 60 for plan hobby.

The route (added in #259, GH#249) exports `maxDuration = 300`. The build compiles fine, so this was invisible in CI/local `npm run build` — it only fails at Vercel's deploy step. Commits `6b68899` (#259) and `582c619` (#263) both failed; production has been stuck on `98a11f7` since Jul 4.

## Fix

`maxDuration = 60` (the hobby-plan ceiling). Safe because the route already caps each run at `MAX_CHANNELS_PER_RUN = 25` sequential deletes and the client re-invokes while `hasMore` is true — one invocation stays well under 60s.

## Verification
- `npm run build` passes locally
- Confirmed via `vercel inspect` that the deploy-stage error is this maxDuration value, not the sponsors/nav changes