### PR TITLE
fix(projects): allow re-edit while update pending + in-page approve/decline status (GH#250)

### DIFF
--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -13,10 +13,7 @@ import { canDeleteProject } from "@/lib/permissions";
 import { auth } from "@/lib/firebaseAdmin";
 import { Project } from "@/types/mentorship";
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
 
@@ -25,10 +22,7 @@ export async function GET(
     const projectDoc = await projectRef.get();
 
     if (!projectDoc.exists) {
-      return NextResponse.json(
-        { error: "Project not found" },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
     }
 
     const projectData = projectDoc.data();
@@ -42,22 +36,19 @@ export async function GET(
       approvedAt: projectData?.approvedAt?.toDate?.()?.toISOString() || null,
       lastActivityAt: projectData?.lastActivityAt?.toDate?.()?.toISOString() || null,
       completedAt: projectData?.completedAt?.toDate?.()?.toISOString() || null,
+      updateRequestedAt: projectData?.updateRequestedAt?.toDate?.()?.toISOString() || null,
+      updateApprovedAt: projectData?.updateApprovedAt?.toDate?.()?.toISOString() || null,
+      updateDeclinedAt: projectData?.updateDeclinedAt?.toDate?.()?.toISOString() || null,
     };
 
     return NextResponse.json({ project }, { status: 200 });
   } catch (error) {
     console.error("Error fetching project:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch project" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to fetch project" }, { status: 500 });
   }
 }
 
-export async function PUT(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     // Phase 1: Authentication - check admin token OR Firebase auth
     let userId: string | null = null;
@@ -91,31 +82,43 @@ export async function PUT(
 
     // If still no userId, authentication failed
     if (!userId) {
-      return NextResponse.json(
-        { error: "Authentication required" },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: "Authentication required" }, { status: 401 });
     }
 
     const { id } = await params;
     const body = await request.json();
-    const { action, declineReason, demoUrl, demoDescription, title, description, githubRepo, techStack, difficulty, maxTeamSize } = body;
+    const {
+      action,
+      declineReason,
+      demoUrl,
+      demoDescription,
+      title,
+      description,
+      githubRepo,
+      techStack,
+      difficulty,
+      maxTeamSize,
+    } = body;
 
     // Fetch project document
     const projectRef = db.collection("projects").doc(id);
     const projectDoc = await projectRef.get();
 
     if (!projectDoc.exists) {
-      return NextResponse.json(
-        { error: "Project not found" },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
     }
 
     const projectData = projectDoc.data();
 
     // Determine if this is a field update request (vs action-based)
-    const isFieldUpdate = !action && (title !== undefined || description !== undefined || githubRepo !== undefined || techStack !== undefined || difficulty !== undefined || maxTeamSize !== undefined);
+    const isFieldUpdate =
+      !action &&
+      (title !== undefined ||
+        description !== undefined ||
+        githubRepo !== undefined ||
+        techStack !== undefined ||
+        difficulty !== undefined ||
+        maxTeamSize !== undefined);
 
     if (isFieldUpdate) {
       // Field update flow: edit project fields
@@ -129,13 +132,7 @@ export async function PUT(
           );
         }
 
-        // Cannot edit if there is already a pending update
-        if (projectData?.status === "update_pending") {
-          return NextResponse.json(
-            { error: "This project already has pending updates waiting for approval" },
-            { status: 403 }
-          );
-        }
+        // update_pending is allowed: owner can replace their pending update
       }
       // Admin can edit any project at any status
 
@@ -150,7 +147,11 @@ export async function PUT(
       }
 
       if (description !== undefined) {
-        if (typeof description !== "string" || description.length < 10 || description.length > 2000) {
+        if (
+          typeof description !== "string" ||
+          description.length < 10 ||
+          description.length > 2000
+        ) {
           return NextResponse.json(
             { error: "Description must be between 10 and 2000 characters" },
             { status: 400 }
@@ -170,19 +171,13 @@ export async function PUT(
 
       if (techStack !== undefined) {
         if (!Array.isArray(techStack)) {
-          return NextResponse.json(
-            { error: "techStack must be an array" },
-            { status: 400 }
-          );
+          return NextResponse.json({ error: "techStack must be an array" }, { status: 400 });
         }
       }
 
       if (difficulty !== undefined) {
         if (!["beginner", "intermediate", "advanced"].includes(difficulty)) {
-          return NextResponse.json(
-            { error: "Invalid difficulty level" },
-            { status: 400 }
-          );
+          return NextResponse.json({ error: "Invalid difficulty level" }, { status: 400 });
         }
       }
 
@@ -196,7 +191,7 @@ export async function PUT(
       }
 
       // Phase 4: Build update object
-      const updateData: Record<string, any> = {
+      const updateData: Record<string, unknown> = {
         updatedAt: FieldValue.serverTimestamp(),
         lastActivityAt: FieldValue.serverTimestamp(),
       };
@@ -243,10 +238,7 @@ export async function PUT(
         completedAt: updatedData?.completedAt?.toDate?.()?.toISOString() || null,
       };
 
-      return NextResponse.json(
-        { success: true, project },
-        { status: 200 }
-      );
+      return NextResponse.json({ success: true, project }, { status: 200 });
     }
 
     // Action-based flow (existing logic)
@@ -338,8 +330,7 @@ export async function PUT(
           const discordUsername = creatorData?.discordUsername;
 
           if (discordUsername) {
-            const siteUrl =
-              process.env.NEXT_PUBLIC_SITE_URL || "https://codewithahsan.dev";
+            const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://codewithahsan.dev";
             const dmMessage =
               `Your project "${projectData.title}" was not approved.\n\n` +
               `**Reason:** ${declineReason}\n\n` +
@@ -361,10 +352,7 @@ export async function PUT(
         updatedAt: FieldValue.serverTimestamp(),
       });
 
-      return NextResponse.json(
-        { success: true, message: "Project declined" },
-        { status: 200 }
-      );
+      return NextResponse.json({ success: true, message: "Project declined" }, { status: 200 });
     } else if (action === "complete") {
       // Verify creator owns the project
       if (projectData?.creatorId !== userId) {
@@ -437,19 +425,13 @@ export async function PUT(
         }
       }
 
-      return NextResponse.json(
-        { success: true, message: "Project completed" },
-        { status: 200 }
-      );
+      return NextResponse.json({ success: true, message: "Project completed" }, { status: 200 });
     } else {
       return NextResponse.json({ error: "Invalid action" }, { status: 400 });
     }
   } catch (error) {
     console.error("Error updating project:", error);
-    return NextResponse.json(
-      { error: "Failed to update project" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to update project" }, { status: 500 });
   }
 }
 
@@ -460,10 +442,7 @@ export async function DELETE(
   try {
     const authResult = await verifyAuth(request);
     if (!authResult) {
-      return NextResponse.json(
-        { error: "Authentication required" },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: "Authentication required" }, { status: 401 });
     }
 
     const { id } = await params;
@@ -473,10 +452,7 @@ export async function DELETE(
     const projectDoc = await projectRef.get();
 
     if (!projectDoc.exists) {
-      return NextResponse.json(
-        { error: "Project not found" },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
     }
 
     const projectData = projectDoc.data();
@@ -495,15 +471,16 @@ export async function DELETE(
     const canDelete = canDeleteProject(permissionUser, {
       ...projectData,
       id,
-    } as any);
+    } as Project);
 
     if (!canDelete) {
       return NextResponse.json(
         {
           error: "Permission denied",
-          message: projectData?.status === "declined"
-            ? "Only the project creator can delete declined projects"
-            : "Only declined projects can be deleted by creators (admins can delete any project)",
+          message:
+            projectData?.status === "declined"
+              ? "Only the project creator can delete declined projects"
+              : "Only declined projects can be deleted by creators (admins can delete any project)",
         },
         { status: 403 }
       );
@@ -518,9 +495,6 @@ export async function DELETE(
     );
   } catch (error) {
     console.error("Error deleting project:", error);
-    return NextResponse.json(
-      { error: "Failed to delete project" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to delete project" }, { status: 500 });
   }
 }

--- a/src/app/projects/[id]/edit/page.tsx
+++ b/src/app/projects/[id]/edit/page.tsx
@@ -20,6 +20,7 @@ export default function EditProjectPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
+  const [warning, setWarning] = useState("");
   const [isAdmin, setIsAdmin] = useState(false);
 
   // Form state
@@ -27,7 +28,9 @@ export default function EditProjectPage() {
   const [description, setDescription] = useState("");
   const [githubRepo, setGithubRepo] = useState("");
   const [techStack, setTechStack] = useState("");
-  const [difficulty, setDifficulty] = useState<"beginner" | "intermediate" | "advanced">("intermediate");
+  const [difficulty, setDifficulty] = useState<"beginner" | "intermediate" | "advanced">(
+    "intermediate"
+  );
   const [maxTeamSize, setMaxTeamSize] = useState(4);
 
   // Check admin status
@@ -93,17 +96,15 @@ export default function EditProjectPage() {
         setDifficulty(projectData.difficulty || "intermediate");
         setMaxTeamSize(projectData.maxTeamSize || 4);
 
-        // If project has pending updates, disable editing
+        // If project has pending updates, warn but still allow editing (will replace pending)
         if (projectData.status === "update_pending" && !isAdmin) {
-          setError("This project has pending updates waiting for admin approval. You cannot make further changes until they are reviewed.");
-          setTimeout(() => {
-            router.push(`/projects/${projectId}`);
-          }, 3000);
-          return;
+          setWarning(
+            "You have a pending update awaiting admin review. Saving will replace it with your new changes."
+          );
         }
-      } catch (err: any) {
+      } catch (err: unknown) {
         console.error("Error loading project:", err);
-        setError(err.message || "Failed to load project");
+        setError(err instanceof Error ? err.message : "Failed to load project");
         setTimeout(() => {
           router.push(`/projects/${projectId}`);
         }, 2000);
@@ -179,8 +180,8 @@ export default function EditProjectPage() {
         setError(data.error || "Failed to update project");
         setSaving(false);
       }
-    } catch (err: any) {
-      console.error("Error updating project:", err);
+    } catch {
+      console.error("Error updating project");
       setError("An error occurred while updating the project");
       setSaving(false);
     }
@@ -235,9 +236,7 @@ export default function EditProjectPage() {
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
           <div>
             <h2 className="text-2xl font-bold">Edit Project</h2>
-            <p className="text-base-content/70">
-              Update project details and settings
-            </p>
+            <p className="text-base-content/70">Update project details and settings</p>
           </div>
           <Link href={`/projects/${projectId}`} className="btn btn-ghost btn-sm">
             ← Back to Project
@@ -249,6 +248,26 @@ export default function EditProjectPage() {
           <div className="card-body">
             <h3 className="card-title">Project Details</h3>
             <div className="divider"></div>
+
+            {/* Warning alert (non-blocking) */}
+            {warning && (
+              <div className="alert alert-warning mb-6">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="stroke-current shrink-0 h-6 w-6"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                  />
+                </svg>
+                <span>{warning}</span>
+              </div>
+            )}
 
             {/* Error alert */}
             {error && (
@@ -349,7 +368,9 @@ export default function EditProjectPage() {
                   </label>
                   <select
                     value={difficulty}
-                    onChange={(e) => setDifficulty(e.target.value as any)}
+                    onChange={(e) =>
+                      setDifficulty(e.target.value as "beginner" | "intermediate" | "advanced")
+                    }
                     className="select select-bordered w-full"
                     disabled={saving}
                   >
@@ -377,11 +398,7 @@ export default function EditProjectPage() {
               </div>
 
               {/* Action buttons */}
-              <button
-                type="submit"
-                className="btn btn-primary w-full"
-                disabled={saving}
-              >
+              <button type="submit" className="btn btn-primary w-full" disabled={saving}>
                 {saving ? (
                   <>
                     <span className="loading loading-spinner loading-sm"></span>

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -168,9 +168,7 @@ export default function ProjectDetailPage() {
 
       // Fetch user's application status if logged in
       if (user) {
-        const appRes = await fetch(
-          `/api/projects/${projectId}/applications?userId=${user.uid}`
-        );
+        const appRes = await fetch(`/api/projects/${projectId}/applications?userId=${user.uid}`);
         if (appRes.ok) {
           const appData = await appRes.json();
           if (appData.applications?.length > 0) {
@@ -230,14 +228,11 @@ export default function ProjectDetailPage() {
   const handleApproveApplication = async (userId: string) => {
     setApprovingUserId(userId);
     try {
-      const response = await authFetch(
-        `/api/projects/${projectId}/applications/${userId}`,
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ action: "approve" }),
-        }
-      );
+      const response = await authFetch(`/api/projects/${projectId}/applications/${userId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "approve" }),
+      });
 
       if (response.ok) {
         fetchProjectData();
@@ -258,14 +253,11 @@ export default function ProjectDetailPage() {
     const feedback = declineFeedback[userId];
     setDecliningUserId(userId);
     try {
-      const response = await authFetch(
-        `/api/projects/${projectId}/applications/${userId}`,
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ action: "decline", feedback }),
-        }
-      );
+      const response = await authFetch(`/api/projects/${projectId}/applications/${userId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "decline", feedback }),
+      });
 
       if (response.ok) {
         fetchProjectData();
@@ -325,14 +317,11 @@ export default function ProjectDetailPage() {
 
     setInvitationLoading(true);
     try {
-      const response = await authFetch(
-        `/api/projects/${projectId}/invitations/${user?.uid}`,
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ action: "accept" }),
-        }
-      );
+      const response = await authFetch(`/api/projects/${projectId}/invitations/${user?.uid}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "accept" }),
+      });
 
       if (response.ok) {
         fetchProjectData();
@@ -354,14 +343,11 @@ export default function ProjectDetailPage() {
 
     setInvitationLoading(true);
     try {
-      const response = await authFetch(
-        `/api/projects/${projectId}/invitations/${user?.uid}`,
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ action: "decline" }),
-        }
-      );
+      const response = await authFetch(`/api/projects/${projectId}/invitations/${user?.uid}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "decline" }),
+      });
 
       if (response.ok) {
         fetchProjectData();
@@ -442,13 +428,10 @@ export default function ProjectDetailPage() {
       onConfirm: async () => {
         setRemovingMemberId(memberId);
         try {
-          const response = await authFetch(
-            `/api/projects/${projectId}/members/${memberId}`,
-            {
-              method: "DELETE",
-              body: JSON.stringify({ requestorId: user?.uid }),
-            }
-          );
+          const response = await authFetch(`/api/projects/${projectId}/members/${memberId}`, {
+            method: "DELETE",
+            body: JSON.stringify({ requestorId: user?.uid }),
+          });
 
           if (response.ok) {
             fetchProjectData();
@@ -609,8 +592,18 @@ export default function ProjectDetailPage() {
         {/* Pending Updates Banner */}
         {project.status === "update_pending" && project.pendingUpdates && (
           <div className="alert alert-warning">
-            <svg xmlns="http://www.w3.org/2000/svg" className="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="stroke-current shrink-0 h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
             </svg>
             <div className="flex-1">
               <h3 className="font-bold">Updates Waiting for Approval</h3>
@@ -619,7 +612,9 @@ export default function ProjectDetailPage() {
                 {isAdmin && (
                   <div className="mt-2 space-y-1">
                     {project.pendingUpdates.title && <p>• Title: {project.pendingUpdates.title}</p>}
-                    {project.pendingUpdates.maxTeamSize && <p>• Max Team Size: {project.pendingUpdates.maxTeamSize}</p>}
+                    {project.pendingUpdates.maxTeamSize && (
+                      <p>• Max Team Size: {project.pendingUpdates.maxTeamSize}</p>
+                    )}
                     {project.pendingUpdates.description && <p>• Description updated</p>}
                     {project.pendingUpdates.techStack && <p>• Tech Stack updated</p>}
                     {project.pendingUpdates.githubRepo && <p>• GitHub Repository updated</p>}
@@ -635,12 +630,65 @@ export default function ProjectDetailPage() {
           </div>
         )}
 
+        {/* Update result banners (Bug #250: in-page notification for approve/decline) */}
+        {isCreator &&
+          project.status === "active" &&
+          project.updateApprovedAt &&
+          !project.pendingUpdates && (
+            <div className="alert alert-success">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="stroke-current shrink-0 h-6 w-6"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <span>
+                Your last project update was <strong>approved</strong> and is now live.
+              </span>
+            </div>
+          )}
+        {isCreator &&
+          project.status === "active" &&
+          project.updateDeclinedAt &&
+          !project.pendingUpdates && (
+            <div className="alert alert-error">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="stroke-current shrink-0 h-6 w-6"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <div>
+                <span>
+                  Your last project update was <strong>declined</strong>.
+                </span>
+                {project.updateDeclineReason && (
+                  <p className="text-sm mt-1">Reason: {project.updateDeclineReason}</p>
+                )}
+              </div>
+            </div>
+          )}
+
         <div className="flex items-start justify-between">
           <div className="flex-1">
             <h1 className="text-3xl font-bold mb-2">{project.title}</h1>
           </div>
           <div className="flex gap-2">
-            {isCreator && project.status !== "update_pending" && (
+            {isCreator && (
               <Link href={`/projects/${projectId}/edit`} className="btn btn-primary btn-sm">
                 ✏️ Edit Project
               </Link>
@@ -692,9 +740,7 @@ export default function ProjectDetailPage() {
               size="lg"
             />
             <div className="flex-1">
-              <div className="font-semibold">
-                {project.creatorProfile?.displayName}
-              </div>
+              <div className="font-semibold">{project.creatorProfile?.displayName}</div>
               <ContactInfo discordUsername={project.creatorProfile?.discordUsername} />
             </div>
           </div>
@@ -773,7 +819,9 @@ export default function ProjectDetailPage() {
                 </div>
               )}
               {project.demoDescription && (
-                <p className="text-base-content/80 whitespace-pre-wrap">{project.demoDescription}</p>
+                <p className="text-base-content/80 whitespace-pre-wrap">
+                  {project.demoDescription}
+                </p>
               )}
             </div>
           </div>
@@ -787,7 +835,9 @@ export default function ProjectDetailPage() {
         isCreator={!!isCreator}
         onRemoveMember={isCreator ? handleRemoveMember : undefined}
         removingMemberId={removingMemberId}
-        onTransferOwnership={isCreator && project.status === "active" ? handleTransferOwnership : undefined}
+        onTransferOwnership={
+          isCreator && project.status === "active" ? handleTransferOwnership : undefined
+        }
       />
 
       {/* Join Project Button — for creator who hasn't joined */}
@@ -813,10 +863,7 @@ export default function ProjectDetailPage() {
       {/* Creator Actions: Complete Project Button */}
       {isCreator && project.status === "active" && (
         <div className="flex justify-end gap-2">
-          <button
-            onClick={handleCompleteProject}
-            className="btn btn-success btn-sm"
-          >
+          <button onClick={handleCompleteProject} className="btn btn-success btn-sm">
             Complete Project
           </button>
         </div>
@@ -860,13 +907,13 @@ export default function ProjectDetailPage() {
                           size="md"
                         />
                         <div className="flex-1">
-                          <div className="font-semibold">
-                            {app.userProfile?.displayName}
-                          </div>
+                          <div className="font-semibold">{app.userProfile?.displayName}</div>
                           <ContactInfo discordUsername={app.userProfile?.discordUsername} />
                         </div>
                         {app.userProfile?.skillLevel && (
-                          <span className={`badge ${difficultyColors[app.userProfile.skillLevel as ProjectDifficulty]}`}>
+                          <span
+                            className={`badge ${difficultyColors[app.userProfile.skillLevel as ProjectDifficulty]}`}
+                          >
                             Skill level: {app.userProfile.skillLevel}
                           </span>
                         )}
@@ -876,7 +923,9 @@ export default function ProjectDetailPage() {
                         <button
                           onClick={() => handleApproveApplication(app.userId)}
                           className="btn btn-success btn-sm"
-                          disabled={approvingUserId === app.userId || decliningUserId === app.userId}
+                          disabled={
+                            approvingUserId === app.userId || decliningUserId === app.userId
+                          }
                         >
                           {approvingUserId === app.userId ? (
                             <>
@@ -897,7 +946,9 @@ export default function ProjectDetailPage() {
                             }
                           }}
                           className="btn btn-error btn-sm"
-                          disabled={approvingUserId === app.userId || decliningUserId === app.userId}
+                          disabled={
+                            approvingUserId === app.userId || decliningUserId === app.userId
+                          }
                         >
                           Decline
                         </button>
@@ -939,7 +990,7 @@ export default function ProjectDetailPage() {
           )}
 
           {/* Invitation Form */}
-          {project.status === 'active' && (
+          {project.status === "active" && (
             <div>
               <h2 className="text-xl font-semibold mb-4">Invite Team Members</h2>
               <div className="flex gap-2">
@@ -998,9 +1049,7 @@ export default function ProjectDetailPage() {
                           <ContactInfo discordUsername={inv.userProfile?.discordUsername} />
                         </div>
                       </div>
-                      <span
-                        className={`badge ${statusBadge[inv.status] || "badge-ghost"}`}
-                      >
+                      <span className={`badge ${statusBadge[inv.status] || "badge-ghost"}`}>
                         {inv.status}
                       </span>
                     </div>
@@ -1013,22 +1062,29 @@ export default function ProjectDetailPage() {
       )}
 
       {/* Non-creator, Non-member: Application Form */}
-      {user && !isCreator && !isMember && !userApplication && !userInvitation && project.status === 'active' && (
-        <div>
-          <h2 className="text-xl font-semibold mb-4">Apply to Join</h2>
-          <ApplicationForm
-            projectId={projectId}
-            project={project}
-            userId={user.uid}
-            userSkillLevel={profile?.skillLevel || "beginner"}
-            onSuccess={fetchProjectData}
-          />
-        </div>
-      )}
+      {user &&
+        !isCreator &&
+        !isMember &&
+        !userApplication &&
+        !userInvitation &&
+        project.status === "active" && (
+          <div>
+            <h2 className="text-xl font-semibold mb-4">Apply to Join</h2>
+            <ApplicationForm
+              projectId={projectId}
+              project={project}
+              userId={user.uid}
+              userSkillLevel={profile?.skillLevel || "beginner"}
+              onSuccess={fetchProjectData}
+            />
+          </div>
+        )}
 
       {/* User has already applied */}
       {userApplication && !isMember && (
-        <div className={`alert ${userApplication.status === "declined" ? "alert-error" : "alert-info"}`}>
+        <div
+          className={`alert ${userApplication.status === "declined" ? "alert-error" : "alert-info"}`}
+        >
           <svg
             xmlns="http://www.w3.org/2000/svg"
             className="stroke-current shrink-0 h-6 w-6"
@@ -1060,10 +1116,10 @@ export default function ProjectDetailPage() {
       {userInvitation && !isMember && (
         <div className="card bg-base-200 shadow-md">
           <div className="card-body">
-            <h2 className="card-title">You've Been Invited!</h2>
+            <h2 className="card-title">You&apos;ve Been Invited!</h2>
             <p>
-              The project creator has invited you to join this project. Accept the
-              invitation to become a team member.
+              The project creator has invited you to join this project. Accept the invitation to
+              become a team member.
             </p>
             <div className="flex gap-2 mt-4">
               <button
@@ -1093,7 +1149,7 @@ export default function ProjectDetailPage() {
       )}
 
       {/* Unauthenticated users */}
-      {!user && project.status === 'active' && (
+      {!user && project.status === "active" && (
         <div className="alert alert-warning">
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -1160,7 +1216,9 @@ export default function ProjectDetailPage() {
                 disabled={completeLoading}
               />
               <label className="label">
-                <span className="label-text-alt">YouTube, Loom, Vimeo, Google Drive, or any HTTPS URL</span>
+                <span className="label-text-alt">
+                  YouTube, Loom, Vimeo, Google Drive, or any HTTPS URL
+                </span>
               </label>
             </div>
 
@@ -1195,14 +1253,19 @@ export default function ProjectDetailPage() {
                 disabled={completeLoading}
               >
                 {completeLoading ? (
-                  <><span className="loading loading-spinner loading-sm"></span> Completing...</>
+                  <>
+                    <span className="loading loading-spinner loading-sm"></span> Completing...
+                  </>
                 ) : (
                   "Complete Project"
                 )}
               </button>
             </div>
           </div>
-          <div className="modal-backdrop" onClick={() => !completeLoading && setShowCompleteModal(false)}></div>
+          <div
+            className="modal-backdrop"
+            onClick={() => !completeLoading && setShowCompleteModal(false)}
+          ></div>
         </div>
       )}
     </div>


### PR DESCRIPTION
Fixes #250

## Summary

Two QA-reported bugs in the project owner update-request flow:

- **Bug 1 (no notification):** Discord DM exists but fails silently when the owner has no Discord username. Added in-page approve/decline result banners on the project detail page — owner sees the outcome immediately on next visit, regardless of Discord.
- **Bug 2 (can't re-edit):** Removed the 403 block that prevented owners from editing while `update_pending`. Saving now replaces the pending update. A yellow warning banner on the edit page makes the intent explicit.

Also serializes `updateApprovedAt` / `updateDeclinedAt` / `updateRequestedAt` Firestore timestamps in `GET /api/projects/[id]` so the banners have data to render.

## Changes

- `src/app/api/projects/[id]/route.ts` — allow owner PUT while `update_pending`; serialize update-result timestamps
- `src/app/projects/[id]/edit/page.tsx` — replace blocking redirect with a non-blocking warning banner
- `src/app/projects/[id]/page.tsx` — add approve/decline result banners; show Edit button regardless of `update_pending`

## Test plan

- [ ] As project owner with active project, submit an edit → status becomes `update_pending`, banner shows on detail page
- [ ] While `update_pending`, go to edit page → yellow warning banner shows, form is usable
- [ ] Submit a new edit → replaces the pending update (still `update_pending`, new changes)
- [ ] As admin, approve the update → owner detail page shows green "approved" banner on next load
- [ ] As admin, decline the update with a reason → owner detail page shows red "declined" banner + reason
- [ ] As admin, decline without a reason → owner still sees the decline banner (no reason text shown)

---
**ClickUp QA ticket:** https://app.clickup.com/t/86canq8nf (in review — pending Ahsan's approval before merge)