### PR TITLE
fix(submissions): repair Submit Project dialog — React-controlled visibility + auth guard (GH#281)

### DIFF
--- a/src/app/courses/[course]/submissions/page.tsx
+++ b/src/app/courses/[course]/submissions/page.tsx
@@ -51,13 +51,14 @@ export default function SubmissionsPage() {
   const [submissions, setSubmissions] = useState<SubmissionItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [user, setUser] = useState<User | null>(null);
+  const [authLoading, setAuthLoading] = useState(true);
   const [isDeletingSubmission, setIsDeletingSubmission] = useState(false);
 
   useEffect(() => {
     const { auth } = getFirebaseServices();
-    setUser(auth.currentUser);
     const sub = auth.onAuthStateChanged((authUser) => {
       setUser(authUser);
+      setAuthLoading(false);
     });
     return () => sub();
   }, []);
@@ -88,9 +89,7 @@ export default function SubmissionsPage() {
     getSubmissions();
   }, [getSubmissions]);
 
-  const deleteProjectFileIfExists = async (
-    docRef: DocumentReference<DocumentData>
-  ) => {
+  const deleteProjectFileIfExists = async (docRef: DocumentReference<DocumentData>) => {
     const existingDoc = await getDoc(docRef);
     if (existingDoc.exists()) {
       const { storage } = getFirebaseServices();
@@ -105,10 +104,7 @@ export default function SubmissionsPage() {
     setIsDeletingSubmission(true);
     try {
       const { firestore } = getFirebaseServices();
-      const docRef = doc(
-        firestore,
-        `cwa-web/project-submissions/${courseSlug}/${user.uid}`
-      );
+      const docRef = doc(firestore, `cwa-web/project-submissions/${courseSlug}/${user.uid}`);
       await deleteProjectFileIfExists(docRef);
       await deleteDoc(docRef);
       getSubmissions();
@@ -131,15 +127,12 @@ export default function SubmissionsPage() {
     <div className="page-padding">
       <header className="mb-6">
         <h1 className="text-4xl text-center">Submissions</h1>
-        {course && (
-          <h2 className="text-xl mt-2 text-center text-base-content/70">
-            {course.name}
-          </h2>
-        )}
+        {course && <h2 className="text-xl mt-2 text-center text-base-content/70">{course.name}</h2>}
       </header>
 
       <SubmissionWrapper
         user={user}
+        authLoading={authLoading}
         submissionUrl={`cwa-web/project-submissions/${courseSlug}/${user?.uid}`}
         submissionDone={getSubmissions}
         submissionParams={{
@@ -183,11 +176,7 @@ export default function SubmissionsPage() {
 
                 <div className="p-5 border-t border-base-200">
                   <div className="flex items-center gap-4">
-                    <ProfileAvatar
-                      photoURL={sub.by.photoURL}
-                      displayName={sub.by.name}
-                      size="md"
-                    />
+                    <ProfileAvatar photoURL={sub.by.photoURL} displayName={sub.by.name} size="md" />
                     <a
                       href={sub.demoLink}
                       target="_blank"
@@ -204,9 +193,7 @@ export default function SubmissionsPage() {
             ))}
           </ul>
         ) : (
-          <h2 className="text-2xl text-center my-8 text-base-content/60">
-            No submissions yet
-          </h2>
+          <h2 className="text-2xl text-center my-8 text-base-content/60">No submissions yet</h2>
         )}
       </SubmissionWrapper>
     </div>

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -1,27 +1,25 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useEffect } from "react";
 import Spinner from "./Spinner";
 
 const Dialog = ({ show, onClose, actions, children, isLoading, title }) => {
-  const toggleModal = useCallback(() => {
+  useEffect(() => {
     const body = document.querySelector("body");
-    const modal = document.querySelector(".modal");
-    if (!show) {
-      modal.classList.add("opacity-0");
-      modal.classList.add("pointer-events-none");
-      body.classList.remove("modal-active");
-    } else {
-      modal.classList.remove("opacity-0");
-      modal.classList.remove("pointer-events-none");
+    if (show) {
       body.classList.add("modal-active");
+    } else {
+      body.classList.remove("modal-active");
     }
+    return () => {
+      body.classList.remove("modal-active");
+    };
   }, [show]);
 
-  useEffect(() => {
-    toggleModal();
-  }, [show, toggleModal]);
-
   return (
-    <div className="modal z-50 opacity-0 pointer-events-none fixed w-full h-full top-0 left-0 flex items-center justify-center">
+    <div
+      className={`modal z-50 fixed w-full h-full top-0 left-0 flex items-center justify-center transition-opacity duration-300 ease ${
+        show ? "" : "opacity-0 pointer-events-none"
+      }`}
+    >
       <div className="modal-overlay absolute w-full h-full bg-gray-900 opacity-50"></div>
 
       <div className="modal-container bg-base-100 text-base-content w-11/12 md:max-w-md mx-auto rounded shadow-lg z-50 overflow-y-auto">
@@ -30,8 +28,8 @@ const Dialog = ({ show, onClose, actions, children, isLoading, title }) => {
             <header>
               <h2 className="text-2xl font-bold">{title || "I am a dialog"}</h2>
               <p className="text-sm my-1 pr-4">
-                Paste the link of your project (GitHub, CodePen, etc) and attach
-                the screenshot of the running project
+                Paste the link of your project (GitHub, CodePen, etc) and attach the screenshot of
+                the running project
               </p>
             </header>
             <button

--- a/src/components/SubmissionWrapper.js
+++ b/src/components/SubmissionWrapper.js
@@ -16,6 +16,7 @@ function getFirebaseServices() {
 
 export default function SubmissionWrapper({
   user,
+  authLoading = false,
   submissionUrl,
   submissionDone,
   submissionParams,
@@ -158,7 +159,12 @@ export default function SubmissionWrapper({
   return (
     <>
       <div className="flex items-center justify-end mb-4">
-        <Button color="primary" title="Submit your project" onClick={newSubmission}>
+        <Button
+          color="primary"
+          title="Submit your project"
+          onClick={newSubmission}
+          disabled={authLoading}
+        >
           {submitButtonText || "+"}
         </Button>
       </div>


### PR DESCRIPTION
## Summary

Fixes #281 — Submit Project button still not working after PR #252.

Two bugs combined to make the Submit Project button appear dead:

### Bug 1: `Dialog.js` used fragile DOM manipulation

`document.querySelector(".modal")` grabs **the first** `.modal` in the DOM. If any other component with a `.modal` class appears before the Dialog, the selector manipulates the wrong element. If the Dialog hasn't painted yet when the `useEffect` runs, it returns `null` and throws a `TypeError` — silently swallowing the show request.

**Fix:** Remove the `useCallback`/`useEffect` DOM manipulation entirely. Let React control visibility directly via the `show` prop in the className. The CSS transition in `layout.css` (`.modal { transition: opacity 0.25s ease }`) still applies. `body.modal-active` is still set/cleared by a simple `useEffect`.

### Bug 2: Auth race condition on cold page load

`submissions/page.tsx` set `user` via `auth.currentUser` (synchronous — can be `null` while Firebase restores auth from IndexedDB) before `onAuthStateChanged` fired. On a direct URL load, clicking Submit in that window sent `user=null` to `SubmissionWrapper` → `setShowLoginPopup(true)` with no visible result.

**Fix:** Remove the sync `auth.currentUser` read; rely solely on `onAuthStateChanged`. Track `authLoading=true` until it fires, and pass `authLoading` to `SubmissionWrapper` to disable the button until auth is confirmed.

## Files changed

- `src/components/Dialog.js` — React-controlled className instead of DOM querySelector
- `src/components/SubmissionWrapper.js` — accept `authLoading` prop; disable button while auth loading
- `src/app/courses/[course]/submissions/page.tsx` — add `authLoading` state; pass to `SubmissionWrapper`

## Test plan

- [ ] Log in, navigate to `/courses/<any-course>/submissions` — Submit Project button is disabled for ~200ms while auth resolves, then becomes clickable
- [ ] Click Submit Project — dialog opens immediately
- [ ] Fill in screenshot + demo link → Save → submission appears in list
- [ ] Log out, navigate to same page — clicking Submit Project shows login popup
- [ ] Verify no regressions on assignment submission in PostDetail (different `SubmissionWrapper` usage)