### PR TITLE
feat(mentorship): delete Discord channels with member DMs on mentorship end (GH#137)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,9 @@ GHOST_ADMIN_URL=
 DISCORD_BOT_TOKEN=
 DISCORD_GUILD_ID=
 DISCORD_MENTORSHIP_CATEGORY_ID=
+# Moderators / registration-notifications channel. Never deleted by the
+# mentorship-end cleanup flows (VIS-141). Falls back to the CWA server channel.
+DISCORD_MODERATORS_CHANNEL_ID=
 DISCORD_WEBHOOK=
 
 # AI — Google Gemini

--- a/src/app/api/mentorship/admin/sessions/regenerate-channel/route.ts
+++ b/src/app/api/mentorship/admin/sessions/regenerate-channel/route.ts
@@ -1,86 +1,104 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { db } from '@/lib/firebaseAdmin'
-import { createMentorshipChannel } from '@/lib/discord'
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/firebaseAdmin";
+import { createMentorshipChannel, deleteDiscordChannel, isDiscordConfigured } from "@/lib/discord";
 
 // POST: Regenerate Discord channel for a mentorship session
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json()
-    const { sessionId } = body
+    const body = await request.json();
+    const { sessionId } = body;
 
     if (!sessionId) {
-      return NextResponse.json({ error: 'Missing sessionId' }, { status: 400 })
+      return NextResponse.json({ error: "Missing sessionId" }, { status: 400 });
     }
 
     // Fetch the session
-    const sessionRef = db.collection('mentorship_sessions').doc(sessionId)
-    const sessionDoc = await sessionRef.get()
+    const sessionRef = db.collection("mentorship_sessions").doc(sessionId);
+    const sessionDoc = await sessionRef.get();
 
     if (!sessionDoc.exists) {
-      return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
 
-    const sessionData = sessionDoc.data()!
+    const sessionData = sessionDoc.data()!;
 
     // Validate session status - only allow for active or completed mentorships
-    if (!['active', 'completed'].includes(sessionData.status)) {
-      return NextResponse.json({
-        error: 'Can only regenerate channel for active or completed mentorships'
-      }, { status: 400 })
+    if (!["active", "completed"].includes(sessionData.status)) {
+      return NextResponse.json(
+        {
+          error: "Can only regenerate channel for active or completed mentorships",
+        },
+        { status: 400 }
+      );
     }
 
-    const mentorId = sessionData.mentorId as string
-    const menteeId = sessionData.menteeId as string
+    const mentorId = sessionData.mentorId as string;
+    const menteeId = sessionData.menteeId as string;
 
     // Fetch mentor profile
-    const mentorRef = db.collection('mentorship_profiles').doc(mentorId)
-    const mentorDoc = await mentorRef.get()
+    const mentorRef = db.collection("mentorship_profiles").doc(mentorId);
+    const mentorDoc = await mentorRef.get();
 
     if (!mentorDoc.exists) {
-      return NextResponse.json({ error: 'Mentor profile not found' }, { status: 404 })
+      return NextResponse.json({ error: "Mentor profile not found" }, { status: 404 });
     }
 
-    const mentorProfile = mentorDoc.data()
+    const mentorProfile = mentorDoc.data();
 
     // Fetch mentee profile
-    const menteeRef = db.collection('mentorship_profiles').doc(menteeId)
-    const menteeDoc = await menteeRef.get()
+    const menteeRef = db.collection("mentorship_profiles").doc(menteeId);
+    const menteeDoc = await menteeRef.get();
 
     if (!menteeDoc.exists) {
-      return NextResponse.json({ error: 'Mentee profile not found' }, { status: 404 })
+      return NextResponse.json({ error: "Mentee profile not found" }, { status: 404 });
     }
 
-    const menteeProfile = menteeDoc.data()
+    const menteeProfile = menteeDoc.data();
+
+    // Delete the old channel first so regeneration doesn't orphan it (GH#137).
+    // Protected community channels are refused by the delete guard.
+    if (isDiscordConfigured() && sessionData.discordChannelId) {
+      await deleteDiscordChannel(
+        sessionData.discordChannelId as string,
+        "Regenerating mentorship Discord channel (GH#137)"
+      ).catch((err) => console.error("Failed to delete old channel during regeneration:", err));
+    }
 
     // Create new Discord channel
     const channelResult = await createMentorshipChannel(
-      mentorProfile?.displayName || mentorProfile?.email?.split("@")[0] || 'Unknown Mentor',
-      menteeProfile?.displayName || menteeProfile?.email?.split("@")[0] || 'Unknown Mentee',
+      mentorProfile?.displayName || mentorProfile?.email?.split("@")[0] || "Unknown Mentor",
+      menteeProfile?.displayName || menteeProfile?.email?.split("@")[0] || "Unknown Mentee",
       sessionId,
       mentorProfile?.discordUsername,
       menteeProfile?.discordUsername
-    )
+    );
 
     if (!channelResult) {
-      return NextResponse.json({
-        error: 'Failed to create Discord channel'
-      }, { status: 500 })
+      return NextResponse.json(
+        {
+          error: "Failed to create Discord channel",
+        },
+        { status: 500 }
+      );
     }
 
     // Update session with new channel info
     await sessionRef.update({
       discordChannelId: channelResult.channelId,
       discordChannelUrl: channelResult.channelUrl,
-      updatedAt: new Date()
-    })
+      updatedAt: new Date(),
+    });
 
-    return NextResponse.json({
-      success: true,
-      channelUrl: channelResult.channelUrl,
-      message: 'Discord channel regenerated successfully'
-    }, { status: 200 })
+    return NextResponse.json(
+      {
+        success: true,
+        channelUrl: channelResult.channelUrl,
+        message: "Discord channel regenerated successfully",
+      },
+      { status: 200 }
+    );
   } catch (error) {
-    console.error('Error regenerating Discord channel:', error)
-    return NextResponse.json({ error: 'Failed to regenerate Discord channel' }, { status: 500 })
+    console.error("Error regenerating Discord channel:", error);
+    return NextResponse.json({ error: "Failed to regenerate Discord channel" }, { status: 500 });
   }
 }

