### PR TITLE
fix(projects): notify owner when admin declines update request (GH#282)

### DIFF
--- a/src/app/api/admin/projects/[id]/route.ts
+++ b/src/app/api/admin/projects/[id]/route.ts
@@ -10,29 +10,20 @@ import {
 } from "@/lib/discord";
 import { Project } from "next/dist/build/swc/types";
 
-export async function PUT(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     // Phase 1: Authentication
     const token = request.headers.get("x-admin-token");
 
     if (!token) {
-      return NextResponse.json(
-        { error: "Admin authentication required" },
-        { status: 401 },
-      );
+      return NextResponse.json({ error: "Admin authentication required" }, { status: 401 });
     }
 
     // Verify admin session
     const sessionDoc = await db.collection("admin_sessions").doc(token).get();
 
     if (!sessionDoc.exists) {
-      return NextResponse.json(
-        { error: "Admin authentication required" },
-        { status: 401 },
-      );
+      return NextResponse.json({ error: "Admin authentication required" }, { status: 401 });
     }
 
     const session = sessionDoc.data()!;
@@ -41,10 +32,7 @@ export async function PUT(
     if (expiresAt < new Date()) {
       // Session expired, delete it
       await db.collection("admin_sessions").doc(token).delete();
-      return NextResponse.json(
-        { error: "Admin authentication required" },
-        { status: 401 },
-      );
+      return NextResponse.json({ error: "Admin authentication required" }, { status: 401 });
     }
 
     // Parse request body
@@ -68,7 +56,7 @@ export async function PUT(
       if (projectData.status !== "pending") {
         return NextResponse.json(
           { error: "Only pending projects can be approved" },
-          { status: 400 },
+          { status: 400 }
         );
       }
 
@@ -97,7 +85,7 @@ export async function PUT(
           projectData.title || "Untitled Project",
           projectData.creatorProfile?.displayName || "Creator",
           projectId,
-          creatorData?.discordUsername,
+          creatorData?.discordUsername
         );
 
         if (channelResult) {
@@ -131,21 +119,18 @@ export async function PUT(
           discordChannelId,
           discordChannelUrl,
         },
-        { status: 200 },
+        { status: 200 }
       );
     } else if (action === "decline") {
       // Validate decline reason
       if (!declineReason || typeof declineReason !== "string") {
-        return NextResponse.json(
-          { error: "Decline reason is required" },
-          { status: 400 },
-        );
+        return NextResponse.json({ error: "Decline reason is required" }, { status: 400 });
       }
 
       if (declineReason.length < 10) {
         return NextResponse.json(
           { error: "Decline reason must be at least 10 characters" },
-          { status: 400 },
+          { status: 400 }
         );
       }
 
@@ -153,7 +138,7 @@ export async function PUT(
       if (projectData.status !== "pending") {
         return NextResponse.json(
           { error: "Only pending projects can be declined" },
-          { status: 400 },
+          { status: 400 }
         );
       }
 
@@ -179,8 +164,7 @@ export async function PUT(
           const discordUsername = creatorData?.discordUsername;
 
           if (discordUsername) {
-            const siteUrl =
-              process.env.NEXT_PUBLIC_SITE_URL || "https://codewithahsan.dev";
+            const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://codewithahsan.dev";
             const dmMessage =
               `Your project "${projectData.title}" was not approved.\n\n` +
               `**Reason:** ${declineReason}\n\n` +
@@ -193,20 +177,11 @@ export async function PUT(
         }
       }
 
-      return NextResponse.json(
-        { success: true, message: "Project declined" },
-        { status: 200 },
-      );
+      return NextResponse.json({ success: true, message: "Project declined" }, { status: 200 });
     } else if (action === "approve_update") {
       // Approve pending updates
-      if (
-        projectData.status !== "update_pending" ||
-        !projectData.pendingUpdates
-      ) {
-        return NextResponse.json(
-          { error: "No pending updates to approve" },
-          { status: 400 },
-        );
+      if (projectData.status !== "update_pending" || !projectData.pendingUpdates) {
+        return NextResponse.json({ error: "No pending updates to approve" }, { status: 400 });
       }
 
       // Apply pending updates - only allow explicit fields to prevent injection
@@ -219,9 +194,7 @@ export async function PUT(
         "maxTeamSize",
       ];
       const safeUpdates = Object.fromEntries(
-        Object.entries(projectData.pendingUpdates).filter(([key]) =>
-          allowedFields.includes(key),
-        ),
+        Object.entries(projectData.pendingUpdates).filter(([key]) => allowedFields.includes(key))
       );
 
       const applyUpdates: Partial<Project> & Record<string, unknown> = {
@@ -263,18 +236,12 @@ export async function PUT(
 
       return NextResponse.json(
         { success: true, message: "Project updates approved and applied" },
-        { status: 200 },
+        { status: 200 }
       );
     } else if (action === "decline_update") {
       // Decline pending updates
-      if (
-        projectData.status !== "update_pending" ||
-        !projectData.pendingUpdates
-      ) {
-        return NextResponse.json(
-          { error: "No pending updates to decline" },
-          { status: 400 },
-        );
+      if (projectData.status !== "update_pending" || !projectData.pendingUpdates) {
+        return NextResponse.json({ error: "No pending updates to decline" }, { status: 400 });
       }
 
       // Clear pending updates
@@ -299,10 +266,11 @@ export async function PUT(
           const creatorData = creatorDoc.exists ? creatorDoc.data() : null;
           const discordUsername = creatorData?.discordUsername;
 
-          if (discordUsername && declineReason) {
-            const dmMessage =
-              `Your update request for project "${projectData.title}" was not approved.\n\n` +
-              `**Reason:** ${declineReason}`;
+          if (discordUsername) {
+            const dmMessage = declineReason
+              ? `Your update request for project "${projectData.title}" was not approved.\n\n` +
+                `**Reason:** ${declineReason}`
+              : `Your update request for project "${projectData.title}" was not approved.`;
             await sendDirectMessage(discordUsername, dmMessage);
           }
         } catch (error) {
@@ -312,43 +280,34 @@ export async function PUT(
 
       return NextResponse.json(
         { success: true, message: "Project updates declined" },
-        { status: 200 },
+        { status: 200 }
       );
     } else {
       return NextResponse.json({ error: "Invalid action" }, { status: 400 });
     }
   } catch (error) {
     console.error("Error updating project:", error);
-    return NextResponse.json(
-      { error: "Failed to update project" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to update project" }, { status: 500 });
   }
 }
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     // Phase 1: Authentication and Validation
     const token = request.headers.get("x-admin-token");
 
     if (!token) {
-      return NextResponse.json(
-        { error: "Admin authentication required" },
-        { status: 401 },
-      );
+      return NextResponse.json({ error: "Admin authentication required" }, { status: 401 });
     }
 
     // Verify admin session
     const sessionDoc = await db.collection("admin_sessions").doc(token).get();
 
     if (!sessionDoc.exists) {
-      return NextResponse.json(
-        { error: "Admin authentication required" },
-        { status: 401 },
-      );
+      return NextResponse.json({ error: "Admin authentication required" }, { status: 401 });
     }
 
     const session = sessionDoc.data();
@@ -357,10 +316,7 @@ export async function DELETE(
     if (expiresAt < new Date()) {
       // Session expired, delete it
       await db.collection("admin_sessions").doc(token).delete();
-      return NextResponse.json(
-        { error: "Admin authentication required" },
-        { status: 401 },
-      );
+      return NextResponse.json({ error: "Admin authentication required" }, { status: 401 });
     }
 
     // Parse request body for reason
@@ -368,16 +324,13 @@ export async function DELETE(
     const { reason } = body;
 
     if (!reason || typeof reason !== "string") {
-      return NextResponse.json(
-        { error: "Deletion reason is required" },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Deletion reason is required" }, { status: 400 });
     }
 
     if (reason.length < 10) {
       return NextResponse.json(
         { error: "Deletion reason must be at least 10 characters" },
-        { status: 400 },
+        { status: 400 }
       );
     }
 
@@ -393,18 +346,9 @@ export async function DELETE(
 
     // Phase 2: Gather Related Data
     const [membersSnap, applicationsSnap, invitationsSnap] = await Promise.all([
-      db
-        .collection("project_members")
-        .where("projectId", "==", projectId)
-        .get(),
-      db
-        .collection("project_applications")
-        .where("projectId", "==", projectId)
-        .get(),
-      db
-        .collection("project_invitations")
-        .where("projectId", "==", projectId)
-        .get(),
+      db.collection("project_members").where("projectId", "==", projectId).get(),
+      db.collection("project_applications").where("projectId", "==", projectId).get(),
+      db.collection("project_invitations").where("projectId", "==", projectId).get(),
     ]);
 
     // Collect Discord usernames for notifications
@@ -432,16 +376,15 @@ export async function DELETE(
         // Channel exists, try to delete it
         const deleted = await deleteDiscordChannel(
           projectData.discordChannelId,
-          `Admin deletion: ${reason}`,
+          `Admin deletion: ${reason}`
         );
 
         if (!deleted) {
           return NextResponse.json(
             {
-              error:
-                "Failed to delete Discord channel. Cannot proceed with atomic deletion.",
+              error: "Failed to delete Discord channel. Cannot proceed with atomic deletion.",
             },
-            { status: 500 },
+            { status: 500 }
           );
         }
       }
@@ -474,12 +417,12 @@ export async function DELETE(
 
     const notificationResults = await Promise.allSettled(
       Array.from(discordUsernames).map((username) =>
-        sendDirectMessage(username, notificationMessage),
-      ),
+        sendDirectMessage(username, notificationMessage)
+      )
     );
 
     const notificationSuccess = notificationResults.filter(
-      (r) => r.status === "fulfilled" && r.value === true,
+      (r) => r.status === "fulfilled" && r.value === true
     ).length;
     const notificationFailed = notificationResults.length - notificationSuccess;
 
@@ -498,40 +441,28 @@ export async function DELETE(
           notificationsFailed: notificationFailed,
         },
       },
-      { status: 200 },
+      { status: 200 }
     );
   } catch (error) {
     console.error("Error deleting project:", error);
-    return NextResponse.json(
-      { error: "Failed to delete project" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to delete project" }, { status: 500 });
   }
 }
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     // Phase 1: Authentication
     const token = request.headers.get("x-admin-token");
 
     if (!token) {
-      return NextResponse.json(
-        { error: "Admin authentication required" },
-        { status: 401 },
-      );
+      return NextResponse.json({ error: "Admin authentication required" }, { status: 401 });
     }
 
     // Verify admin session
     const sessionDoc = await db.collection("admin_sessions").doc(token).get();
 
     if (!sessionDoc.exists) {
-      return NextResponse.json(
-        { error: "Admin authentication required" },
-        { status: 401 },
-      );
+      return NextResponse.json({ error: "Admin authentication required" }, { status: 401 });
     }
 
     const session = sessionDoc.data();
@@ -540,10 +471,7 @@ export async function PATCH(
     if (expiresAt < new Date()) {
       // Session expired, delete it
       await db.collection("admin_sessions").doc(token).delete();
-      return NextResponse.json(
-        { error: "Admin authentication required" },
-        { status: 401 },
-      );
+      return NextResponse.json({ error: "Admin authentication required" }, { status: 401 });
     }
 
     // Phase 2: Parse and validate request
@@ -551,34 +479,23 @@ export async function PATCH(
     const body = await request.json();
 
     // Allowed editable fields
-    const {
-      title,
-      description,
-      githubRepo,
-      techStack,
-      difficulty,
-      maxTeamSize,
-    } = body;
+    const { title, description, githubRepo, techStack, difficulty, maxTeamSize } = body;
 
     // Validation
     if (title !== undefined) {
       if (typeof title !== "string" || title.length < 3 || title.length > 100) {
         return NextResponse.json(
           { error: "Title must be between 3 and 100 characters" },
-          { status: 400 },
+          { status: 400 }
         );
       }
     }
 
     if (description !== undefined) {
-      if (
-        typeof description !== "string" ||
-        description.length < 10 ||
-        description.length > 2000
-      ) {
+      if (typeof description !== "string" || description.length < 10 || description.length > 2000) {
         return NextResponse.json(
           { error: "Description must be between 10 and 2000 characters" },
-          { status: 400 },
+          { status: 400 }
         );
       }
     }
@@ -588,36 +505,26 @@ export async function PATCH(
       if (!githubRepo.startsWith("https://github.com/")) {
         return NextResponse.json(
           { error: "GitHub URL must start with https://github.com/" },
-          { status: 400 },
+          { status: 400 }
         );
       }
     }
 
     if (techStack !== undefined && !Array.isArray(techStack)) {
-      return NextResponse.json(
-        { error: "techStack must be an array" },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "techStack must be an array" }, { status: 400 });
     }
 
     if (difficulty !== undefined) {
       if (!["beginner", "intermediate", "advanced"].includes(difficulty)) {
-        return NextResponse.json(
-          { error: "Invalid difficulty level" },
-          { status: 400 },
-        );
+        return NextResponse.json({ error: "Invalid difficulty level" }, { status: 400 });
       }
     }
 
     if (maxTeamSize !== undefined) {
-      if (
-        typeof maxTeamSize !== "number" ||
-        maxTeamSize < 1 ||
-        maxTeamSize > 20
-      ) {
+      if (typeof maxTeamSize !== "number" || maxTeamSize < 1 || maxTeamSize > 20) {
         return NextResponse.json(
           { error: "maxTeamSize must be between 1 and 20" },
-          { status: 400 },
+          { status: 400 }
         );
       }
     }
@@ -659,17 +566,13 @@ export async function PATCH(
       createdAt: updatedData?.createdAt?.toDate?.()?.toISOString() || null,
       updatedAt: updatedData?.updatedAt?.toDate?.()?.toISOString() || null,
       approvedAt: updatedData?.approvedAt?.toDate?.()?.toISOString() || null,
-      lastActivityAt:
-        updatedData?.lastActivityAt?.toDate?.()?.toISOString() || null,
+      lastActivityAt: updatedData?.lastActivityAt?.toDate?.()?.toISOString() || null,
       completedAt: updatedData?.completedAt?.toDate?.()?.toISOString() || null,
     };
 
     return NextResponse.json({ success: true, project }, { status: 200 });
   } catch (error) {
     console.error("Error updating project:", error);
-    return NextResponse.json(
-      { error: "Failed to update project" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to update project" }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary

Fixes GH#282 — project owner received **no notification when an admin declined their update request**, while approvals worked. Partial regression from the approve/decline update-notification work.

## Root cause

In `PUT /api/admin/projects/[id]` the `decline_update` branch gated the Discord DM on a **truthy `declineReason`**:

```ts
if (discordUsername && declineReason) { ... }
```

But the admin UI (`src/app/admin/projects/page.tsx`) treats the decline reason as **optional** (label literally says "Decline Reason (optional)", default `""`). When an admin declined without typing a reason, `declineReason` was `""` (falsy) → the DM never fired. The `approve_update` branch has no such guard, so approvals always notified.

## Fix

Send the DM whenever the creator has a Discord username; include the reason line only when a reason was actually provided:

```ts
if (discordUsername) {
  const dmMessage = declineReason
    ? `...was not approved.\n\n**Reason:** ${declineReason}`
    : `...was not approved.`;
  await sendDirectMessage(discordUsername, dmMessage);
}
```

## Note on diff size

The pre-commit hook (`lint-staged` → `prettier --write`) reformatted the whole file to the repo's Prettier config (printWidth 100). **The only semantic change is the `decline_update` block** — everything else is auto-format. Review with `git diff -w` to isolate the logic change.

## Testing

Typecheck passes. Manual UAT steps in the ClickUp ticket — decline an update request with and without a reason, confirm the owner gets a Discord DM in both cases.

Co-Authored-By: Paperclip <noreply@paperclip.ing>