### PR TITLE
feat(mentorship): Request Match on public page + one-at-a-time withdrawal dialog (GH#234, GH#235)

### DIFF
--- a/src/app/api/mentorship/match/route.ts
+++ b/src/app/api/mentorship/match/route.ts
@@ -162,6 +162,39 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // One active request at a time (GH#234): reject if the mentee already has a
+    // pending request with a DIFFERENT mentor. The specific-mentor check above
+    // already rules out an existing session with this mentor, so any pending
+    // session found here belongs to another mentor. The client surfaces a
+    // withdrawal dialog using the details returned below.
+    const existingPending = await db
+      .collection("mentorship_sessions")
+      .where("menteeId", "==", menteeId)
+      .where("status", "==", "pending")
+      .limit(1)
+      .get();
+
+    if (!existingPending.empty) {
+      const pendingDoc = existingPending.docs[0];
+      const pendingMentorId = pendingDoc.data().mentorId;
+      const pendingMentorDoc = await db
+        .collection("mentorship_profiles")
+        .doc(pendingMentorId)
+        .get();
+      return NextResponse.json(
+        {
+          error: "You already have a pending mentorship request",
+          code: "pending_request_exists",
+          pendingMatchId: pendingDoc.id,
+          pendingMentorId,
+          pendingMentorName: pendingMentorDoc.exists
+            ? pendingMentorDoc.data()?.displayName
+            : undefined,
+        },
+        { status: 409 }
+      );
+    }
+
     // Check if mentee already has an active mentorship (one mentor per mentee)
     const existingActiveMentorship = await db
       .collection("mentorship_sessions")

--- a/src/app/mentorship/browse/page.tsx
+++ b/src/app/mentorship/browse/page.tsx
@@ -6,10 +6,10 @@ import { AuthContext } from "@/contexts/AuthContext";
 import { useToast } from "@/contexts/ToastContext";
 import { useMentorship, MentorshipProfile } from "@/contexts/MentorshipContext";
 import MentorCard from "@/components/mentorship/MentorCard";
+import WithdrawToProceedDialog from "@/components/mentorship/WithdrawToProceedDialog";
+import { useMatchRequests } from "@/lib/mentorship/useMatchRequests";
 import Link from "next/link";
 import { hasRole } from "@/lib/permissions";
-
-type RequestStatus = "none" | "pending" | "declined" | "active" | "completed";
 
 export default function BrowseMentorsPage() {
   const router = useRouter();
@@ -20,20 +20,21 @@ export default function BrowseMentorsPage() {
   const [loadingMentors, setLoadingMentors] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedExpertise, setSelectedExpertise] = useState<string>("");
-  const [requestingMentor, setRequestingMentor] = useState<string | null>(null);
-  const [withdrawingMentor, setWithdrawingMentor] = useState<string | null>(null);
-  // Track request status per mentor (pending, declined, active, completed, or none)
-  const [mentorRequestStatus, setMentorRequestStatus] = useState<
-    Map<string, RequestStatus>
-  >(new Map());
-  // Track session IDs and rating status for completed mentorships
-  const [mentorSessionInfo, setMentorSessionInfo] = useState<
-    Map<string, { sessionId: string; hasRated: boolean }>
-  >(new Map());
-  // Track match IDs for pending requests (needed for withdraw)
-  const [pendingMatchIds, setPendingMatchIds] = useState<Map<string, string>>(
-    new Map()
-  );
+
+  const isMentee = hasRole(profile, "mentee");
+  const {
+    statusMap,
+    sessionInfo,
+    requestingMentor,
+    withdrawingMentor,
+    conflict,
+    switching,
+    requestMatch,
+    withdraw,
+    confirmSwitch,
+    cancelConflict,
+    refresh,
+  } = useMatchRequests(user?.uid, Boolean(user && isMentee));
 
   useEffect(() => {
     if (!loading && !profileLoading && !user) {
@@ -62,143 +63,16 @@ export default function BrowseMentorsPage() {
       }
     };
 
-    if (user && hasRole(profile, "mentee")) {
+    if (user && isMentee) {
       fetchMentors();
     }
-  }, [user, profile]);
-
-  // Fetch mentee's existing requests to show correct status
-  useEffect(() => {
-    const fetchMyRequests = async () => {
-      if (!user) return;
-      try {
-        const response = await fetch(
-          `/api/mentorship/mentee-requests?menteeId=${user.uid}`,
-        );
-        if (response.ok) {
-          const data = await response.json();
-          const statusMap = new Map<string, RequestStatus>();
-          const sessionInfoMap = new Map<
-            string,
-            { sessionId: string; hasRated: boolean }
-          >();
-
-          const pendingMap = new Map<string, string>();
-
-          // Map each mentor's request status
-          for (const request of data.requests || []) {
-            statusMap.set(request.mentorId, request.status as RequestStatus);
-            // Store session info for completed mentorships to enable rating
-            if (request.status === "completed") {
-              sessionInfoMap.set(request.mentorId, {
-                sessionId: request.sessionId || request.id,
-                hasRated: request.hasRated || false,
-              });
-            }
-            // Store match IDs for pending requests to enable withdraw
-            if (request.status === "pending") {
-              pendingMap.set(request.mentorId, request.sessionId || request.id);
-            }
-          }
-
-          setMentorRequestStatus(statusMap);
-          setMentorSessionInfo(sessionInfoMap);
-          setPendingMatchIds(pendingMap);
-        }
-      } catch (error) {
-        console.error("Error fetching mentee requests:", error);
-      }
-    };
-
-    if (user && hasRole(profile, "mentee")) {
-      fetchMyRequests();
-    }
-  }, [user, profile]);
-
-  const handleRequestMatch = async (mentorId: string) => {
-    if (!user) return;
-
-    setRequestingMentor(mentorId);
-    try {
-      const response = await fetch("/api/mentorship/match", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          menteeId: user.uid,
-          mentorId,
-        }),
-      });
-
-      if (response.ok) {
-        // Update status to pending
-        setMentorRequestStatus((prev) =>
-          new Map(prev).set(mentorId, "pending"),
-        );
-      } else {
-        const error = await response.json();
-        if (response.status === 409) {
-          // Already requested - update with actual status
-          setMentorRequestStatus((prev) =>
-            new Map(prev).set(mentorId, error.status || "pending"),
-          );
-        } else {
-          toast.error("Failed to send request: " + error.error);
-        }
-      }
-    } catch (error) {
-      console.error("Error requesting match:", error);
-      toast.error("An error occurred. Please try again.");
-    } finally {
-      setRequestingMentor(null);
-    }
-  };
-
-  const handleWithdraw = async (mentorId: string) => {
-    if (!user) return;
-    const matchId = pendingMatchIds.get(mentorId);
-    if (!matchId) return;
-
-    setWithdrawingMentor(mentorId);
-    try {
-      const response = await fetch("/api/mentorship/match", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          matchId,
-          action: "withdraw",
-          menteeId: user.uid,
-        }),
-      });
-
-      if (response.ok) {
-        setMentorRequestStatus((prev) => {
-          const updated = new Map(prev);
-          updated.delete(mentorId);
-          return updated;
-        });
-        setPendingMatchIds((prev) => {
-          const updated = new Map(prev);
-          updated.delete(mentorId);
-          return updated;
-        });
-        toast.success("Request withdrawn successfully.");
-      } else {
-        const error = await response.json();
-        toast.error(error.error || "Failed to withdraw request");
-      }
-    } catch (error) {
-      console.error("Error withdrawing request:", error);
-      toast.error("Failed to withdraw request. Please try again.");
-    } finally {
-      setWithdrawingMentor(null);
-    }
-  };
+  }, [user, isMentee]);
 
   const handleRateNow = async (
     mentorId: string,
     sessionId: string,
     rating: number,
-    feedback: string,
+    feedback: string
   ) => {
     if (!user) return;
     try {
@@ -215,15 +89,7 @@ export default function BrowseMentorsPage() {
       });
 
       if (response.ok) {
-        // Update session info to mark as rated
-        setMentorSessionInfo((prev) => {
-          const updated = new Map(prev);
-          const existing = updated.get(mentorId);
-          if (existing) {
-            updated.set(mentorId, { ...existing, hasRated: true });
-          }
-          return updated;
-        });
+        await refresh();
         toast.success("Thank you for your feedback!");
       } else {
         const error = await response.json();
@@ -262,9 +128,7 @@ export default function BrowseMentorsPage() {
     return (
       <div className="card bg-base-100 shadow-xl">
         <div className="card-body text-center">
-          <h2 className="card-title justify-center text-2xl">
-            Access Required
-          </h2>
+          <h2 className="card-title justify-center text-2xl">Access Required</h2>
           <p className="text-base-content/70 mt-2">
             Please sign in and complete your mentee profile to browse mentors.
           </p>
@@ -344,20 +208,20 @@ export default function BrowseMentorsPage() {
       ) : (
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
           {filteredMentors.map((mentor) => {
-            const sessionInfo = mentorSessionInfo.get(mentor.uid);
+            const info = sessionInfo.get(mentor.uid);
             return (
               <MentorCard
                 key={mentor.uid}
                 mentor={{
                   ...mentor,
-                  sessionId: sessionInfo?.sessionId,
-                  hasRated: sessionInfo?.hasRated,
+                  sessionId: info?.sessionId,
+                  hasRated: info?.hasRated,
                 }}
-                onRequestMatch={handleRequestMatch}
+                onRequestMatch={(id) => requestMatch(id, mentor.displayName)}
                 isRequesting={requestingMentor === mentor.uid}
-                requestStatus={mentorRequestStatus.get(mentor.uid) || "none"}
+                requestStatus={statusMap.get(mentor.uid) || "none"}
                 onRateNow={handleRateNow}
-                onWithdraw={handleWithdraw}
+                onWithdraw={withdraw}
                 isWithdrawing={withdrawingMentor === mentor.uid}
                 currentUserId={user?.uid}
               />
@@ -372,6 +236,13 @@ export default function BrowseMentorsPage() {
           Showing {filteredMentors.length} of {mentors.length} mentors
         </div>
       )}
+
+      <WithdrawToProceedDialog
+        conflict={conflict}
+        isSwitching={switching}
+        onConfirm={confirmSwitch}
+        onCancel={cancelConflict}
+      />
     </div>
   );
 }

--- a/src/app/mentorship/page.tsx
+++ b/src/app/mentorship/page.tsx
@@ -7,6 +7,9 @@ import { useMentorship } from "@/contexts/MentorshipContext";
 import Link from "next/link";
 import type { PublicMentor } from "@/types/mentorship";
 import ProfileAvatar from "@/components/ProfileAvatar";
+import { hasRole } from "@/lib/permissions";
+import { useMatchRequests } from "@/lib/mentorship/useMatchRequests";
+import WithdrawToProceedDialog from "@/components/mentorship/WithdrawToProceedDialog";
 
 import DiscordValidationBanner from "@/components/mentorship/DiscordValidationBanner";
 import MentorshipHero from "@/components/mentorship/MentorshipHero";
@@ -20,9 +23,22 @@ export default function MentorshipPage() {
   const [mentors, setMentors] = useState<PublicMentor[]>([]);
   const [loadingMentors, setLoadingMentors] = useState(true);
   const [filter, setFilter] = useState("");
-  const [pendingRedirect, setPendingRedirect] = useState<
-    "mentor" | "mentee" | null
-  >(null);
+  const [pendingRedirect, setPendingRedirect] = useState<"mentor" | "mentee" | null>(null);
+  // Mentor the user intended to request before authenticating (Option A, GH#235)
+  const [pendingRequestMentorId, setPendingRequestMentorId] = useState<string | null>(null);
+
+  const isMentee = hasRole(profile, "mentee");
+  const {
+    statusMap,
+    requestingMentor,
+    withdrawingMentor,
+    conflict,
+    switching,
+    requestMatch,
+    withdraw,
+    confirmSwitch,
+    cancelConflict,
+  } = useMatchRequests(user?.uid, Boolean(user && isMentee));
 
   // Fetch public mentors
   useEffect(() => {
@@ -51,6 +67,21 @@ export default function MentorshipPage() {
     }
   }, [loading, user, pendingRedirect, router]);
 
+  // Resume a Request Match action after login (Option A, GH#235). `loading`
+  // stays true until the profile is resolved, so isMentee is reliable here.
+  useEffect(() => {
+    if (loading || !user || !pendingRequestMentorId) return;
+    const mentorId = pendingRequestMentorId;
+    setPendingRequestMentorId(null);
+    if (isMentee) {
+      const mentor = mentors.find((m) => m.uid === mentorId);
+      requestMatch(mentorId, mentor?.displayName);
+    } else {
+      // Authenticated but no mentee profile yet — send them to onboarding.
+      router.push("/mentorship/onboarding?role=mentee");
+    }
+  }, [loading, user, isMentee, pendingRequestMentorId, mentors, requestMatch, router]);
+
   const handleRoleClick = (role: "mentor" | "mentee") => {
     if (!user) {
       // Store pending redirect and show login
@@ -63,12 +94,89 @@ export default function MentorshipPage() {
     // If user has profile, they should see the dashboard button instead
   };
 
+  const handleRequestClick = (mentor: PublicMentor) => {
+    if (!user) {
+      // Unauthenticated → prompt login, then resume the request (Option A).
+      setPendingRequestMentorId(mentor.uid);
+      setShowLoginPopup(true);
+      return;
+    }
+    if (!isMentee) {
+      // Authenticated but not a mentee → onboard as mentee first.
+      router.push("/mentorship/onboarding?role=mentee");
+      return;
+    }
+    requestMatch(mentor.uid, mentor.displayName);
+  };
+
+  const renderRequestAction = (mentor: PublicMentor) => {
+    const status = statusMap.get(mentor.uid) || "none";
+
+    if (status === "pending") {
+      return (
+        <div className="flex gap-2 w-full">
+          <button type="button" className="btn btn-warning btn-sm flex-1" disabled>
+            Request Pending
+          </button>
+          <button
+            type="button"
+            className="btn btn-error btn-outline btn-sm"
+            onClick={() => withdraw(mentor.uid)}
+            disabled={withdrawingMentor === mentor.uid}
+          >
+            {withdrawingMentor === mentor.uid ? (
+              <span className="loading loading-spinner loading-sm"></span>
+            ) : (
+              "Withdraw"
+            )}
+          </button>
+        </div>
+      );
+    }
+    if (status === "active") {
+      return (
+        <button type="button" className="btn btn-success btn-sm btn-block" disabled>
+          Already Matched
+        </button>
+      );
+    }
+    if (status === "completed") {
+      return (
+        <button type="button" className="btn btn-success btn-sm btn-block" disabled>
+          Mentorship Completed
+        </button>
+      );
+    }
+    if (mentor.isAtCapacity) {
+      return (
+        <button type="button" className="btn btn-ghost btn-sm btn-block" disabled>
+          At Capacity
+        </button>
+      );
+    }
+    return (
+      <button
+        type="button"
+        className="btn btn-primary btn-sm btn-block"
+        onClick={() => handleRequestClick(mentor)}
+        disabled={requestingMentor === mentor.uid}
+      >
+        {requestingMentor === mentor.uid ? (
+          <>
+            <span className="loading loading-spinner loading-sm"></span>
+            Sending...
+          </>
+        ) : (
+          "Request Match"
+        )}
+      </button>
+    );
+  };
+
   const filteredMentors = filter
     ? mentors.filter(
         (m) =>
-          m.expertise?.some((e) =>
-            e.toLowerCase().includes(filter.toLowerCase())
-          ) ||
+          m.expertise?.some((e) => e.toLowerCase().includes(filter.toLowerCase())) ||
           m.displayName?.toLowerCase().includes(filter.toLowerCase()) ||
           m.currentRole?.toLowerCase().includes(filter.toLowerCase())
       )
@@ -78,17 +186,11 @@ export default function MentorshipPage() {
     <div className="space-y-8">
       {/* Discord Validation Warning */}
       {profile && (
-        <DiscordValidationBanner
-          discordUsernameValidated={profile.discordUsernameValidated}
-        />
+        <DiscordValidationBanner discordUsernameValidated={profile.discordUsernameValidated} />
       )}
 
       {/* Hero Section */}
-      <MentorshipHero
-        profile={profile}
-        loading={loading}
-        onRoleClickAction={handleRoleClick}
-      />
+      <MentorshipHero profile={profile} loading={loading} onRoleClickAction={handleRoleClick} />
 
       {/* Mentorship Stats from API */}
       <MentorshipStats />
@@ -104,8 +206,7 @@ export default function MentorshipPage() {
               <span className="text-primary">🌟</span> Browse Mentors
             </h3>
             <p className="text-base-content/70 text-sm">
-              Meet the amazing professionals who volunteer their time to guide
-              and support others.
+              Meet the amazing professionals who volunteer their time to guide and support others.
             </p>
           </div>
 
@@ -148,14 +249,15 @@ export default function MentorshipPage() {
                 <div className="card-body">
                   {/* Header with Avatar */}
                   <div className="flex items-start gap-4">
-                    <ProfileAvatar photoURL={mentor.photoURL} displayName={mentor.displayName} size="xl" ring />
+                    <ProfileAvatar
+                      photoURL={mentor.photoURL}
+                      displayName={mentor.displayName}
+                      size="xl"
+                      ring
+                    />
                     <div className="flex-1 min-w-0">
-                      <h3 className="card-title text-lg">
-                        {mentor.displayName}
-                      </h3>
-                      <p className="text-sm text-base-content/70 truncate">
-                        {mentor.currentRole}
-                      </p>
+                      <h3 className="card-title text-lg">{mentor.displayName}</h3>
+                      <p className="text-sm text-base-content/70 truncate">{mentor.currentRole}</p>
                     </div>
                   </div>
 
@@ -163,10 +265,7 @@ export default function MentorshipPage() {
                   {mentor.expertise && mentor.expertise.length > 0 && (
                     <div className="flex flex-wrap gap-1 mt-3">
                       {mentor.expertise.slice(0, 4).map((skill) => (
-                        <span
-                          key={skill}
-                          className="badge badge-primary badge-sm"
-                        >
+                        <span key={skill} className="badge badge-primary badge-sm">
                           {skill}
                         </span>
                       ))}
@@ -180,9 +279,7 @@ export default function MentorshipPage() {
 
                   {/* Bio */}
                   {mentor.bio && (
-                    <p className="text-sm text-base-content/70 mt-3 line-clamp-2">
-                      {mentor.bio}
-                    </p>
+                    <p className="text-sm text-base-content/70 mt-3 line-clamp-2">{mentor.bio}</p>
                   )}
 
                   {/* Stats */}
@@ -197,38 +294,32 @@ export default function MentorshipPage() {
                       <div className="text-lg font-bold text-secondary">
                         {mentor.completedMentorships}
                       </div>
-                      <div className="text-xs text-base-content/60">
-                        Completed
-                      </div>
+                      <div className="text-xs text-base-content/60">Completed</div>
                     </div>
                     <div className="text-center flex-1">
-                      <div className="text-lg font-bold text-accent">
-                        {mentor.maxMentees}
-                      </div>
+                      <div className="text-lg font-bold text-accent">{mentor.maxMentees}</div>
                       <div className="text-xs text-base-content/60">Max</div>
                     </div>
                   </div>
 
                   {/* Availability */}
-                  {mentor.availability &&
-                    Object.keys(mentor.availability).length > 0 && (
-                      <div className="flex items-center gap-1 mt-3 text-xs text-base-content/60">
-                        <span>📅</span>
-                        <span className="capitalize">
-                          {Object.keys(mentor.availability)
-                            .map(
-                              (d) => d.charAt(0).toUpperCase() + d.slice(1, 3)
-                            )
-                            .join(", ")}
-                        </span>
-                      </div>
-                    )}
+                  {mentor.availability && Object.keys(mentor.availability).length > 0 && (
+                    <div className="flex items-center gap-1 mt-3 text-xs text-base-content/60">
+                      <span>📅</span>
+                      <span className="capitalize">
+                        {Object.keys(mentor.availability)
+                          .map((d) => d.charAt(0).toUpperCase() + d.slice(1, 3))
+                          .join(", ")}
+                      </span>
+                    </div>
+                  )}
 
-                  {/* View Profile */}
-                  <div className="card-actions mt-4">
+                  {/* Actions: Request Match (Option A) + View Profile */}
+                  <div className="card-actions mt-4 flex-col gap-2">
+                    {renderRequestAction(mentor)}
                     <Link
                       href={`/mentorship/mentors/${mentor.username || mentor.uid}`}
-                      className="btn btn-primary btn-sm btn-block"
+                      className="btn btn-ghost btn-sm btn-block"
                     >
                       View Profile
                     </Link>
@@ -239,6 +330,13 @@ export default function MentorshipPage() {
           </div>
         )}
       </div>
+
+      <WithdrawToProceedDialog
+        conflict={conflict}
+        isSwitching={switching}
+        onConfirm={confirmSwitch}
+        onCancel={cancelConflict}
+      />
     </div>
   );
 }

--- a/src/components/mentorship/WithdrawToProceedDialog.tsx
+++ b/src/components/mentorship/WithdrawToProceedDialog.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { PendingConflict } from "@/lib/mentorship/useMatchRequests";
+
+interface WithdrawToProceedDialogProps {
+  conflict: PendingConflict | null;
+  isSwitching: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * One-at-a-time withdrawal dialog (GH#234). Shown when a mentee tries to
+ * request a new mentor while they already have a pending request with another
+ * mentor. Confirming withdraws the existing request and sends the new one.
+ */
+export default function WithdrawToProceedDialog({
+  conflict,
+  isSwitching,
+  onConfirm,
+  onCancel,
+}: WithdrawToProceedDialogProps) {
+  if (!conflict) return null;
+
+  const existingMentor = conflict.pendingMentorName || "another mentor";
+  const newMentor = conflict.newMentorName || "this mentor";
+
+  return (
+    <dialog className="modal modal-open">
+      <div className="modal-box">
+        <h3 className="font-bold text-lg">You already have a pending request</h3>
+        <p className="py-4 text-base-content/80">
+          You have an active mentorship request with <strong>{existingMentor}</strong>. You can only
+          have one pending request at a time. Withdraw that request to send a new one to{" "}
+          <strong>{newMentor}</strong>?
+        </p>
+        <div className="modal-action">
+          <button type="button" className="btn btn-ghost" onClick={onCancel} disabled={isSwitching}>
+            Keep existing request
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={onConfirm}
+            disabled={isSwitching}
+          >
+            {isSwitching ? (
+              <>
+                <span className="loading loading-spinner loading-sm"></span>
+                Switching...
+              </>
+            ) : (
+              "Withdraw & Request"
+            )}
+          </button>
+        </div>
+      </div>
+      <form method="dialog" className="modal-backdrop">
+        <button onClick={onCancel} disabled={isSwitching}>
+          close
+        </button>
+      </form>
+    </dialog>
+  );
+}

--- a/src/lib/mentorship/useMatchRequests.ts
+++ b/src/lib/mentorship/useMatchRequests.ts
@@ -1,0 +1,210 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useToast } from "@/contexts/ToastContext";
+
+export type RequestStatus = "none" | "pending" | "declined" | "active" | "completed";
+
+export interface PendingConflict {
+  newMentorId: string;
+  newMentorName?: string;
+  pendingMatchId: string;
+  pendingMentorName?: string;
+}
+
+/**
+ * Shared client logic for the "Request Match" flow used by both the public
+ * `/mentorship` landing page (Option A, GH#235) and the gated
+ * `/mentorship/browse` page.
+ *
+ * Enforces the "one active request at a time" policy (GH#234): when the mentee
+ * already has a pending request with a different mentor, the API responds 409
+ * with `code: "pending_request_exists"`, which this hook surfaces as a
+ * `conflict` so the caller can render a one-at-a-time withdrawal dialog.
+ */
+export function useMatchRequests(userId?: string, enabled = true) {
+  const toast = useToast();
+  const [statusMap, setStatusMap] = useState<Map<string, RequestStatus>>(new Map());
+  const [pendingMatchIds, setPendingMatchIds] = useState<Map<string, string>>(new Map());
+  const [sessionInfo, setSessionInfo] = useState<
+    Map<string, { sessionId: string; hasRated: boolean }>
+  >(new Map());
+  const [requestingMentor, setRequestingMentor] = useState<string | null>(null);
+  const [withdrawingMentor, setWithdrawingMentor] = useState<string | null>(null);
+  const [conflict, setConflict] = useState<PendingConflict | null>(null);
+  const [switching, setSwitching] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!userId) return;
+    try {
+      const res = await fetch(`/api/mentorship/mentee-requests?menteeId=${userId}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      const sm = new Map<string, RequestStatus>();
+      const pm = new Map<string, string>();
+      const si = new Map<string, { sessionId: string; hasRated: boolean }>();
+      for (const r of data.requests || []) {
+        sm.set(r.mentorId, r.status as RequestStatus);
+        if (r.status === "completed") {
+          si.set(r.mentorId, {
+            sessionId: r.sessionId || r.id,
+            hasRated: r.hasRated || false,
+          });
+        }
+        if (r.status === "pending") {
+          pm.set(r.mentorId, r.sessionId || r.id);
+        }
+      }
+      setStatusMap(sm);
+      setPendingMatchIds(pm);
+      setSessionInfo(si);
+    } catch (error) {
+      console.error("Error fetching mentee requests:", error);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    if (enabled && userId) refresh();
+  }, [enabled, userId, refresh]);
+
+  const postMatch = useCallback(
+    (mentorId: string) =>
+      fetch("/api/mentorship/match", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ menteeId: userId, mentorId }),
+      }),
+    [userId]
+  );
+
+  const requestMatch = useCallback(
+    async (mentorId: string, mentorName?: string) => {
+      if (!userId) return;
+      setRequestingMentor(mentorId);
+      try {
+        const res = await postMatch(mentorId);
+        if (res.ok) {
+          setStatusMap((prev) => new Map(prev).set(mentorId, "pending"));
+          await refresh();
+          return;
+        }
+        const err = await res.json();
+        if (res.status === 409 && err.code === "pending_request_exists") {
+          setConflict({
+            newMentorId: mentorId,
+            newMentorName: mentorName,
+            pendingMatchId: err.pendingMatchId,
+            pendingMentorName: err.pendingMentorName,
+          });
+          return;
+        }
+        if (res.status === 409 && err.status) {
+          // Existing request with THIS mentor — sync the displayed status.
+          setStatusMap((prev) => new Map(prev).set(mentorId, err.status as RequestStatus));
+          return;
+        }
+        toast.error(`Failed to send request: ${err.error || err.message || ""}`);
+      } catch (error) {
+        console.error("Error requesting match:", error);
+        toast.error("An error occurred. Please try again.");
+      } finally {
+        setRequestingMentor(null);
+      }
+    },
+    [userId, postMatch, refresh, toast]
+  );
+
+  const withdraw = useCallback(
+    async (mentorId: string) => {
+      if (!userId) return;
+      const matchId = pendingMatchIds.get(mentorId);
+      if (!matchId) return;
+      setWithdrawingMentor(mentorId);
+      try {
+        const res = await fetch("/api/mentorship/match", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            matchId,
+            action: "withdraw",
+            menteeId: userId,
+          }),
+        });
+        if (res.ok) {
+          setStatusMap((prev) => {
+            const m = new Map(prev);
+            m.delete(mentorId);
+            return m;
+          });
+          setPendingMatchIds((prev) => {
+            const m = new Map(prev);
+            m.delete(mentorId);
+            return m;
+          });
+          toast.success("Request withdrawn successfully.");
+        } else {
+          const err = await res.json();
+          toast.error(err.error || "Failed to withdraw request");
+        }
+      } catch (error) {
+        console.error("Error withdrawing request:", error);
+        toast.error("Failed to withdraw request. Please try again.");
+      } finally {
+        setWithdrawingMentor(null);
+      }
+    },
+    [userId, pendingMatchIds, toast]
+  );
+
+  /** Withdraw the existing pending request, then send the new one. */
+  const confirmSwitch = useCallback(async () => {
+    if (!userId || !conflict) return;
+    setSwitching(true);
+    try {
+      const wr = await fetch("/api/mentorship/match", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          matchId: conflict.pendingMatchId,
+          action: "withdraw",
+          menteeId: userId,
+        }),
+      });
+      if (!wr.ok) {
+        const err = await wr.json();
+        toast.error(err.error || "Failed to withdraw existing request");
+        return;
+      }
+      const res = await postMatch(conflict.newMentorId);
+      if (res.ok) {
+        toast.success("Request sent!");
+        setConflict(null);
+        await refresh();
+      } else {
+        const err = await res.json();
+        toast.error(`Failed to send request: ${err.error || err.message || ""}`);
+        await refresh();
+      }
+    } catch (error) {
+      console.error("Error switching request:", error);
+      toast.error("An error occurred. Please try again.");
+    } finally {
+      setSwitching(false);
+    }
+  }, [userId, conflict, postMatch, refresh, toast]);
+
+  return {
+    statusMap,
+    pendingMatchIds,
+    sessionInfo,
+    requestingMentor,
+    withdrawingMentor,
+    conflict,
+    switching,
+    requestMatch,
+    withdraw,
+    confirmSwitch,
+    cancelConflict: () => setConflict(null),
+    refresh,
+  };
+}


### PR DESCRIPTION
## What & why

Implements Ahsan's board decision (VIS-139 / VIS-143) for the mentorship Request Match flow.

**Option A — public page (GH#235)**
- Adds a **Request Match** button to each mentor card on the public `/mentorship` page.
- Unauthenticated users → login popup; the request **resumes automatically** after they log in.
- Authenticated users without a mentee profile → routed to `/mentorship/onboarding?role=mentee`.
- Authenticated mentees → existing request flow, with live status (Pending / Withdraw / Already Matched / At Capacity).

**One active request at a time (GH#234)**
- Button stays **enabled** (not disabled). When a mentee already has a pending request with a *different* mentor, a **withdrawal dialog** appears (one match at a time): withdraw the existing request → send the new one.
- Enforced **server-side** in `POST /api/mentorship/match`: returns `409 { code: "pending_request_exists", pendingMatchId, pendingMentorName }` when a pending request already exists elsewhere.

## Implementation
- New `useMatchRequests` hook centralizes request/withdraw/conflict logic so the public landing page and gated `/mentorship/browse` page behave identically (browse page refactored onto it — net code reduction).
- New `WithdrawToProceedDialog` component renders the one-at-a-time confirmation.

## Verification
- ✅ `tsc --noEmit` clean
- ✅ `eslint` clean on changed files
- ✅ `next build` compiles successfully

## Testing (UAT)
See linked ClickUp ticket for step-by-step UAT. Requires a mentee account + at least two public mentors.

Closes #234
Closes #235