--- a/src/app/api/mentorship/admin/sessions/route.ts
+++ b/src/app/api/mentorship/admin/sessions/route.ts
@@ -1,129 +1,148 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { FieldValue } from 'firebase-admin/firestore'
-import { db } from '@/lib/firebaseAdmin'
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { db } from "@/lib/firebaseAdmin";
 import {
   sendChannelMessage,
   sendChannelMessageWithComponents,
-  sendDirectMessage,
   isDiscordConfigured,
-  archiveMentorshipChannel,
+  deleteMentorshipChannel,
   unarchiveMentorshipChannel,
-} from '@/lib/discord'
-import { sendMentorshipRemovedEmail } from '@/lib/email'
+} from "@/lib/discord";
+import { sendMentorshipRemovedEmail } from "@/lib/email";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://codewithahsan.dev'
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://codewithahsan.dev";
 
 // Allowed status transitions state machine
 const ALLOWED_TRANSITIONS: Record<string, string[]> = {
-  pending: ['active', 'cancelled'],
-  active: ['completed', 'cancelled'],
-  completed: ['active'], // Allows revert
-  cancelled: ['active'], // Can be re-activated by admin
-}
+  pending: ["active", "cancelled"],
+  active: ["completed", "cancelled"],
+  completed: ["active"], // Allows revert
+  cancelled: ["active"], // Can be re-activated by admin
+};
 
 // PUT: Update session status with state machine validation
 export async function PUT(request: NextRequest) {
   try {
-    const body = await request.json()
-    const { sessionId, status } = body
+    const body = await request.json();
+    const { sessionId, status } = body;
 
     if (!sessionId) {
-      return NextResponse.json({ error: 'Missing sessionId' }, { status: 400 })
+      return NextResponse.json({ error: "Missing sessionId" }, { status: 400 });
     }
 
     // Validate target status
-    if (!status || !['active', 'completed'].includes(status)) {
-      return NextResponse.json({
-        error: 'Invalid status. Must be "active" or "completed"'
-      }, { status: 400 })
+    if (!status || !["active", "completed"].includes(status)) {
+      return NextResponse.json(
+        {
+          error: 'Invalid status. Must be "active" or "completed"',
+        },
+        { status: 400 }
+      );
     }
 
-    const sessionRef = db.collection('mentorship_sessions').doc(sessionId)
-    const sessionDoc = await sessionRef.get()
+    const sessionRef = db.collection("mentorship_sessions").doc(sessionId);
+    const sessionDoc = await sessionRef.get();
 
     if (!sessionDoc.exists) {
-      return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
 
-    const sessionData = sessionDoc.data()!
-    const currentStatus = sessionData.status
+    const sessionData = sessionDoc.data()!;
+    const currentStatus = sessionData.status;
 
     // Validate state machine transition
-    const allowedTargets = ALLOWED_TRANSITIONS[currentStatus] || []
+    const allowedTargets = ALLOWED_TRANSITIONS[currentStatus] || [];
     if (!allowedTargets.includes(status)) {
-      return NextResponse.json({
-        error: `Cannot transition from ${currentStatus} to ${status}`
-      }, { status: 400 })
+      return NextResponse.json(
+        {
+          error: `Cannot transition from ${currentStatus} to ${status}`,
+        },
+        { status: 400 }
+      );
     }
 
     // Build update data
     const updateData: Record<string, unknown> = {
       status,
       updatedAt: new Date(),
-    }
+    };
 
     // Add completedAt timestamp when marking as completed
-    if (status === 'completed') {
-      updateData.completedAt = new Date()
+    if (status === "completed") {
+      updateData.completedAt = new Date();
     }
 
     // Add revertedAt timestamp when reverting from completed to active
-    if (currentStatus === 'completed' && status === 'active') {
-      updateData.revertedAt = new Date()
+    if (currentStatus === "completed" && status === "active") {
+      updateData.revertedAt = new Date();
     }
 
     // Add reactivatedAt timestamp when re-activating from cancelled to active
-    const isReactivation = currentStatus === 'cancelled' && status === 'active'
+    const isReactivation = currentStatus === "cancelled" && status === "active";
     if (isReactivation) {
-      updateData.reactivatedAt = new Date()
+      updateData.reactivatedAt = new Date();
       // Clear stale cancellation metadata so the session reads as a clean active match
-      updateData.cancellationReason = FieldValue.delete()
-      updateData.cancelledAt = FieldValue.delete()
-      updateData.cancelledBy = FieldValue.delete()
+      updateData.cancellationReason = FieldValue.delete();
+      updateData.cancelledAt = FieldValue.delete();
+      updateData.cancelledBy = FieldValue.delete();
     }
 
-    await sessionRef.update(updateData)
+    await sessionRef.update(updateData);
 
     // Fetch profiles once for notification paths that need them
-    const needsProfiles = (status === 'completed' || (currentStatus === 'completed' && status === 'active') || isReactivation)
-    let mentorData: Record<string, unknown> | null = null
-    let menteeData: Record<string, unknown> | null = null
+    const needsProfiles =
+      status === "completed" ||
+      (currentStatus === "completed" && status === "active") ||
+      isReactivation;
+    let mentorData: Record<string, unknown> | null = null;
+    let menteeData: Record<string, unknown> | null = null;
     if (needsProfiles && isDiscordConfigured()) {
       try {
         const [mentorProfile, menteeProfile] = await Promise.all([
-          db.collection('mentorship_profiles').doc(sessionData.mentorId).get(),
-          db.collection('mentorship_profiles').doc(sessionData.menteeId).get(),
-        ])
-        mentorData = mentorProfile.exists ? (mentorProfile.data() as Record<string, unknown>) : null
-        menteeData = menteeProfile.exists ? (menteeProfile.data() as Record<string, unknown>) : null
+          db.collection("mentorship_profiles").doc(sessionData.mentorId).get(),
+          db.collection("mentorship_profiles").doc(sessionData.menteeId).get(),
+        ]);
+        mentorData = mentorProfile.exists
+          ? (mentorProfile.data() as Record<string, unknown>)
+          : null;
+        menteeData = menteeProfile.exists
+          ? (menteeProfile.data() as Record<string, unknown>)
+          : null;
       } catch (err) {
-        console.error('Admin sessions: profile fetch failed:', err)
+        console.error("Admin sessions: profile fetch failed:", err);
       }
     }
 
-    // On admin completion, mirror the mentor-path completion notifications
-    if (status === 'completed' && isDiscordConfigured() && sessionData.discordChannelId) {
-      sendChannelMessage(
-        sessionData.discordChannelId,
-        `🎓 **Congratulations! This mentorship has been marked as completed by an administrator!** 🎉\n\n` +
-          `Thank you both for your dedication to learning and growth.\n\n` +
-          `**${(mentorData?.displayName as string) || 'Mentor'}**, thank you for sharing your knowledge!\n` +
-          `**${(menteeData?.displayName as string) || 'Mentee'}**, we hope you learned a lot!\n\n` +
-          `Best of luck on your continued journey! 🚀`
-      ).catch((err) => console.error('Admin completion channel message failed:', err))
+    // On admin completion, DM both members then delete the channel (VIS-141).
+    if (status === "completed" && isDiscordConfigured() && sessionData.discordChannelId) {
+      const mentorName = (mentorData?.displayName as string) || "your mentor";
+      const menteeName = (menteeData?.displayName as string) || "your mentee";
 
-      archiveMentorshipChannel(
-        sessionData.discordChannelId,
-        `📦 **This mentorship session has been completed by an administrator.**\n\nThis channel is now archived. Thank you for being part of the mentorship program!`
-      ).catch((err) => console.error('Admin completion channel archive failed:', err))
+      deleteMentorshipChannel(sessionData.discordChannelId, {
+        mentorUsername: mentorData?.discordUsername as string | undefined,
+        menteeUsername: menteeData?.discordUsername as string | undefined,
+        mentorMessage:
+          `🎓 **Your mentorship with ${menteeName} has been marked as completed by an administrator!** 🎉\n\n` +
+          `Thank you for sharing your knowledge and mentoring. Your Discord channel has been closed.`,
+        menteeMessage:
+          `🎓 **Your mentorship with ${mentorName} has been marked as completed by an administrator!** 🎉\n\n` +
+          `We hope you learned a lot! Your Discord channel has been closed.\n\n` +
+          `Best of luck on your continued journey! 🚀`,
+        reason: "Mentorship completed by administrator (VIS-141)",
+      }).catch((err) => console.error("Admin completion channel deletion failed:", err));
     }
 
     // On admin revert (completed → active): notify channel the mentorship was restored
-    if (currentStatus === 'completed' && status === 'active' && isDiscordConfigured() && sessionData.discordChannelId) {
+    if (
+      currentStatus === "completed" &&
+      status === "active" &&
+      isDiscordConfigured() &&
+      sessionData.discordChannelId
+    ) {
       sendChannelMessage(
         sessionData.discordChannelId,
         `↩️ **This mentorship has been reverted to active by an administrator.**\n\n@here Your mentorship session has been restored. Welcome back!`
-      ).catch((err) => console.error('Admin revert channel message failed:', err))
+      ).catch((err) => console.error("Admin revert channel message failed:", err));
     }
 
     // On admin reactivation, restore the Discord channel and post the same
@@ -135,10 +154,10 @@ export async function PUT(request: NextRequest) {
           sessionData.discordChannelId,
           mentorData?.discordUsername as string | undefined,
           menteeData?.discordUsername as string | undefined
-        ).catch((err) => console.error('Discord channel unarchive failed:', err))
+        ).catch((err) => console.error("Discord channel unarchive failed:", err));
 
         // Post reactivation notification with a dashboard link button
-        const dashboardUrl = `${SITE_URL}/mentorship/dashboard/${sessionId}`
+        const dashboardUrl = `${SITE_URL}/mentorship/dashboard/${sessionId}`;
         await sendChannelMessageWithComponents(
           sessionData.discordChannelId,
           `♻️ **This mentorship has been reactivated by an administrator!**\n\n@here Your mentorship session has been restored. Welcome back!`,
@@ -149,118 +168,99 @@ export async function PUT(request: NextRequest) {
                 {
                   type: 2,
                   style: 5,
-                  label: 'View Dashboard',
+                  label: "View Dashboard",
                   url: dashboardUrl,
                 },
               ],
             },
           ]
-        ).catch((err) => console.error('Reactivation channel message failed:', err))
+        ).catch((err) => console.error("Reactivation channel message failed:", err));
       } catch (err) {
-        console.error('Reactivation Discord notification failed:', err)
+        console.error("Reactivation Discord notification failed:", err);
       }
     }
 
-    return NextResponse.json({
-      success: true,
-      sessionId,
-      status,
-      message: `Session status updated to ${status}`
-    }, { status: 200 })
+    return NextResponse.json(
+      {
+        success: true,
+        sessionId,
+        status,
+        message: `Session status updated to ${status}`,
+      },
+      { status: 200 }
+    );
   } catch (error) {
-    console.error('Error updating session status:', error)
-    return NextResponse.json({ error: 'Failed to update session status' }, { status: 500 })
+    console.error("Error updating session status:", error);
+    return NextResponse.json({ error: "Failed to update session status" }, { status: 500 });
   }
 }
 
 // DELETE: End a mentorship session (mark as cancelled, archive Discord, notify participants)
 export async function DELETE(request: NextRequest) {
   try {
-    const { searchParams } = new URL(request.url)
-    const sessionId = searchParams.get('id')
+    const { searchParams } = new URL(request.url);
+    const sessionId = searchParams.get("id");
 
     if (!sessionId) {
-      return NextResponse.json({ error: 'Missing session id parameter' }, { status: 400 })
+      return NextResponse.json({ error: "Missing session id parameter" }, { status: 400 });
     }
 
-    const sessionRef = db.collection('mentorship_sessions').doc(sessionId)
-    const sessionDoc = await sessionRef.get()
+    const sessionRef = db.collection("mentorship_sessions").doc(sessionId);
+    const sessionDoc = await sessionRef.get();
 
     if (!sessionDoc.exists) {
-      return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
 
-    const sessionData = sessionDoc.data()!
+    const sessionData = sessionDoc.data()!;
 
     // If already cancelled/completed, just delete the record
-    if (sessionData.status === 'cancelled' || sessionData.status === 'completed') {
-      await sessionRef.delete()
-      return NextResponse.json({
-        success: true,
-        sessionId,
-        message: 'Session record deleted'
-      }, { status: 200 })
+    if (sessionData.status === "cancelled" || sessionData.status === "completed") {
+      await sessionRef.delete();
+      return NextResponse.json(
+        {
+          success: true,
+          sessionId,
+          message: "Session record deleted",
+        },
+        { status: 200 }
+      );
     }
 
     // For active/pending sessions: mark as cancelled and handle notifications
     await sessionRef.update({
-      status: 'cancelled',
-      cancellationReason: 'ended_by_admin',
+      status: "cancelled",
+      cancellationReason: "ended_by_admin",
       cancelledAt: new Date(),
-      cancelledBy: 'admin',
-    })
+      cancelledBy: "admin",
+    });
 
     // Fetch profiles for notifications
     const [mentorProfile, menteeProfile] = await Promise.all([
-      db.collection('mentorship_profiles').doc(sessionData.mentorId).get(),
-      db.collection('mentorship_profiles').doc(sessionData.menteeId).get(),
-    ])
+      db.collection("mentorship_profiles").doc(sessionData.mentorId).get(),
+      db.collection("mentorship_profiles").doc(sessionData.menteeId).get(),
+    ]);
 
