### PR TITLE
fix(roadmaps): show pending roadmaps to admins (GH#296)

### DIFF
--- a/src/__tests__/permissions.test.ts
+++ b/src/__tests__/permissions.test.ts
@@ -14,6 +14,7 @@ import {
   canManageProjectMembers,
   canApplyToProject,
   canEditRoadmap,
+  canViewRoadmap,
   hasRole,
   hasAnyRole,
   hasAllRoles,
@@ -233,9 +234,7 @@ describe("Permission System", () => {
     });
 
     it("returns true for accepted mentor (owner)", () => {
-      expect(canManageProjectMembers(acceptedMentorOwner, testProject)).toBe(
-        true
-      );
+      expect(canManageProjectMembers(acceptedMentorOwner, testProject)).toBe(true);
     });
 
     it("returns false for accepted mentor (non-owner)", () => {
@@ -448,9 +447,7 @@ describe("hasAnyRole (new helper)", () => {
   };
 
   it("returns true when at least one argument role is present", () => {
-    expect(hasAnyRole(multiProfile, ["mentor", "alumni-ambassador"])).toBe(
-      true
-    );
+    expect(hasAnyRole(multiProfile, ["mentor", "alumni-ambassador"])).toBe(true);
   });
 
   it("returns true when the profile has all argument roles", () => {
@@ -459,9 +456,7 @@ describe("hasAnyRole (new helper)", () => {
 
   it("returns true for alumni-ambassador match", () => {
     expect(hasAnyRole(alumniMulti, ["alumni-ambassador"])).toBe(true);
-    expect(hasAnyRole(alumniMulti, ["ambassador", "alumni-ambassador"])).toBe(
-      true
-    );
+    expect(hasAnyRole(alumniMulti, ["ambassador", "alumni-ambassador"])).toBe(true);
   });
 
   it("returns true for mentee-only profile when mentee is requested", () => {
@@ -470,9 +465,7 @@ describe("hasAnyRole (new helper)", () => {
   });
 
   it("returns false when no argument role is present", () => {
-    expect(hasAnyRole(multiProfile, ["mentee", "alumni-ambassador"])).toBe(
-      false
-    );
+    expect(hasAnyRole(multiProfile, ["mentee", "alumni-ambassador"])).toBe(false);
   });
 
   it("returns false for empty argument array", () => {
@@ -482,9 +475,7 @@ describe("hasAnyRole (new helper)", () => {
 
   it("returns false for empty profile.roles array", () => {
     expect(hasAnyRole(emptyProfile, ["mentor"])).toBe(false);
-    expect(hasAnyRole(emptyProfile, ["mentor", "mentee", "ambassador"])).toBe(
-      false
-    );
+    expect(hasAnyRole(emptyProfile, ["mentor", "mentee", "ambassador"])).toBe(false);
   });
 
   it("returns false for null/undefined profile", () => {
@@ -530,13 +521,9 @@ describe("hasAllRoles (new helper)", () => {
   });
 
   it("returns true when profile has all three argument roles", () => {
-    expect(
-      hasAllRoles(tripleRoleProfile, [
-        "mentor",
-        "ambassador",
-        "alumni-ambassador",
-      ])
-    ).toBe(true);
+    expect(hasAllRoles(tripleRoleProfile, ["mentor", "ambassador", "alumni-ambassador"])).toBe(
+      true
+    );
   });
 
   it("returns true for single-role mentor profile asked for mentor", () => {
@@ -549,9 +536,7 @@ describe("hasAllRoles (new helper)", () => {
 
   it("returns false when profile is missing one argument role", () => {
     expect(hasAllRoles(mentorOnly, ["mentor", "ambassador"])).toBe(false);
-    expect(
-      hasAllRoles(multiProfile, ["mentor", "ambassador", "alumni-ambassador"])
-    ).toBe(false);
+    expect(hasAllRoles(multiProfile, ["mentor", "ambassador", "alumni-ambassador"])).toBe(false);
   });
 
   it("returns true (vacuous) for empty argument array", () => {
@@ -599,9 +584,7 @@ describe("claim-side helpers (hasRoleClaim / hasAnyRoleClaim / hasAllRoleClaimsC
 
   it("hasAnyRoleClaim honors multi-role intent", () => {
     expect(hasAnyRoleClaim(arrayClaim, ["mentee", "ambassador"])).toBe(true);
-    expect(hasAnyRoleClaim(arrayClaim, ["mentee", "alumni-ambassador"])).toBe(
-      false
-    );
+    expect(hasAnyRoleClaim(arrayClaim, ["mentee", "alumni-ambassador"])).toBe(false);
   });
 
   it("hasAnyRoleClaim handles empty argument array + null token", () => {
@@ -611,9 +594,7 @@ describe("claim-side helpers (hasRoleClaim / hasAnyRoleClaim / hasAllRoleClaimsC
   });
 
   it("hasAllRoleClaimsClaim returns true iff every argument is present", () => {
-    expect(hasAllRoleClaimsClaim(arrayClaim, ["mentor", "ambassador"])).toBe(
-      true
-    );
+    expect(hasAllRoleClaimsClaim(arrayClaim, ["mentor", "ambassador"])).toBe(true);
     expect(hasAllRoleClaimsClaim(arrayClaim, ["mentor", "mentee"])).toBe(false);
   });
 
@@ -646,38 +627,68 @@ describe("role fixture matrix", () => {
   });
 
   it("mentor + ambassador: roles=['mentor','ambassador']", () => {
-    const p: PermissionUser = { uid: "m-3", roles: ["mentor", "ambassador"], status: "accepted", isAdmin: false };
+    const p: PermissionUser = {
+      uid: "m-3",
+      roles: ["mentor", "ambassador"],
+      status: "accepted",
+      isAdmin: false,
+    };
     expect(hasRole(p, "mentor")).toBe(true);
     expect(hasRole(p, "ambassador")).toBe(true);
     expect(hasAllRoles(p, ["mentor", "ambassador"])).toBe(true);
   });
 
   it("mentee + ambassador: roles=['mentee','ambassador']", () => {
-    const p: PermissionUser = { uid: "m-4", roles: ["mentee", "ambassador"], status: "accepted", isAdmin: false };
+    const p: PermissionUser = {
+      uid: "m-4",
+      roles: ["mentee", "ambassador"],
+      status: "accepted",
+      isAdmin: false,
+    };
     expect(hasRole(p, "mentee")).toBe(true);
     expect(hasRole(p, "ambassador")).toBe(true);
     expect(hasAllRoles(p, ["mentee", "ambassador"])).toBe(true);
   });
 
   it("mentor + alumni-ambassador: roles=['mentor','alumni-ambassador']", () => {
-    const p: PermissionUser = { uid: "m-5", roles: ["mentor", "alumni-ambassador"], status: "accepted", isAdmin: false };
+    const p: PermissionUser = {
+      uid: "m-5",
+      roles: ["mentor", "alumni-ambassador"],
+      status: "accepted",
+      isAdmin: false,
+    };
     expect(hasRole(p, "alumni-ambassador")).toBe(true);
     expect(hasAnyRole(p, ["alumni-ambassador"])).toBe(true);
   });
 
   it("triple-role: roles=['mentor','ambassador','alumni-ambassador']", () => {
-    const p: PermissionUser = { uid: "m-6", roles: ["mentor", "ambassador", "alumni-ambassador"], status: "accepted", isAdmin: false };
+    const p: PermissionUser = {
+      uid: "m-6",
+      roles: ["mentor", "ambassador", "alumni-ambassador"],
+      status: "accepted",
+      isAdmin: false,
+    };
     expect(hasAllRoles(p, ["mentor", "ambassador", "alumni-ambassador"])).toBe(true);
   });
 
   it("ambassador-only: roles=['ambassador']", () => {
-    const p: PermissionUser = { uid: "m-12", roles: ["ambassador"], status: "accepted", isAdmin: false };
+    const p: PermissionUser = {
+      uid: "m-12",
+      roles: ["ambassador"],
+      status: "accepted",
+      isAdmin: false,
+    };
     expect(hasRole(p, "ambassador")).toBe(true);
     expect(hasRole(p, "mentor")).toBe(false);
   });
 
   it("alumni-ambassador-only: roles=['alumni-ambassador']", () => {
-    const p: PermissionUser = { uid: "m-13", roles: ["alumni-ambassador"], status: "accepted", isAdmin: false };
+    const p: PermissionUser = {
+      uid: "m-13",
+      roles: ["alumni-ambassador"],
+      status: "accepted",
+      isAdmin: false,
+    };
     expect(hasRole(p, "alumni-ambassador")).toBe(true);
   });
 
@@ -688,21 +699,106 @@ describe("role fixture matrix", () => {
 
   it("bulk fixture sanity: every permutation of the four-role vocabulary", () => {
     const fixtures: Array<{ p: PermissionUser; role: Role; expected: boolean }> = [
-      { p: { uid: "b-1", roles: ["mentor"], status: "accepted", isAdmin: false }, role: "mentor", expected: true },
-      { p: { uid: "b-2", roles: ["mentor"], status: "accepted", isAdmin: false }, role: "mentee", expected: false },
-      { p: { uid: "b-3", roles: ["mentee"], status: "accepted", isAdmin: false }, role: "mentee", expected: true },
-      { p: { uid: "b-4", roles: ["mentee"], status: "accepted", isAdmin: false }, role: "mentor", expected: false },
-      { p: { uid: "b-5", roles: ["mentor", "ambassador"], status: "accepted", isAdmin: false }, role: "ambassador", expected: true },
-      { p: { uid: "b-6", roles: ["mentor", "ambassador"], status: "accepted", isAdmin: false }, role: "alumni-ambassador", expected: false },
-      { p: { uid: "b-7", roles: ["mentee", "ambassador"], status: "accepted", isAdmin: false }, role: "ambassador", expected: true },
-      { p: { uid: "b-8", roles: ["mentor", "alumni-ambassador"], status: "accepted", isAdmin: false }, role: "alumni-ambassador", expected: true },
-      { p: { uid: "b-9", roles: ["mentor", "ambassador", "alumni-ambassador"], status: "accepted", isAdmin: false }, role: "ambassador", expected: true },
-      { p: { uid: "b-10", roles: ["ambassador"], status: "accepted", isAdmin: false }, role: "ambassador", expected: true },
-      { p: { uid: "b-11", roles: ["alumni-ambassador"], status: "accepted", isAdmin: false }, role: "alumni-ambassador", expected: true },
-      { p: { uid: "b-12", roles: [], status: "pending", isAdmin: false }, role: "mentor", expected: false },
+      {
+        p: { uid: "b-1", roles: ["mentor"], status: "accepted", isAdmin: false },
+        role: "mentor",
+        expected: true,
+      },
+      {
+        p: { uid: "b-2", roles: ["mentor"], status: "accepted", isAdmin: false },
+        role: "mentee",
+        expected: false,
+      },
+      {
+        p: { uid: "b-3", roles: ["mentee"], status: "accepted", isAdmin: false },
+        role: "mentee",
+        expected: true,
+      },
+      {
+        p: { uid: "b-4", roles: ["mentee"], status: "accepted", isAdmin: false },
+        role: "mentor",
+        expected: false,
+      },
+      {
+        p: { uid: "b-5", roles: ["mentor", "ambassador"], status: "accepted", isAdmin: false },
+        role: "ambassador",
+        expected: true,
+      },
+      {
+        p: { uid: "b-6", roles: ["mentor", "ambassador"], status: "accepted", isAdmin: false },
+        role: "alumni-ambassador",
+        expected: false,
+      },
+      {
+        p: { uid: "b-7", roles: ["mentee", "ambassador"], status: "accepted", isAdmin: false },
+        role: "ambassador",
+        expected: true,
+      },
+      {
+        p: {
+          uid: "b-8",
+          roles: ["mentor", "alumni-ambassador"],
+          status: "accepted",
+          isAdmin: false,
+        },
+        role: "alumni-ambassador",
+        expected: true,
+      },
+      {
+        p: {
+          uid: "b-9",
+          roles: ["mentor", "ambassador", "alumni-ambassador"],
+          status: "accepted",
+          isAdmin: false,
+        },
+        role: "ambassador",
+        expected: true,
+      },
+      {
+        p: { uid: "b-10", roles: ["ambassador"], status: "accepted", isAdmin: false },
+        role: "ambassador",
+        expected: true,
+      },
+      {
+        p: { uid: "b-11", roles: ["alumni-ambassador"], status: "accepted", isAdmin: false },
+        role: "alumni-ambassador",
+        expected: true,
+      },
+      {
+        p: { uid: "b-12", roles: [], status: "pending", isAdmin: false },
+        role: "mentor",
+        expected: false,
+      },
     ];
     for (const { p, role, expected } of fixtures) {
       expect(hasRole(p, role)).toBe(expected);
     }
+  });
+
+  describe("canViewRoadmap (GH#296 admin preview)", () => {
+    const pendingRoadmap = { status: "pending", creatorId: "mentor-owner-789" };
+    const draftRoadmap = { status: "draft", creatorId: "mentor-owner-789" };
+    const approvedRoadmap = { status: "approved", creatorId: "mentor-owner-789" };
+
+    it("lets anyone (even null) view an approved roadmap", () => {
+      expect(canViewRoadmap(nullUser, approvedRoadmap)).toBe(true);
+      expect(canViewRoadmap(mentee, approvedRoadmap)).toBe(true);
+    });
+
+    it("lets an admin preview a pending roadmap they did not create", () => {
+      expect(canViewRoadmap(adminUser, pendingRoadmap)).toBe(true);
+      expect(canViewRoadmap(adminUser, draftRoadmap)).toBe(true);
+    });
+
+    it("lets the creator view their own unpublished roadmap", () => {
+      expect(canViewRoadmap(acceptedMentorOwner, pendingRoadmap)).toBe(true);
+      expect(canViewRoadmap(acceptedMentorOwner, draftRoadmap)).toBe(true);
+    });
+
+    it("blocks a non-admin non-creator from an unpublished roadmap", () => {
+      expect(canViewRoadmap(acceptedMentor, pendingRoadmap)).toBe(false);
+      expect(canViewRoadmap(mentee, draftRoadmap)).toBe(false);
+      expect(canViewRoadmap(nullUser, pendingRoadmap)).toBe(false);
+    });
   });
 });

--- a/src/app/admin/roadmaps/page.tsx
+++ b/src/app/admin/roadmaps/page.tsx
@@ -36,8 +36,7 @@ export default function AdminRoadmapsPage() {
     setFilters((prev) => ({ ...prev, author: value }));
   }, 300);
 
-  const hasActiveFilters =
-    filters.status !== "pending" || filters.domain || filters.author;
+  const hasActiveFilters = filters.status !== "pending" || filters.domain || filters.author;
 
   useEffect(() => {
     const fetchRoadmaps = async () => {
@@ -49,7 +48,10 @@ export default function AdminRoadmapsPage() {
         if (filters.domain) params.set("domain", filters.domain);
         if (filters.author) params.set("author", filters.author);
 
-        const response = await fetch(`/api/roadmaps?${params.toString()}`);
+        const token = localStorage.getItem(ADMIN_TOKEN_KEY);
+        const response = await fetch(`/api/roadmaps?${params.toString()}`, {
+          headers: token ? { "x-admin-token": token } : {},
+        });
         if (response.ok) {
           const data = await response.json();
           setRoadmaps(data.roadmaps || []);
@@ -105,9 +107,7 @@ export default function AdminRoadmapsPage() {
   };
 
   const handleRequestChanges = async (id: string) => {
-    const feedback = prompt(
-      "Please provide feedback for the roadmap author (min 10 characters):",
-    );
+    const feedback = prompt("Please provide feedback for the roadmap author (min 10 characters):");
     if (!feedback || feedback.length < 10) {
       toast.error("Feedback must be at least 10 characters");
       return;
@@ -148,7 +148,7 @@ export default function AdminRoadmapsPage() {
   const handleDelete = async (id: string, title: string) => {
     if (
       !confirm(
-        `Are you sure you want to delete the roadmap "${title}"? This action cannot be undone.`,
+        `Are you sure you want to delete the roadmap "${title}"? This action cannot be undone.`
       )
     ) {
       return;
@@ -201,9 +201,7 @@ export default function AdminRoadmapsPage() {
             <select
               className="select select-bordered w-full"
               value={filters.status}
-              onChange={(e) =>
-                setFilters((prev) => ({ ...prev, status: e.target.value }))
-              }
+              onChange={(e) => setFilters((prev) => ({ ...prev, status: e.target.value }))}
             >
               <option value="pending">Pending Review</option>
               <option value="all">All Roadmaps</option>
@@ -220,9 +218,7 @@ export default function AdminRoadmapsPage() {
             <select
               className="select select-bordered w-full"
               value={filters.domain}
-              onChange={(e) =>
-                setFilters((prev) => ({ ...prev, domain: e.target.value }))
-              }
+              onChange={(e) => setFilters((prev) => ({ ...prev, domain: e.target.value }))}
             >
               <option value="">All Domains</option>
               {Object.entries(DOMAIN_LABELS).map(([value, label]) => (
@@ -249,10 +245,7 @@ export default function AdminRoadmapsPage() {
 
           {/* Clear filters button */}
           {hasActiveFilters && (
-            <button
-              className="btn btn-ghost btn-sm gap-2 md:self-end"
-              onClick={handleClearFilters}
-            >
+            <button className="btn btn-ghost btn-sm gap-2 md:self-end" onClick={handleClearFilters}>
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 className="h-4 w-4"
@@ -287,9 +280,7 @@ export default function AdminRoadmapsPage() {
           <span className="loading loading-spinner loading-lg"></span>
         </div>
       ) : roadmaps.length === 0 ? (
-        <div className="text-center py-12 text-base-content/60">
-          No roadmaps found
-        </div>
+        <div className="text-center py-12 text-base-content/60">No roadmaps found</div>
       ) : (
         <div className="grid gap-4">
           {roadmaps.map((roadmap) => (
@@ -356,21 +347,17 @@ export default function AdminRoadmapsPage() {
                   </div>
                   {roadmap.estimatedHours && (
                     <div>
-                      <span className="font-semibold">Estimated:</span>{" "}
-                      {roadmap.estimatedHours} hours
+                      <span className="font-semibold">Estimated:</span> {roadmap.estimatedHours}{" "}
+                      hours
                     </div>
                   )}
                   <div>
-                    <span className="font-semibold">Current Version:</span>{" "}
-                    {roadmap.version}
+                    <span className="font-semibold">Current Version:</span> {roadmap.version}
                   </div>
                   <div className="text-xs text-base-content/60">
                     Submitted:{" "}
                     {roadmap.createdAt
-                      ? format(
-                          new Date(roadmap.createdAt as unknown as string),
-                          "MMM d, yyyy",
-                        )
+                      ? format(new Date(roadmap.createdAt as unknown as string), "MMM d, yyyy")
                       : "Unknown"}
                   </div>
                 </div>
@@ -382,14 +369,11 @@ export default function AdminRoadmapsPage() {
                   >
                     Preview
                   </Link>
-                  {(roadmap.status === "pending" ||
-                    roadmap.hasPendingDraft) && (
+                  {(roadmap.status === "pending" || roadmap.hasPendingDraft) && (
                     <>
                       <button
                         className="btn btn-success btn-sm"
-                        onClick={() =>
-                          handleApprove(roadmap.id, roadmap.hasPendingDraft)
-                        }
+                        onClick={() => handleApprove(roadmap.id, roadmap.hasPendingDraft)}
                         disabled={actionLoading === roadmap.id}
                       >
                         {actionLoading === roadmap.id ? (

--- a/src/app/roadmaps/[id]/page.tsx
+++ b/src/app/roadmaps/[id]/page.tsx
@@ -10,6 +10,7 @@ import VersionHistoryList from "@/components/roadmaps/VersionHistoryList";
 import { Roadmap, MentorshipProfile } from "@/types/mentorship";
 import RelatedProjectsWidget from "@/components/roadmaps/RelatedProjectsWidget";
 import RoadmapActionsDropdown from "@/components/roadmaps/RoadmapActionsDropdown";
+import { canViewRoadmap } from "@/lib/permissions";
 import { useRouter } from "next/navigation";
 import ProfileAvatar from "@/components/ProfileAvatar";
 
@@ -36,11 +37,13 @@ export default function RoadmapDetailPage() {
 
         // Check if we should preview the draft version
         const searchParams = new URLSearchParams(window.location.search);
-        const previewDraft = searchParams.get('preview') === 'draft';
+        const previewDraft = searchParams.get("preview") === "draft";
         setIsPreviewingDraft(previewDraft);
 
         // Fetch roadmap with full content
-        const roadmapRes = await fetch(`/api/roadmaps/${roadmapId}${previewDraft ? '?preview=draft' : ''}`);
+        const roadmapRes = await fetch(
+          `/api/roadmaps/${roadmapId}${previewDraft ? "?preview=draft" : ""}`
+        );
 
         if (!roadmapRes.ok) {
           throw new Error("Roadmap not found");
@@ -98,7 +101,7 @@ export default function RoadmapDetailPage() {
     if (action === "delete") {
       router.push("/roadmaps/my");
     } else if (action === "submit") {
-      setRoadmap((prev) => prev ? { ...prev, status: "pending" } : null);
+      setRoadmap((prev) => (prev ? { ...prev, status: "pending" } : null));
     }
   };
 
@@ -123,12 +126,22 @@ export default function RoadmapDetailPage() {
     );
   }
 
-  // Access control: Only show unpublished roadmaps to creator
-  // (Server-side will enforce admin access if needed)
+  // Access control: unpublished roadmaps are visible to the creator or an admin.
+  // Admins need this to preview pending submissions before approving (GH#296).
   const isCreator = user?.uid === roadmap.creatorId;
-  const isPublished = roadmap.status === "approved";
+  const canView = canViewRoadmap(
+    profile
+      ? {
+          uid: profile.uid,
+          roles: profile.roles ?? [],
+          status: profile.status,
+          isAdmin: (profile as { isAdmin?: boolean }).isAdmin,
+        }
+      : null,
+    { status: roadmap.status, creatorId: roadmap.creatorId }
+  );
 
-  if (!isPublished && !isCreator) {
+  if (!canView) {
     return (
       <div className="max-w-4xl mx-auto p-8">
         <div className="alert alert-warning">
@@ -203,35 +216,33 @@ export default function RoadmapDetailPage() {
             />
           </svg>
           <span>
-            <strong>Admin Preview Mode:</strong> This roadmap is pending approval and not visible to the public yet.
+            <strong>Admin Preview Mode:</strong> This roadmap is pending approval and not visible to
+            the public yet.
           </span>
         </div>
       )}
 
-              {/* Header Section */}
-            <div className="mb-8">
-              <div className="flex items-start justify-between mb-4">
-                <h1 className="text-4xl font-bold flex-1">{roadmap.title}</h1>
-                <div className="flex items-center gap-2">
-                  {user?.uid === roadmap.creatorId && (
-                    <RoadmapActionsDropdown 
-                      roadmap={roadmap} 
-                      onAction={handleAction} 
-                      className="dropdown-end"
-                    />
-                  )}
-                </div>
-              </div>
-      
-              {/* Metadata badges */}        <div className="flex items-center gap-4 text-sm text-base-content/70 mb-4">
+      {/* Header Section */}
+      <div className="mb-8">
+        <div className="flex items-start justify-between mb-4">
+          <h1 className="text-4xl font-bold flex-1">{roadmap.title}</h1>
+          <div className="flex items-center gap-2">
+            {user?.uid === roadmap.creatorId && (
+              <RoadmapActionsDropdown
+                roadmap={roadmap}
+                onAction={handleAction}
+                className="dropdown-end"
+              />
+            )}
+          </div>
+        </div>
+        {/* Metadata badges */}{" "}
+        <div className="flex items-center gap-4 text-sm text-base-content/70 mb-4">
           <span className="badge badge-primary">{domainLabel}</span>
           <span className="badge badge-secondary">{roadmap.difficulty}</span>
-          {roadmap.estimatedHours && (
-            <span>{roadmap.estimatedHours}h estimated</span>
-          )}
+          {roadmap.estimatedHours && <span>{roadmap.estimatedHours}h estimated</span>}
           <span>Version {roadmap.version}</span>
         </div>
-
         {/* Author Attribution */}
         {roadmap.creatorProfile && (
           <div className="card bg-base-200 p-4 mb-4">
@@ -243,9 +254,7 @@ export default function RoadmapDetailPage() {
               />
               <div className="flex-1">
                 <p className="text-sm text-base-content/70">Created by</p>
-                <p className="font-semibold text-lg">
-                  {roadmap.creatorProfile.displayName}
-                </p>
+                <p className="font-semibold text-lg">{roadmap.creatorProfile.displayName}</p>
                 {roadmap.creatorProfile.discordUsername && (
                   <div className="flex items-center gap-2 mt-1">
                     <svg
@@ -264,14 +273,10 @@ export default function RoadmapDetailPage() {
             </div>
           </div>
         )}
-
         {/* Description */}
         {roadmap.description && (
-          <p className="text-lg text-base-content/80 mb-4">
-            {roadmap.description}
-          </p>
+          <p className="text-lg text-base-content/80 mb-4">{roadmap.description}</p>
         )}
-
         {/* Last updated timestamp */}
         <p className="text-xs text-base-content/60">
           Last updated: {new Date(roadmap.updatedAt).toLocaleDateString()}
@@ -295,8 +300,7 @@ export default function RoadmapDetailPage() {
         <div className="mt-12 border-t pt-8">
           <h2 className="text-2xl font-bold mb-4">Related Mentors</h2>
           <p className="text-base-content/70 mb-6">
-            These mentors teach {domainLabel} and can help guide you through
-            this roadmap
+            These mentors teach {domainLabel} and can help guide you through this roadmap
           </p>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {relatedMentors.map((mentor: MentorshipProfile) => (
@@ -313,9 +317,7 @@ export default function RoadmapDetailPage() {
                       size="lg"
                     />
                     <div className="flex-1 min-w-0">
-                      <h3 className="font-semibold text-sm truncate">
-                        {mentor.displayName}
-                      </h3>
+                      <h3 className="font-semibold text-sm truncate">{mentor.displayName}</h3>
                       {mentor.currentRole && (
                         <p className="text-xs text-base-content/70 truncate">
                           {mentor.currentRole}
@@ -326,10 +328,7 @@ export default function RoadmapDetailPage() {
                   {mentor.expertise && mentor.expertise.length > 0 && (
                     <div className="flex flex-wrap gap-1">
                       {mentor.expertise.slice(0, 3).map((skill, idx) => (
-                        <span
-                          key={idx}
-                          className="badge badge-sm badge-outline"
-                        >
+                        <span key={idx} className="badge badge-sm badge-outline">
                           {skill}
                         </span>
                       ))}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -66,10 +66,7 @@ function isAuthenticated(user: PermissionUser | null): boolean {
 /**
  * Check if user owns a resource
  */
-function isOwner(
-  user: PermissionUser | null,
-  resource: { creatorId: string }
-): boolean {
+function isOwner(user: PermissionUser | null, resource: { creatorId: string }): boolean {
   if (!user) return false;
   return user.uid === resource.creatorId;
 }
@@ -93,10 +90,7 @@ function canOwnerOrAdminAccess(
  * Returns true if the profile has the given role. Null-safe.
  * Use hasAnyRole / hasAllRoles for multi-role semantics.
  */
-export function hasRole(
-  profile: PermissionUser | null | undefined,
-  role: Role
-): boolean {
+export function hasRole(profile: PermissionUser | null | undefined, role: Role): boolean {
   if (!profile) return false;
   return profile.roles.includes(role);
 }
@@ -104,10 +98,7 @@ export function hasRole(
 /**
  * Returns true if the profile has AT LEAST ONE of the given roles. Null-safe.
  */
-export function hasAnyRole(
-  profile: PermissionUser | null | undefined,
-  roles: Role[]
-): boolean {
+export function hasAnyRole(profile: PermissionUser | null | undefined, roles: Role[]): boolean {
   if (!profile) return false;
   if (roles.length === 0) return false;
   return roles.some((r) => profile.roles.includes(r));
@@ -116,10 +107,7 @@ export function hasAnyRole(
 /**
  * Returns true if the profile has EVERY given role. Null-safe.
  */
-export function hasAllRoles(
-  profile: PermissionUser | null | undefined,
-  roles: Role[]
-): boolean {
+export function hasAllRoles(profile: PermissionUser | null | undefined, roles: Role[]): boolean {
   if (!profile) return false;
   if (roles.length === 0) return true;
   return roles.every((r) => profile.roles.includes(r));
@@ -142,10 +130,7 @@ export interface DecodedRoleClaim {
  * Returns true if the decoded token carries the given role claim. Null-safe.
  * Use in API route handlers that have a decoded token and don't want a Firestore round-trip.
  */
-export function hasRoleClaim(
-  token: DecodedRoleClaim | null | undefined,
-  role: Role
-): boolean {
+export function hasRoleClaim(token: DecodedRoleClaim | null | undefined, role: Role): boolean {
   if (!token) return false;
   return !!token.roles?.includes(role);
 }
@@ -196,10 +181,7 @@ export function canCreateProject(user: PermissionUser | null): boolean {
  * PERM-03: Can approve projects
  * Only admins can approve projects
  */
-export function canApproveProject(
-  user: PermissionUser | null,
-  project: Project
-): boolean {
+export function canApproveProject(user: PermissionUser | null, project: Project): boolean {
   return isAdminUser(user);
 }
 
@@ -207,19 +189,18 @@ export function canApproveProject(
  * PERM-04: Can edit projects
  * Admin can edit any project status, creators can only edit pending/declined projects
  */
-export function canEditProject(
-  user: PermissionUser | null,
-  project: Project
-): boolean {
+export function canEditProject(user: PermissionUser | null, project: Project): boolean {
   // Admin can always edit any project
   if (isAdminUser(user)) return true;
 
   // Creator can edit pending, declined, or active projects
   // update_pending status blocks edits until pending changes are reviewed
   if (isOwner(user, project)) {
-    return project.status === "pending" 
-        || project.status === "declined" 
-        || (project.status === "active" && !project.pendingUpdates);
+    return (
+      project.status === "pending" ||
+      project.status === "declined" ||
+      (project.status === "active" && !project.pendingUpdates)
+    );
   }
 
   return false;
@@ -229,10 +210,7 @@ export function canEditProject(
  * PERM-04: Can manage project members
  * Only project creator or admin can manage members
  */
-export function canManageProjectMembers(
-  user: PermissionUser | null,
-  project: Project
-): boolean {
+export function canManageProjectMembers(user: PermissionUser | null, project: Project): boolean {
   return canOwnerOrAdminAccess(user, project);
 }
 
@@ -240,10 +218,7 @@ export function canManageProjectMembers(
  * PERM-07, PERM-08: Can apply to projects
  * Any authenticated user can apply, except the project creator
  */
-export function canApplyToProject(
-  user: PermissionUser | null,
-  project: Project
-): boolean {
+export function canApplyToProject(user: PermissionUser | null, project: Project): boolean {
   if (!isAuthenticated(user)) return false;
   if (isOwner(user, project)) return false; // PERM-08: Cannot apply to own project
   return true;
@@ -253,10 +228,7 @@ export function canApplyToProject(
  * PERM-09: Can delete projects
  * Admin can delete any project, creators can delete their own declined projects
  */
-export function canDeleteProject(
-  user: PermissionUser | null,
-  project: Project
-): boolean {
+export function canDeleteProject(user: PermissionUser | null, project: Project): boolean {
   // Admin can delete any project
   if (isAdminUser(user)) return true;
 
@@ -280,10 +252,7 @@ export function canCreateRoadmap(user: PermissionUser | null): boolean {
  * PERM-03: Can approve roadmaps
  * Only admins can approve roadmaps
  */
-export function canApproveRoadmap(
-  user: PermissionUser | null,
-  roadmap: Roadmap
-): boolean {
+export function canApproveRoadmap(user: PermissionUser | null, roadmap: Roadmap): boolean {
   return isAdminUser(user);
 }
 
@@ -291,9 +260,20 @@ export function canApproveRoadmap(
  * Can edit roadmaps
  * Only roadmap creator or admin can edit
  */
-export function canEditRoadmap(
-  user: PermissionUser | null,
-  roadmap: Roadmap
-): boolean {
+export function canEditRoadmap(user: PermissionUser | null, roadmap: Roadmap): boolean {
   return canOwnerOrAdminAccess(user, roadmap);
+}
+
+/**
+ * Can view a roadmap detail page.
+ * Approved roadmaps are public. Unpublished roadmaps (draft/pending) are only
+ * visible to the creator or an admin — admins need this to preview submissions
+ * before approving them (GH#296).
+ */
+export function canViewRoadmap(
+  user: PermissionUser | null,
+  roadmap: { status?: string; creatorId: string }
+): boolean {
+  if (roadmap.status === "approved") return true;
+  return canOwnerOrAdminAccess(user, { creatorId: roadmap.creatorId });
 }


### PR DESCRIPTION
Fixes #296

## Two admin-visibility bugs on the roadmaps flow

### 1. `/admin/roadmaps` shows no pending roadmaps (#296)
The admin GET fetch never sent the `x-admin-token` header, so the admin-view API (`/api/roadmaps?admin=true`) returned **401** and the pending list rendered empty for everyone. Now sends the token like every other admin fetch in the app.

### 2. Admins can't preview a pending roadmap they didn't create
The roadmap detail page (`/roadmaps/[id]`) gated unpublished roadmaps to the **creator only** — so an admin previewing a submission got "Roadmap Not Available", even though the page already renders an "Admin Preview Mode" banner. The repo owner saw them only because he was the creator.

Added a pure, tested `canViewRoadmap(user, roadmap)` helper (`approved` → public; otherwise owner **or** admin) and used it for the gate.

## Notes
- Admin on the detail page = `mentorship_profiles.isAdmin === true` (matches `set-admin-flag.js` and the permissions module) — **not** the `/admin` password session, which only gates the admin section. Admins previewing via the public detail page need the profile flag: `node scripts/set-admin-flag.js <email>`.

## Testing
- 4 new unit tests for `canViewRoadmap` (approved-public, admin-preview, creator, blocked) — `vitest` 98/98 pass
- `tsc --noEmit` clean