### PR TITLE
feat(challenges): add email column to admin submissions page (#279)

### DIFF
--- a/src/app/admin/challenges/[id]/submissions/page.tsx
+++ b/src/app/admin/challenges/[id]/submissions/page.tsx
@@ -59,6 +59,7 @@ export default function AdminChallengeSubmissionsPage() {
             <thead>
               <tr>
                 <th>User</th>
+                <th>Email</th>
                 <th>Repo</th>
                 <th>Demo</th>
                 <th>LinkedIn</th>
@@ -81,6 +82,15 @@ export default function AdminChallengeSubmissionsPage() {
                       )}
                       <span className="font-medium">{s.userName}</span>
                     </div>
+                  </td>
+                  <td>
+                    {s.userEmail ? (
+                      <a href={`mailto:${s.userEmail}`} className="link link-primary text-sm">
+                        {s.userEmail}
+                      </a>
+                    ) : (
+                      <span className="text-base-content/40 text-sm">—</span>
+                    )}
                   </td>
                   <td>
                     <a

--- a/src/services/ChallengeService.ts
+++ b/src/services/ChallengeService.ts
@@ -426,6 +426,7 @@ export async function getSubmissionsForChallenge(challengeId: string): Promise<S
 /**
  * Retrieves ALL submissions for a challenge regardless of status.
  * For admin use only — do not expose on public endpoints.
+ * Also joins participant email from challenge_participants for each submitter.
  *
  * @param challengeId The ID of the challenge.
  * @returns An array of Submissions ordered by submission date descending.
@@ -436,8 +437,23 @@ export async function getAllSubmissionsForChallenge(challengeId: string): Promis
     .where("challengeId", "==", challengeId)
     .orderBy("submittedAt", "desc");
 
-  const snapshot = await query.get();
-  return snapshot.docs.map((doc) => normalizeSubmission(doc));
+  const [snapshot, participantsSnap] = await Promise.all([
+    query.get(),
+    db.collection(CHALLENGE_PARTICIPANTS_COLLECTION).where("challengeId", "==", challengeId).get(),
+  ]);
+
+  const emailByUserId = new Map<string, string>();
+  for (const doc of participantsSnap.docs) {
+    const p = normalizeParticipant(doc);
+    if (p.email) emailByUserId.set(p.userId, p.email);
+  }
+
+  return snapshot.docs.map((doc) => {
+    const submission = normalizeSubmission(doc);
+    const email = emailByUserId.get(submission.userId);
+    if (email) submission.userEmail = email;
+    return submission;
+  });
 }
 
 /**

--- a/src/types/challenges.ts
+++ b/src/types/challenges.ts
@@ -46,6 +46,7 @@ export interface Submission {
   userId: string;
   userName: string;
   userAvatar?: string;
+  userEmail?: string; // Admin-only — populated from participant record; never exposed on public endpoints
   repoUrl: string;
   demoUrl?: string;
   linkedinUrl: string;


### PR DESCRIPTION
## Problem

Fixes #279 — the admin challenge submissions page was missing an email column, making it difficult to send certificates to participants.

## Solution

- Added optional `userEmail?: string` to the `Submission` type (admin-only field, never exposed on public endpoints)
- Updated `getAllSubmissionsForChallenge` to fetch participant records in parallel and join email data per submitter (participant email was already stored at join time in `ChallengeParticipant`)
- Added **Email** column to the admin submissions table with a `mailto:` link for convenience; shows `—` when no email is available

## UAT Steps

1. Navigate to `/admin/challenges`
2. Click **Submissions** for any challenge that has submissions
3. Verify a new **Email** column appears in the submissions table
4. Verify rows show the submitter's email as a `mailto:` link (or `—` if unavailable)
5. Verify all other columns (User, Repo, Demo, LinkedIn, Status, Score, Submitted At) still display correctly