-    const mentorData = mentorProfile.exists ? mentorProfile.data() : null
-    const menteeData = menteeProfile.exists ? menteeProfile.data() : null
+    const mentorData = mentorProfile.exists ? mentorProfile.data() : null;
+    const menteeData = menteeProfile.exists ? menteeProfile.data() : null;
 
-    const notificationTasks: Promise<unknown>[] = []
+    const notificationTasks: Promise<unknown>[] = [];
 
-    // Send message to Discord channel before archiving
+    // DM both members, then delete the Discord channel (VIS-141). Deletion
+    // replaces the previous archive; the moderators channel is guarded inside
+    // deleteMentorshipChannel.
     if (isDiscordConfigured() && sessionData.discordChannelId) {
       notificationTasks.push(
-        sendChannelMessage(
-          sessionData.discordChannelId,
-          `📢 This mentorship has been ended by an administrator. The channel will be archived.`
-        ).catch((err) =>
-          console.error('Channel message before archive failed:', err)
-        )
-      )
-    }
-
-    // Archive Discord channel
-    if (isDiscordConfigured() && sessionData.discordChannelId) {
-      notificationTasks.push(
-        archiveMentorshipChannel(sessionData.discordChannelId).catch((err) =>
-          console.error('Discord channel archiving failed:', err)
-        )
-      )
-    }
-
-    // Notify mentor via DM
-    if (isDiscordConfigured() && mentorData?.discordUsername) {
-      notificationTasks.push(
-        sendDirectMessage(
-          mentorData.discordUsername,
-          `📢 Your mentorship with **${menteeData?.displayName || 'your mentee'}** has been ended by an administrator.`
-        ).catch((err) => console.error('Mentor DM failed:', err))
-      )
-    }
-
-    // Notify mentee via DM
-    if (isDiscordConfigured() && menteeData?.discordUsername) {
-      notificationTasks.push(
-        sendDirectMessage(
-          menteeData.discordUsername,
-          `📢 Your mentorship with **${mentorData?.displayName || 'your mentor'}** has been ended by an administrator.\n\n` +
-            `You can browse for a new mentor: https://codewithahsan.dev/mentorship/browse`
-        ).catch((err) => console.error('Mentee DM failed:', err))
-      )
+        deleteMentorshipChannel(sessionData.discordChannelId, {
+          mentorUsername: mentorData?.discordUsername,
+          menteeUsername: menteeData?.discordUsername,
+          mentorMessage: `📢 Your mentorship with **${menteeData?.displayName || "your mentee"}** has been ended by an administrator. The Discord channel has been closed.`,
+          menteeMessage:
+            `📢 Your mentorship with **${mentorData?.displayName || "your mentor"}** has been ended by an administrator. The Discord channel has been closed.\n\n` +
+            `You can browse for a new mentor: https://codewithahsan.dev/mentorship/browse`,
+          reason: "Mentorship ended by administrator (VIS-141)",
+        }).catch((err) => console.error("Discord channel deletion failed:", err))
+      );
     }
 
     // Send email to both parties
@@ -269,29 +269,32 @@ export async function DELETE(request: NextRequest) {
         sendMentorshipRemovedEmail(
           {
             uid: sessionData.mentorId,
-            displayName: mentorData.displayName || '',
-            email: mentorData.email || '',
-            roles: ['mentor'],
+            displayName: mentorData.displayName || "",
+            email: mentorData.email || "",
+            roles: ["mentor"],
           },
           {
             uid: sessionData.menteeId,
-            displayName: menteeData.displayName || '',
-            email: menteeData.email || '',
-            roles: ['mentee'],
+            displayName: menteeData.displayName || "",
+            email: menteeData.email || "",
+            roles: ["mentee"],
           }
-        ).catch((err) => console.error('Failed to send end email:', err))
-      )
+        ).catch((err) => console.error("Failed to send end email:", err))
+      );
     }
 
-    await Promise.allSettled(notificationTasks)
+    await Promise.allSettled(notificationTasks);
 
-    return NextResponse.json({
-      success: true,
-      sessionId,
-      message: 'Mentorship ended successfully'
-    }, { status: 200 })
+    return NextResponse.json(
+      {
+        success: true,
+        sessionId,
+        message: "Mentorship ended successfully",
+      },
+      { status: 200 }
+    );
   } catch (error) {
-    console.error('Error ending session:', error)
-    return NextResponse.json({ error: 'Failed to end session' }, { status: 500 })
+    console.error("Error ending session:", error);
+    return NextResponse.json({ error: "Failed to end session" }, { status: 500 });
   }
 }

--- a/src/app/api/mentorship/dashboard/[matchId]/route.ts
+++ b/src/app/api/mentorship/dashboard/[matchId]/route.ts
@@ -1,14 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/firebaseAdmin";
+import { sendMentorshipCompletedEmail, sendMentorshipRemovedEmail } from "@/lib/email";
 import {
-  sendMentorshipCompletedEmail,
-  sendMentorshipRemovedEmail,
-} from "@/lib/email";
-import {
-  sendChannelMessage,
   sendDirectMessage,
   isDiscordConfigured,
-  archiveMentorshipChannel,
+  deleteMentorshipChannel,
   sendMentorshipCompletionAnnouncement,
 } from "@/lib/discord";
 
@@ -21,17 +17,11 @@ export async function GET(
   const uid = searchParams.get("uid");
 
   if (!uid) {
-    return NextResponse.json(
-      { error: "Missing uid parameter" },
-      { status: 400 }
-    );
+    return NextResponse.json({ error: "Missing uid parameter" }, { status: 400 });
   }
 
   try {
-    const matchDoc = await db
-      .collection("mentorship_sessions")
-      .doc(resolvedParams.matchId)
-      .get();
+    const matchDoc = await db.collection("mentorship_sessions").doc(resolvedParams.matchId).get();
 
     if (!matchDoc.exists) {
       return NextResponse.json({ error: "Match not found" }, { status: 404 });
@@ -46,19 +36,12 @@ export async function GET(
 
     // Check match is active
     if (matchData.status !== "active") {
-      return NextResponse.json(
-        { error: "Match is not active" },
-        { status: 403 }
-      );
+      return NextResponse.json({ error: "Match is not active" }, { status: 403 });
     }
 
     // Get partner profile
-    const partnerId =
-      matchData.mentorId === uid ? matchData.menteeId : matchData.mentorId;
-    const partnerDoc = await db
-      .collection("mentorship_profiles")
-      .doc(partnerId)
-      .get();
+    const partnerId = matchData.mentorId === uid ? matchData.menteeId : matchData.mentorId;
+    const partnerDoc = await db.collection("mentorship_profiles").doc(partnerId).get();
 
     const partnerData = partnerDoc.exists ? partnerDoc.data() : null;
 
@@ -86,10 +69,7 @@ export async function GET(
     );
   } catch (error) {
     console.error("Error fetching match details:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch match" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to fetch match" }, { status: 500 });
   }
 }
 
@@ -108,10 +88,7 @@ export async function PUT(
       return NextResponse.json({ error: "Missing uid" }, { status: 400 });
     }
 
-    const matchDoc = await db
-      .collection("mentorship_sessions")
-      .doc(resolvedParams.matchId)
-      .get();
+    const matchDoc = await db.collection("mentorship_sessions").doc(resolvedParams.matchId).get();
 
     if (!matchDoc.exists) {
       return NextResponse.json({ error: "Match not found" }, { status: 404 });
@@ -164,23 +141,6 @@ export async function PUT(
       // Execute notification tasks in parallel but await them to ensure Vercel function stays alive
       const notificationTasks = [];
 
-      // Send congratulations message to the mentorship channel
-      if (isDiscordConfigured() && matchData.discordChannelId) {
-        notificationTasks.push(
-          sendChannelMessage(
-            matchData.discordChannelId,
-            `🎓 **Congratulations! This mentorship has been marked as completed by ${mentorData?.displayName || "the mentor"}!** 🎉\n\n` +
-              `Thank you both for your dedication to learning and growth.\n\n` +
-              `**${mentorData?.displayName || "Mentor"}**, thank you for sharing your knowledge!\n` +
-              `**${menteeData?.displayName || "Mentee"}**, we hope you learned a lot!\n\n` +
-              `This channel will remain available for you to reference past conversations.\n\n` +
-              `Best of luck on your continued journey! 🚀`
-          ).catch((err) =>
-            console.error("Completion channel message failed:", err)
-          )
-        );
-      }
-
       // Send DM to mentee asking to rate the mentor
       if (isDiscordConfigured() && menteeData?.discordUsername && mentorData) {
         notificationTasks.push(
@@ -202,22 +162,21 @@ export async function PUT(
             menteeData.displayName || "Mentee",
             mentorData.discordUsername,
             menteeData.discordUsername
-          ).catch((err) =>
-            console.error("Completion announcement failed:", err)
-          )
+          ).catch((err) => console.error("Completion announcement failed:", err))
         );
       }
 
-      // Archive Discord channel
+      // DM the mentor a completion notice, then delete the channel (VIS-141).
+      // The mentee is notified separately above via the rating DM.
       if (isDiscordConfigured() && matchData.discordChannelId) {
         notificationTasks.push(
-          archiveMentorshipChannel(
-            matchData.discordChannelId,
-            `📦 **This mentorship session has been completed.**\n\n` +
-              `This channel is now archived. Thank you for being part of the mentorship program!`
-          ).catch((err) =>
-            console.error("Discord channel archiving failed:", err)
-          )
+          deleteMentorshipChannel(matchData.discordChannelId, {
+            mentorUsername: mentorData?.discordUsername,
+            mentorMessage:
+              `🎓 **Your mentorship with ${menteeData?.displayName || "your mentee"} is now complete!** 🎉\n\n` +
+              `Thank you for sharing your knowledge and mentoring. The Discord channel has been closed.`,
+            reason: "Mentorship completed (VIS-141)",
+          }).catch((err) => console.error("Discord channel deletion failed:", err))
         );
       }
 
@@ -237,9 +196,7 @@ export async function PUT(
               email: menteeData?.email || "",
               roles: ["mentee"],
             }
-          ).catch((err) =>
-            console.error("Failed to send completion email:", err)
-          )
+          ).catch((err) => console.error("Failed to send completion email:", err))
         );
       }
 
@@ -263,10 +220,7 @@ export async function PUT(
       }
 
       if (matchData.status !== "active") {
-        return NextResponse.json(
-          { error: "Can only remove active mentorships" },
-          { status: 400 }
-        );
+        return NextResponse.json({ error: "Can only remove active mentorships" }, { status: 400 });
       }
 
       await db
@@ -290,35 +244,17 @@ export async function PUT(
 
       const notificationTasks = [];
 
-      // Send message to channel before archiving
+      // DM the mentee, then delete the channel (VIS-141). Deletion replaces the
+      // previous archive; the mentee is the affected member here.
       if (isDiscordConfigured() && matchData.discordChannelId) {
         notificationTasks.push(
-          sendChannelMessage(
-            matchData.discordChannelId,
-            `📢 This mentorship has been ended by the mentor. The channel will be archived.`
-          ).catch((err) =>
-            console.error("Channel message before archive failed:", err)
-          )
-        );
-      }
-
-      // Archive Discord channel
-      if (isDiscordConfigured() && matchData.discordChannelId) {
-        notificationTasks.push(
-          archiveMentorshipChannel(matchData.discordChannelId).catch((err) =>
-            console.error("Discord channel archiving failed:", err)
-          )
-        );
-      }
-
-      // Notify mentee via DM
-      if (isDiscordConfigured() && menteeData?.discordUsername && mentorData) {
-        notificationTasks.push(
-          sendDirectMessage(
-            menteeData.discordUsername,
-            `📢 Your mentorship with **${mentorData.displayName}** has been ended.\n\n` +
-              `You can browse for a new mentor: https://codewithahsan.dev/mentorship/browse`
-          ).catch((err) => console.error("Mentee removal DM failed:", err))
+          deleteMentorshipChannel(matchData.discordChannelId, {
+            menteeUsername: menteeData?.discordUsername,
+            menteeMessage:
+              `📢 Your mentorship with **${mentorData?.displayName || "your mentor"}** has been ended. The Discord channel has been closed.\n\n` +
+              `You can browse for a new mentor: https://codewithahsan.dev/mentorship/browse`,
+            reason: "Mentorship ended by mentor (VIS-141)",
+          }).catch((err) => console.error("Discord channel deletion failed:", err))
         );
       }
 
@@ -361,10 +297,7 @@ export async function PUT(
       }
 
       if (matchData.status !== "active") {
-        return NextResponse.json(
-          { error: "Can only end active mentorships" },
-          { status: 400 }
-        );
+        return NextResponse.json({ error: "Can only end active mentorships" }, { status: 400 });
       }
 
       await db
@@ -388,35 +321,17 @@ export async function PUT(
 
       const notificationTasks = [];
 
-      // Send message to channel before archiving
+      // DM the mentor, then delete the channel (VIS-141). Deletion replaces the
+      // previous archive; the mentor is the affected member here.
       if (isDiscordConfigured() && matchData.discordChannelId) {
         notificationTasks.push(
-          sendChannelMessage(
-            matchData.discordChannelId,
-            `📢 This mentorship has been ended by the mentee. The channel will be archived.`
-          ).catch((err) =>
-            console.error("Channel message before archive failed:", err)
-          )
-        );
-      }
-
-      // Archive Discord channel
-      if (isDiscordConfigured() && matchData.discordChannelId) {
-        notificationTasks.push(
-          archiveMentorshipChannel(matchData.discordChannelId).catch((err) =>
-            console.error("Discord channel archiving failed:", err)
-          )
-        );
-      }
-
-      // Notify mentor via DM
-      if (isDiscordConfigured() && mentorData?.discordUsername && menteeData) {
-        notificationTasks.push(
-          sendDirectMessage(
-            mentorData.discordUsername,
-            `📢 **${menteeData.displayName || "Your mentee"}** has ended the mentorship.\n\n` +
-              `You now have an open slot for a new mentee.`
-          ).catch((err) => console.error("Mentor end DM failed:", err))
+          deleteMentorshipChannel(matchData.discordChannelId, {
+            mentorUsername: mentorData?.discordUsername,
+            mentorMessage:
+              `📢 **${menteeData?.displayName || "Your mentee"}** has ended the mentorship. The Discord channel has been closed.\n\n` +
+              `You now have an open slot for a new mentee.`,
+            reason: "Mentorship ended by mentee (VIS-141)",
+          }).catch((err) => console.error("Discord channel deletion failed:", err))
         );
       }
 
@@ -454,9 +369,6 @@ export async function PUT(
     return NextResponse.json({ error: "Invalid action" }, { status: 400 });
   } catch (error) {
     console.error("Error updating match:", error);
-    return NextResponse.json(
-      { error: "Failed to update match" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to update match" }, { status: 500 });
   }
 }

--- a/src/lib/discord.test.ts
+++ b/src/lib/discord.test.ts
@@ -3,7 +3,7 @@
  * Test boundary: mock global.fetch (fetchWithRateLimit ultimately calls it).
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { removeDiscordRole } from "./discord";
+import { removeDiscordRole, isProtectedChannel, deleteDiscordChannel } from "./discord";
 
 describe("removeDiscordRole (DISC-05)", () => {
   beforeEach(() => {
@@ -13,34 +13,66 @@ describe("removeDiscordRole (DISC-05)", () => {
   });
 
   it("returns true on Discord 204", async () => {
-    vi.spyOn(global, "fetch").mockResolvedValue(
-      new Response(null, { status: 204 }),
-    );
+    vi.spyOn(global, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
     const result = await removeDiscordRole("123456789012345678", "999");
     expect(result).toBe(true);
   });
 
   it("returns true on Discord 404 (idempotent — Pitfall 5)", async () => {
-    vi.spyOn(global, "fetch").mockResolvedValue(
-      new Response("Not found", { status: 404 }),
-    );
+    vi.spyOn(global, "fetch").mockResolvedValue(new Response("Not found", { status: 404 }));
     const result = await removeDiscordRole("123456789012345678", "999");
     expect(result).toBe(true);
   });
 
   it("returns false on Discord 500", async () => {
-    vi.spyOn(global, "fetch").mockResolvedValue(
-      new Response("Server error", { status: 500 }),
-    );
+    vi.spyOn(global, "fetch").mockResolvedValue(new Response("Server error", { status: 500 }));
     const result = await removeDiscordRole("123456789012345678", "999");
     expect(result).toBe(false);
   });
 
   it("returns false on Discord 403", async () => {
-    vi.spyOn(global, "fetch").mockResolvedValue(
-      new Response("Forbidden", { status: 403 }),
-    );
+    vi.spyOn(global, "fetch").mockResolvedValue(new Response("Forbidden", { status: 403 }));
     const result = await removeDiscordRole("123456789012345678", "999");
     expect(result).toBe(false);
+  });
+});
+
+describe("protected channel deletion guard (VIS-141)", () => {
+  beforeEach(() => {
+    process.env.DISCORD_BOT_TOKEN = "test-token";
+    process.env.DISCORD_GUILD_ID = "1234567890";
+    vi.restoreAllMocks();
+  });
+
+  it("flags the moderators/registration channel as protected", () => {
+    // Default MODERATORS_CHANNEL_ID (also the project-review channel).
+    expect(isProtectedChannel("874565618458824715")).toBe(true);
+  });
+
+  it("flags the #find-a-mentor announcement channel as protected", () => {
+    expect(isProtectedChannel("1419645845258768385")).toBe(true);
+  });
+
+  it("does not flag an ordinary per-mentorship channel", () => {
+    expect(isProtectedChannel("999999999999999999")).toBe(false);
+  });
+
+  it("refuses to delete a protected channel and never calls Discord", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch");
+    const result = await deleteDiscordChannel("874565618458824715", "should be blocked");
+    expect(result).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("deletes an ordinary channel (Discord 204)", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
+    const result = await deleteDiscordChannel("999999999999999999", "ordinary delete");
+    expect(result).toBe(true);
+  });
+
+  it("treats a 404 as an idempotent success", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(new Response("Not found", { status: 404 }));
+    const result = await deleteDiscordChannel("999999999999999999", "already gone");
+    expect(result).toBe(true);
   });
 });

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -97,9 +97,7 @@ async function fetchWithRateLimit(
  * Lookup a Discord user ID by their username in the guild
  * Returns null if not found
  */
-export async function lookupMemberByUsername(
-  username: string
-): Promise<DiscordMember | null> {
+export async function lookupMemberByUsername(username: string): Promise<DiscordMember | null> {
   // Normalize: strip leading @ and trailing #discriminator (legacy format)
   const normalized = username.trim().replace(/^@/, "").replace(/#\d+$/, "");
   const guildId = getGuildId();
@@ -114,9 +112,7 @@ export async function lookupMemberByUsername(
 
     if (!response.ok) {
       const errorText = await response.text();
-      log.error(
-        `Discord member search failed: ${response.status} - ${errorText}`
-      );
+      log.error(`Discord member search failed: ${response.status} - ${errorText}`);
       return null;
     }
 
@@ -179,17 +175,12 @@ async function getOrCreateMonthlyCategory(): Promise<string | null> {
 
   try {
     // Get all channels in the guild
-    const response = await fetchWithRateLimit(
-      `${DISCORD_API}/guilds/${guildId}/channels`,
-      {
-        headers: getHeaders(),
-      }
-    );
+    const response = await fetchWithRateLimit(`${DISCORD_API}/guilds/${guildId}/channels`, {
+      headers: getHeaders(),
+    });
 
     if (!response.ok) {
-      log.error(
-        `Failed to fetch guild channels: ${response.status} - ${await response.text()}`
-      );
+      log.error(`Failed to fetch guild channels: ${response.status} - ${await response.text()}`);
       return null;
     }
 
@@ -200,9 +191,7 @@ async function getOrCreateMonthlyCategory(): Promise<string | null> {
       (ch: { type: number; name: string }) =>
         ch.type === 4 &&
         (ch.name.toLowerCase() === baseNamePrefix.toLowerCase() ||
-          ch.name
-            .toLowerCase()
-            .startsWith(baseNamePrefix.toLowerCase() + " - batch"))
+          ch.name.toLowerCase().startsWith(baseNamePrefix.toLowerCase() + " - batch"))
     );
 
     // Sort by batch number (base name = batch 1, then Batch 2, Batch 3, etc.)
@@ -236,10 +225,7 @@ async function getOrCreateMonthlyCategory(): Promise<string | null> {
       const currentBatch =
         latestCategory.name.toLowerCase() === baseNamePrefix.toLowerCase()
           ? 1
-          : parseInt(
-              latestCategory.name.match(/batch\s*(\d+)/i)?.[1] || "1",
-              10
-            );
+          : parseInt(latestCategory.name.match(/batch\s*(\d+)/i)?.[1] || "1", 10);
       const newBatchNum = currentBatch + 1;
       const newCategoryName = `${baseNamePrefix} - Batch ${newBatchNum}`;
 
@@ -259,10 +245,7 @@ async function getOrCreateMonthlyCategory(): Promise<string | null> {
 /**
  * Helper to create a category with standard permissions
  */
-async function createCategory(
-  guildId: string,
-  categoryName: string
-): Promise<string | null> {
+async function createCategory(guildId: string, categoryName: string): Promise<string | null> {
   // Category permission: @everyone cannot view (private by default)
   const permissionOverwrites = [
     {
@@ -273,18 +256,15 @@ async function createCategory(
     },
   ];
 
-  const createResponse = await fetch(
-    `${DISCORD_API}/guilds/${guildId}/channels`,
-    {
-      method: "POST",
-      headers: getHeaders(),
-      body: JSON.stringify({
-        name: categoryName,
-        type: 4, // GUILD_CATEGORY
-        permission_overwrites: permissionOverwrites,
-      }),
-    }
-  );
+  const createResponse = await fetch(`${DISCORD_API}/guilds/${guildId}/channels`, {
+    method: "POST",
+    headers: getHeaders(),
+    body: JSON.stringify({
+      name: categoryName,
+      type: 4, // GUILD_CATEGORY
+      permission_overwrites: permissionOverwrites,
+    }),
+  });
 
   if (!createResponse.ok) {
     log.error(
@@ -294,9 +274,7 @@ async function createCategory(
   }
 
   const newCategory = await createResponse.json();
-  log.debug(
-    `Created new category: ${newCategory.name} (ID: ${newCategory.id})`
-  );
+  log.debug(`Created new category: ${newCategory.name} (ID: ${newCategory.id})`);
   return newCategory.id;
 }
 
@@ -393,20 +371,15 @@ export async function createMentorshipChannel(
       channelPayload.parent_id = categoryId;
     }
 
-    const response = await fetchWithRateLimit(
-      `${DISCORD_API}/guilds/${guildId}/channels`,
-      {
-        method: "POST",
-        headers: getHeaders(),
-        body: JSON.stringify(channelPayload),
-      }
-    );
+    const response = await fetchWithRateLimit(`${DISCORD_API}/guilds/${guildId}/channels`, {
+      method: "POST",
+      headers: getHeaders(),
+      body: JSON.stringify(channelPayload),
+    });
 
     if (!response.ok) {
       const errorText = await response.text();
-      log.error(
-        `[Discord] Channel creation failed: ${response.status} - ${errorText}`
-      );
+      log.error(`[Discord] Channel creation failed: ${response.status} - ${errorText}`);
       return null;
     }
 
@@ -414,12 +387,8 @@ export async function createMentorshipChannel(
     log.debug(`Channel created: ${channel.name} (ID: ${channel.id})`);
 
     // Build mention string for users who were found
-    const mentorMention = mentorMemberId
-      ? `<@${mentorMemberId}>`
-      : `**${mentorName}**`;
-    const menteeMention = menteeMemberId
-      ? `<@${menteeMemberId}>`
-      : `**${menteeName}**`;
+    const mentorMention = mentorMemberId ? `<@${mentorMemberId}>` : `**${mentorName}**`;
+    const menteeMention = menteeMemberId ? `<@${menteeMemberId}>` : `**${menteeName}**`;
 
     // Send welcome message with @mentions
     await sendChannelMessage(
@@ -450,20 +419,14 @@ export async function createMentorshipChannel(
  * Send a message to a Discord channel
  * Exported for use in session/goal notifications
  */
-export async function sendChannelMessage(
-  channelId: string,
-  content: string
-): Promise<boolean> {
+export async function sendChannelMessage(channelId: string, content: string): Promise<boolean> {
   log.debug(` Sending message to channel ${channelId}...`);
   try {
-    const response = await fetch(
-      `${DISCORD_API}/channels/${channelId}/messages`,
-      {
-        method: "POST",
-        headers: getHeaders(),
-        body: JSON.stringify({ content }),
-      }
-    );
+    const response = await fetch(`${DISCORD_API}/channels/${channelId}/messages`, {
+      method: "POST",
+      headers: getHeaders(),
+      body: JSON.stringify({ content }),
+    });
 
     if (response.ok) {
       log.debug(`Message sent successfully to channel ${channelId}`);
@@ -493,14 +456,11 @@ export async function sendChannelMessageWithComponents(
 ): Promise<boolean> {
   log.debug(` Sending message with components to channel ${channelId}...`);
   try {
-    const response = await fetch(
-      `${DISCORD_API}/channels/${channelId}/messages`,
-      {
-        method: "POST",
-        headers: getHeaders(),
-        body: JSON.stringify({ content, components }),
-      }
-    );
+    const response = await fetch(`${DISCORD_API}/channels/${channelId}/messages`, {
+      method: "POST",
+      headers: getHeaders(),
+      body: JSON.stringify({ content, components }),
+    });
 
     if (response.ok) {
       log.debug(`Message with components sent successfully to channel ${channelId}`);
@@ -554,14 +514,11 @@ export async function sendDirectMessage(
     const dmChannel = await dmChannelResponse.json();
 
     // Send message
-    const messageResponse = await fetch(
-      `${DISCORD_API}/channels/${dmChannel.id}/messages`,
-      {
-        method: "POST",
-        headers: getHeaders(),
-        body: JSON.stringify({ content: message }),
-      }
-    );
+    const messageResponse = await fetch(`${DISCORD_API}/channels/${dmChannel.id}/messages`, {
+      method: "POST",
+      headers: getHeaders(),
+      body: JSON.stringify({ content: message }),
+    });
 
     log.debug(` DM sent successfully to ${discordUsername}`);
     return messageResponse.ok;
@@ -587,12 +544,9 @@ export async function archiveMentorshipChannel(
 
   try {
     // Get current channel info
-    const channelResponse = await fetch(
-      `${DISCORD_API}/channels/${channelId}`,
-      {
-        headers: getHeaders(),
-      }
-    );
+    const channelResponse = await fetch(`${DISCORD_API}/channels/${channelId}`, {
+      headers: getHeaders(),
+    });
 
     if (!channelResponse.ok) {
       log.error("Failed to get channel:", await channelResponse.text());
@@ -618,9 +572,7 @@ export async function archiveMentorshipChannel(
 
     // Send archive message (use custom reason or default completion message)
     const archiveMessage =
-      reason ||
-      `📦 **This mentorship session has ended.**\n\n` +
-        `This channel is now archived.`;
+      reason || `📦 **This mentorship session has ended.**\n\n` + `This channel is now archived.`;
 
     await sendChannelMessage(channelId, archiveMessage);
 
@@ -646,10 +598,9 @@ export async function unarchiveMentorshipChannel(
 
   try {
     // Get current channel info
-    const channelResponse = await fetch(
-      `${DISCORD_API}/channels/${channelId}`,
-      { headers: getHeaders() }
-    );
+    const channelResponse = await fetch(`${DISCORD_API}/channels/${channelId}`, {
+      headers: getHeaders(),
+    });
 
     if (!channelResponse.ok) {
       log.error("Failed to get channel:", await channelResponse.text());
@@ -658,15 +609,15 @@ export async function unarchiveMentorshipChannel(
 
     const channel = await channelResponse.json();
     const newName = channel.name.replace(/^archived-/, "");
-    // If it didn't have archived- prefix, maybe just ensure permissions? 
+    // If it didn't have archived- prefix, maybe just ensure permissions?
     // But let's assume we want to clean it up.
 
     const newTopic = channel.topic?.replace(/^\[ARCHIVED\]\s*/, "") || "";
 
     // Prepare permission updates if IDs provided
-    // We need to fetch existing overwrites first if we want to preserve others, 
+    // We need to fetch existing overwrites first if we want to preserve others,
     // but typically we just want to ensure these two have access.
-    // However, PATCH /channels/{id} expects the FULL list of overwrites if provided, 
+    // However, PATCH /channels/{id} expects the FULL list of overwrites if provided,
     // OR we can use PUT /channels/{id}/permissions/{trigger_id} for individual updates.
     // Using individual PUTs is safer to not wipe other permissions (like bots/mods).
 
@@ -684,51 +635,49 @@ export async function unarchiveMentorshipChannel(
       log.error("Failed to unarchive channel (rename):", await updateResponse.text());
       return { success: false };
     }
-    
+
     // 2. Restore permissions for Mentor
     if (mentorDiscordId) {
       await fetch(`${DISCORD_API}/channels/${channelId}/permissions/${mentorDiscordId}`, {
-         method: "PUT",
-         headers: getHeaders(),
-         body: JSON.stringify({
-           allow: "3072", // VIEW_CHANNEL + SEND_MESSAGES
-           deny: "0",
-           type: 1 // Member
-         })
+        method: "PUT",
+        headers: getHeaders(),
+        body: JSON.stringify({
+          allow: "3072", // VIEW_CHANNEL + SEND_MESSAGES
+          deny: "0",
+          type: 1, // Member
+        }),
       });
     }
 
     // 3. Restore permissions for Mentee
     if (menteeDiscordId) {
       await fetch(`${DISCORD_API}/channels/${channelId}/permissions/${menteeDiscordId}`, {
-         method: "PUT",
-         headers: getHeaders(),
-         body: JSON.stringify({
-           allow: "3072", // VIEW_CHANNEL + SEND_MESSAGES
-           deny: "0",
-           type: 1 // Member
-         })
+        method: "PUT",
+        headers: getHeaders(),
+        body: JSON.stringify({
+          allow: "3072", // VIEW_CHANNEL + SEND_MESSAGES
+          deny: "0",
+          type: 1, // Member
+        }),
       });
     }
 
-    
     const channelUrl = `https://discord.com/channels/${guildId}/${channelId}`;
     await sendChannelMessage(channelId, "♻️ **This channel has been restored/unarchived.**");
 
     log.debug(` Channel unarchived successfully: ${channelId}`);
     return { success: true, channelUrl };
-
   } catch (error) {
     log.error("[Discord] Error unarchiving channel:", error);
     return { success: false };
   }
 }
 
-
 /**
  * Get a Discord channel by ID to check if it exists
  * returns null if not found (404) or other error
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Discord channel payload is untyped
 export async function getChannel(channelId: string): Promise<any | null> {
   const channelUrl = `${DISCORD_API}/channels/${channelId}`;
   log.debug(` Checking if channel exists: ${channelId}`);
@@ -759,9 +708,7 @@ export async function getChannel(channelId: string): Promise<any | null> {
  * Used by inactivity cron jobs to determine real channel activity.
  * Returns null if the channel doesn't exist, has no messages, or all messages are from bots.
  */
-export async function getLastChannelActivityDate(
-  channelId: string
-): Promise<Date | null> {
+export async function getLastChannelActivityDate(channelId: string): Promise<Date | null> {
   try {
     const response = await fetchWithRateLimit(
       `${DISCORD_API}/channels/${channelId}/messages?limit=50`,
@@ -770,9 +717,7 @@ export async function getLastChannelActivityDate(
 
     if (!response.ok) {
       if (response.status === 404) return null;
-      log.error(
-        `Failed to fetch messages for channel ${channelId}: ${response.status}`
-      );
+      log.error(`Failed to fetch messages for channel ${channelId}: ${response.status}`);
       return null;
     }
 
@@ -839,9 +784,7 @@ export async function getGuildMemberById(
  * Check if Discord integration is properly configured
  */
 export function isDiscordConfigured(): boolean {
-  const configured = !!(
-    process.env.DISCORD_BOT_TOKEN && process.env.DISCORD_GUILD_ID
-  );
+  const configured = !!(process.env.DISCORD_BOT_TOKEN && process.env.DISCORD_GUILD_ID);
   if (!configured) {
     log.debug("Not configured - missing DISCORD_BOT_TOKEN or DISCORD_GUILD_ID");
   }
@@ -876,6 +819,40 @@ const MONTHLY_LEARNING_CHALLENGES_CHANNEL_ID =
   process.env.DISCORD_MONTHLY_CHALLENGES_CHANNEL_ID || "1498942172488007780";
 
 /**
+ * Moderators / mentorship-registration notifications channel. New mentorship
+ * registrations are announced here for the moderators to review. Per the
+ * VIS-141 board decision, this channel must NEVER be deleted by the
+ * mentorship-end cleanup flows. Configurable via env so it can differ per
+ * environment; falls back to the known CWA server channel.
+ */
+const MODERATORS_CHANNEL_ID = process.env.DISCORD_MODERATORS_CHANNEL_ID || "874565618458824715";
+
+/**
+ * Community/shared channels that must never be deleted by any mentorship or
+ * project cleanup flow. These are long-lived server channels (announcements,
+ * moderator review, collaboration) — only the ephemeral per-mentorship and
+ * per-project channels are eligible for deletion. Guarding here gives every
+ * `deleteDiscordChannel` caller defense-in-depth against a bad channel ID.
+ * (VIS-141)
+ */
+const PROTECTED_CHANNEL_IDS: ReadonlySet<string> = new Set([
+  FIND_A_MENTOR_CHANNEL_ID,
+  PROJECT_REVIEW_CHANNEL_ID,
+  PROJECT_COLLABORATION_CHANNEL_ID,
+  MONTHLY_LEARNING_CHALLENGES_CHANNEL_ID,
+  MODERATORS_CHANNEL_ID,
+]);
+
+/**
+ * Returns true if the given channel is a protected community channel that must
+ * never be deleted. Exported for unit testing and for callers that want to
+ * branch before attempting a delete. (VIS-141)
+ */
+export function isProtectedChannel(channelId: string): boolean {
+  return PROTECTED_CHANNEL_IDS.has(channelId);
+}
+
+/**
  * Assign a Discord role to a user
  * This is a fire-and-forget operation - failures are logged but do not throw
  *
@@ -898,9 +875,7 @@ export async function assignDiscordRole(
     } else {
       const member = await lookupMemberByUsername(discordUsernameOrId);
       if (!member) {
-        log.warn(
-          `[Discord] Cannot assign role - user not found: ${discordUsernameOrId}`
-        );
+        log.warn(`[Discord] Cannot assign role - user not found: ${discordUsernameOrId}`);
         return false;
       }
       memberId = member.id;
@@ -918,9 +893,7 @@ export async function assignDiscordRole(
     );
 
     if (response.status === 204) {
-      log.debug(
-        `Successfully assigned role ${roleId} to ${discordUsernameOrId} (ID: ${memberId})`
-      );
+      log.debug(`Successfully assigned role ${roleId} to ${discordUsernameOrId} (ID: ${memberId})`);
       return true;
     } else {
       const errorText = await response.text();
@@ -930,10 +903,7 @@ export async function assignDiscordRole(
       return false;
     }
   } catch (error) {
-    log.error(
-      `[Discord] Error assigning role ${roleId} to ${discordUsernameOrId}:`,
-      error
-    );
+    log.error(`[Discord] Error assigning role ${roleId} to ${discordUsernameOrId}:`, error);
     return false;
   }
 }
@@ -951,7 +921,7 @@ export async function assignDiscordRole(
  */
 export async function removeDiscordRole(
   discordMemberIdOrUsername: string,
-  roleId: string,
+  roleId: string
 ): Promise<boolean> {
   log.debug(`Removing role ${roleId} from user ${discordMemberIdOrUsername}`);
   try {
@@ -971,18 +941,16 @@ export async function removeDiscordRole(
     const guildId = getGuildId();
     const response = await fetchWithRateLimit(
       `${DISCORD_API}/guilds/${guildId}/members/${memberId}/roles/${roleId}`,
-      { method: "DELETE", headers: getHeaders() },
+      { method: "DELETE", headers: getHeaders() }
     );
     if (response.status === 204 || response.status === 404) {
       log.debug(
-        `Role ${roleId} removed from ${discordMemberIdOrUsername} (status ${response.status})`,
+        `Role ${roleId} removed from ${discordMemberIdOrUsername} (status ${response.status})`
       );
       return true;
     }
     const errorText = await response.text();
-    log.error(
-      `[Discord] Failed to remove role ${roleId}: ${response.status} - ${errorText}`,
-    );
+    log.error(`[Discord] Failed to remove role ${roleId}: ${response.status} - ${errorText}`);
     return false;
   } catch (error) {
     log.error(`[Discord] Error removing role ${roleId}:`, error);
@@ -1005,9 +973,7 @@ export async function sendMentorshipCompletionAnnouncement(
   mentorDiscordUsername?: string,
   menteeDiscordUsername?: string
 ): Promise<boolean> {
-  log.debug(
-    `Sending completion announcement for ${mentorName} <-> ${menteeName}`
-  );
+  log.debug(`Sending completion announcement for ${mentorName} <-> ${menteeName}`);
 
   try {
     // Look up members for @mentions
@@ -1058,16 +1024,14 @@ export async function sendMentorshipCompletionAnnouncement(
  *
  * @param challenge The challenge that was published.
  */
-export async function announceChallenge(
-  challenge: {
-    id: string;
-    title: string;
-    topic: string;
-    difficulty: string;
-    startDate: string;
-    endDate: string;
-  }
-): Promise<boolean> {
+export async function announceChallenge(challenge: {
+  id: string;
+  title: string;
+  topic: string;
+  difficulty: string;
+  startDate: string;
+  endDate: string;
+}): Promise<boolean> {
   log.debug(`Sending monthly challenge announcement for: ${challenge.title}`);
 
   try {
@@ -1099,10 +1063,7 @@ export async function announceChallenge(
       `👉 ${challengeUrl}\n\n` +
       `Good luck! 💻✨`;
 
-    const success = await sendChannelMessage(
-      MONTHLY_LEARNING_CHALLENGES_CHANNEL_ID,
-      message
-    );
+    const success = await sendChannelMessage(MONTHLY_LEARNING_CHALLENGES_CHANNEL_ID, message);
 
     if (success) {
       log.debug(`Monthly challenge announcement sent successfully`);
@@ -1134,17 +1095,12 @@ async function getOrCreateProjectsCategory(): Promise<string | null> {
 
   try {
     // Get all channels in the guild
-    const response = await fetchWithRateLimit(
-      `${DISCORD_API}/guilds/${guildId}/channels`,
-      {
-        headers: getHeaders(),
-      }
-    );
+    const response = await fetchWithRateLimit(`${DISCORD_API}/guilds/${guildId}/channels`, {
+      headers: getHeaders(),
+    });
 
     if (!response.ok) {
-      log.error(
-        `Failed to fetch guild channels: ${response.status} - ${await response.text()}`
-      );
+      log.error(`Failed to fetch guild channels: ${response.status} - ${await response.text()}`);
       return null;
     }
 
@@ -1155,9 +1111,7 @@ async function getOrCreateProjectsCategory(): Promise<string | null> {
       (ch: { type: number; name: string }) =>
         ch.type === 4 &&
         (ch.name.toLowerCase() === baseNamePrefix.toLowerCase() ||
-          ch.name
-            .toLowerCase()
-            .startsWith(baseNamePrefix.toLowerCase() + " - batch"))
+          ch.name.toLowerCase().startsWith(baseNamePrefix.toLowerCase() + " - batch"))
     );
 
     // Sort by batch number (base name = batch 1, then Batch 2, Batch 3, etc.)
@@ -1191,10 +1145,7 @@ async function getOrCreateProjectsCategory(): Promise<string | null> {
       const currentBatch =
         latestCategory.name.toLowerCase() === baseNamePrefix.toLowerCase()
           ? 1
-          : parseInt(
-              latestCategory.name.match(/batch\s*(\d+)/i)?.[1] || "1",
-              10
-            );
+          : parseInt(latestCategory.name.match(/batch\s*(\d+)/i)?.[1] || "1", 10);
       const newBatchNum = currentBatch + 1;
       const newCategoryName = `${baseNamePrefix} - Batch ${newBatchNum}`;
 
@@ -1227,9 +1178,7 @@ export async function createProjectChannel(
   creatorDiscordUsername?: string
 ): Promise<ChannelResult | null> {
   log.debug(`Creating project channel for ${projectTitle} by ${creatorName}`);
-  log.debug(
-    `Discord username - Creator: ${creatorDiscordUsername || "not set"}`
-  );
+  log.debug(`Discord username - Creator: ${creatorDiscordUsername || "not set"}`);
 
   const guildId = getGuildId();
 
@@ -1289,20 +1238,15 @@ export async function createProjectChannel(
       channelPayload.parent_id = categoryId;
     }
 
-    const response = await fetchWithRateLimit(
-      `${DISCORD_API}/guilds/${guildId}/channels`,
-      {
-        method: "POST",
-        headers: getHeaders(),
-        body: JSON.stringify(channelPayload),
-      }
-    );
+    const response = await fetchWithRateLimit(`${DISCORD_API}/guilds/${guildId}/channels`, {
+      method: "POST",
+      headers: getHeaders(),
+      body: JSON.stringify(channelPayload),
+    });
 
     if (!response.ok) {
       const errorText = await response.text();
-      log.error(
-        `[Discord] Channel creation failed: ${response.status} - ${errorText}`
-      );
+      log.error(`[Discord] Channel creation failed: ${response.status} - ${errorText}`);
       return null;
     }
 
@@ -1310,9 +1254,7 @@ export async function createProjectChannel(
     log.debug(`Channel created: ${channel.name} (ID: ${channel.id})`);
 
     // Build mention string for creator if found
-    const creatorMention = creatorMemberId
-      ? `<@${creatorMemberId}>`
-      : `**${creatorName}**`;
+    const creatorMention = creatorMemberId ? `<@${creatorMemberId}>` : `**${creatorName}**`;
 
     // Send welcome message
     await sendChannelMessage(
@@ -1360,12 +1302,8 @@ export async function sendProjectDetailsMessage(
   try {
     // Format the details message
     const techStackText =
-      project.techStack.length > 0
-        ? project.techStack.join(", ")
-        : "Not specified";
-    const githubText = project.githubRepo
-      ? `\n**GitHub:** ${project.githubRepo}`
-      : "";
+      project.techStack.length > 0 ? project.techStack.join(", ") : "Not specified";
+    const githubText = project.githubRepo ? `\n**GitHub:** ${project.githubRepo}` : "";
 
     const message =
       `**${project.title}**\n\n` +
@@ -1374,20 +1312,15 @@ export async function sendProjectDetailsMessage(
       `**Difficulty:** ${project.difficulty}${githubText}`;
 
     // Send the message
-    const response = await fetchWithRateLimit(
-      `${DISCORD_API}/channels/${channelId}/messages`,
-      {
-        method: "POST",
-        headers: getHeaders(),
-        body: JSON.stringify({ content: message }),
-      }
-    );
+    const response = await fetchWithRateLimit(`${DISCORD_API}/channels/${channelId}/messages`, {
+      method: "POST",
+      headers: getHeaders(),
+      body: JSON.stringify({ content: message }),
+    });
 
     if (!response.ok) {
       const errorText = await response.text();
-      log.error(
-        `[Discord] Failed to send project details: ${response.status} - ${errorText}`
-      );
+      log.error(`[Discord] Failed to send project details: ${response.status} - ${errorText}`);
       return false;
     }
 
@@ -1405,9 +1338,7 @@ export async function sendProjectDetailsMessage(
 
     if (!pinResponse.ok) {
       const errorText = await pinResponse.text();
-      log.error(
-        `[Discord] Failed to pin message: ${pinResponse.status} - ${errorText}`
-      );
+      log.error(`[Discord] Failed to pin message: ${pinResponse.status} - ${errorText}`);
       return false;
     }
 
@@ -1473,9 +1404,7 @@ export async function addMemberToChannel(
       return true;
     } else {
       const errorText = await response.text();
-      log.error(
-        `[Discord] Failed to add member to channel: ${response.status} - ${errorText}`
-      );
+      log.error(`[Discord] Failed to add member to channel: ${response.status} - ${errorText}`);
       return false;
     }
   } catch (error) {
@@ -1501,10 +1430,10 @@ export async function removeMemberFromChannel(
     // Look up member by username
     const member = await lookupMemberByUsername(discordUsername);
     if (!member) {
-      log.warn(
-        `[Discord] Cannot remove member - user not found in guild`,
-        { channelId, discordUsername }
-      );
+      log.warn(`[Discord] Cannot remove member - user not found in guild`, {
+        channelId,
+        discordUsername,
+      });
       return false;
     }
 
@@ -1536,10 +1465,11 @@ export async function removeMemberFromChannel(
       return false;
     }
   } catch (error) {
-    log.error(
-      `[Discord] Error removing member from channel`,
-      { channelId, discordUsername, error }
-    );
+    log.error(`[Discord] Error removing member from channel`, {
+      channelId,
+      discordUsername,
+      error,
+    });
     return false;
   }
 }
@@ -1558,9 +1488,7 @@ export async function sendProjectSubmissionNotification(
   creatorName: string,
   projectId: string
 ): Promise<boolean> {
-  log.debug(
-    `Sending project submission notification for "${projectTitle}" by ${creatorName}`
-  );
+  log.debug(`Sending project submission notification for "${projectTitle}" by ${creatorName}`);
 
   try {
     const message =
@@ -1613,9 +1541,7 @@ export async function sendNewProjectAnnouncementToCollaborators(
   creatorName: string,
   projectId: string
 ): Promise<boolean> {
-  log.debug(
-    `Sending project collaboration announcement for "${projectTitle}" by ${creatorName}`
-  );
+  log.debug(`Sending project collaboration announcement for "${projectTitle}" by ${creatorName}`);
 
   try {
     const message =
@@ -1851,9 +1777,7 @@ export async function sendMentorChangesRequestedNotification(
   mentorName: string,
   feedback: string
 ): Promise<boolean> {
-  log.debug(
-    `Sending mentor changes requested notification to ${discordUsername}`
-  );
+  log.debug(`Sending mentor changes requested notification to ${discordUsername}`);
 
   if (!discordUsername) {
     log.warn("[Discord] Cannot send mentor changes notification - discordUsername is empty");
@@ -1880,23 +1804,24 @@ export async function sendMentorChangesRequestedNotification(
  * @param reason - Reason for deletion (added to audit log)
  * @returns true if deleted successfully (200) or already gone (404), false on other errors
  */
-export async function deleteDiscordChannel(
-  channelId: string,
-  reason: string
-): Promise<boolean> {
+export async function deleteDiscordChannel(channelId: string, reason: string): Promise<boolean> {
   log.debug(`Deleting Discord channel: ${channelId} (reason: ${reason})`);
 
+  // Guard: never delete a protected community/moderators channel, no matter
+  // which flow (mentorship end, project cleanup, bulk delete) asks. (VIS-141)
+  if (isProtectedChannel(channelId)) {
+    log.warn(`[Discord] Refusing to delete protected channel ${channelId} (reason: ${reason})`);
+    return false;
+  }
+
   try {
-    const response = await fetchWithRateLimit(
-      `${DISCORD_API}/channels/${channelId}`,
-      {
-        method: "DELETE",
-        headers: {
-          ...getHeaders(),
-          "X-Audit-Log-Reason": reason,
-        },
-      }
-    );
+    const response = await fetchWithRateLimit(`${DISCORD_API}/channels/${channelId}`, {
+      method: "DELETE",
+      headers: {
+        ...getHeaders(),
+        "X-Audit-Log-Reason": reason,
+      },
+    });
 
     if (response.ok) {
       log.debug(`Channel ${channelId} deleted successfully`);
@@ -1915,4 +1840,67 @@ export async function deleteDiscordChannel(
     log.error(`[Discord] Error deleting channel ${channelId}:`, error);
     return false;
   }
+}
+
+/**
+ * Per-member direct-message notices sent before a mentorship channel is
+ * deleted. Each message is optional — omit one to skip DMing that member.
+ * (VIS-141)
+ */
+export interface MentorshipChannelDeletionNotice {
+  /** Discord username of the mentor. */
+  mentorUsername?: string;
+  /** Discord username of the mentee. */
+  menteeUsername?: string;
+  /** DM sent to the mentor. Skipped when omitted. */
+  mentorMessage?: string;
+  /** DM sent to the mentee. Skipped when omitted. */
+  menteeMessage?: string;
+  /** Audit-log reason recorded on the Discord channel deletion. */
+  reason: string;
+}
+
+/**
+ * Delete a mentorship channel after directly notifying the affected members.
+ *
+ * Per the VIS-141 board decision, ended mentorships have their Discord channel
+ * DELETED (not archived). Because a deleted channel takes any in-channel
+ * message with it, the affected members are notified individually via DM
+ * FIRST, then the channel is removed. Protected community/moderators channels
+ * are refused by the underlying `deleteDiscordChannel` guard.
+ *
+ * DM failures never block the deletion — members may have DMs disabled or have
+ * left the server. Each outcome is reported back so callers can log it.
+ *
+ * @returns per-step outcomes: whether the channel was deleted and whether each
+ *          member DM was delivered.
+ */
+export async function deleteMentorshipChannel(
+  channelId: string,
+  notice: MentorshipChannelDeletionNotice
+): Promise<{
+  deleted: boolean;
+  mentorNotified: boolean;
+  menteeNotified: boolean;
+}> {
+  // Notify the affected members BEFORE the channel disappears. Run both DMs
+  // concurrently; a failure on one must not stop the other or the delete.
+  const [mentorNotified, menteeNotified] = await Promise.all([
+    notice.mentorUsername && notice.mentorMessage
+      ? sendDirectMessage(notice.mentorUsername, notice.mentorMessage).catch((err) => {
+          log.error("[Discord] Mentor deletion DM failed:", err);
+          return false;
+        })
+      : Promise.resolve(false),
+    notice.menteeUsername && notice.menteeMessage
+      ? sendDirectMessage(notice.menteeUsername, notice.menteeMessage).catch((err) => {
+          log.error("[Discord] Mentee deletion DM failed:", err);
+          return false;
+        })
+      : Promise.resolve(false),
+  ]);
+
+  const deleted = await deleteDiscordChannel(channelId, notice.reason);
+
+  return { deleted, mentorNotified, menteeNotified };
 }


### PR DESCRIPTION
## What & why

Per the **VIS-141** board decision (ClickUp 86canvffw), ended mentorships now **delete** their Discord channel instead of archiving it, and notify the **affected members individually by DM** before the channel disappears. The moderators / registration channel is never deleted.

Closes #137.

## Changes

- **`deleteMentorshipChannel(channelId, notice)`** helper in `src/lib/discord.ts` — DMs mentor/mentee (concurrently, failures non-blocking), then deletes the channel.
- **Protected-channel guard** in `deleteDiscordChannel` — refuses to delete the moderators/registration channel and other shared community channels (`#find-a-mentor`, project-review, project-collaboration, monthly-challenges), no matter which flow calls it. Configurable via `DISCORD_MODERATORS_CHANNEL_ID`.
- Converted every mentorship-end flow from **archive → guarded delete + individual DMs**:
  - Admin: complete, cancel (`admin/sessions/route.ts`)
  - Dashboard: complete, remove (by mentor), end (by mentee) (`dashboard/[matchId]/route.ts`)
- **Regenerate-channel** now deletes the old channel first so it isn't orphaned (GH#137 regeneration concern).
- Unit tests for the protected-channel guard and delete idempotency (10 pass).

## Acceptance criteria (VIS-141)

- [x] Channel delete triggers individual DM notifications to affected members
- [x] Moderators channel excluded from deletion flow
- [x] Closes GH#137

## Verification

- `npx vitest run src/lib/discord.test.ts` → 10/10 pass
- `npx tsc --noEmit` → clean
- `npx eslint src/lib/discord.ts` → 0 errors

## UAT steps

Requires `DISCORD_BOT_TOKEN` + `DISCORD_GUILD_ID` configured (optionally `DISCORD_MODERATORS_CHANNEL_ID`).

1. **Complete from admin dashboard** — mark an active mentorship `completed` in `/admin`. Verify: the mentorship's Discord channel is **deleted** (not archived), and both mentor and mentee receive a DM from the bot saying the mentorship was completed and the channel closed.
2. **Cancel from admin dashboard** — end an active mentorship from admin. Verify: channel deleted; both members get an "ended by administrator" DM.
3. **Mentor removes mentee** (dashboard) — verify the mentee gets a DM + the channel is deleted.
4. **Mentee ends mentorship** (dashboard) — verify the mentor gets a DM + the channel is deleted.
5. **Complete from dashboard** — verify mentee gets the rating DM, mentor gets a completion DM, channel deleted, and the `#find-a-mentor` completion announcement still posts.
6. **Moderators channel guard** — confirm the moderators/registration channel and `#find-a-mentor` remain intact after all the above (never deleted).
7. **Regenerate channel** — regenerate a session's channel from admin; verify the old channel is removed (no orphan) and a new one is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)