### PR TITLE
feat(admin-projects): reactivate completed projects (GH#294)

### DIFF
--- a/src/app/admin/projects/page.tsx
+++ b/src/app/admin/projects/page.tsx
@@ -41,18 +41,11 @@ export default function AdminProjectsPage() {
     techStack: "",
     creator: "",
   });
-  const [deleteTarget, setDeleteTarget] = useState<EnrichedProject | null>(
-    null,
-  );
-  const [declineTarget, setDeclineTarget] = useState<EnrichedProject | null>(
-    null,
-  );
+  const [deleteTarget, setDeleteTarget] = useState<EnrichedProject | null>(null);
+  const [declineTarget, setDeclineTarget] = useState<EnrichedProject | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
-  const [deletionSummary, setDeletionSummary] =
-    useState<DeletionSummary | null>(null);
-  const [reviewTarget, setReviewTarget] = useState<EnrichedProject | null>(
-    null,
-  );
+  const [deletionSummary, setDeletionSummary] = useState<DeletionSummary | null>(null);
+  const [reviewTarget, setReviewTarget] = useState<EnrichedProject | null>(null);
   const [declineReason, setDeclineReason] = useState("");
 
   useEffect(() => {
@@ -68,12 +61,9 @@ export default function AdminProjectsPage() {
         if (filters.techStack) params.set("techStack", filters.techStack);
         if (filters.creator) params.set("creator", filters.creator);
 
-        const response = await fetch(
-          `/api/admin/projects?${params.toString()}`,
-          {
-            headers: token ? { "x-admin-token": token } : {},
-          },
-        );
+        const response = await fetch(`/api/admin/projects?${params.toString()}`, {
+          headers: token ? { "x-admin-token": token } : {},
+        });
 
         if (response.ok) {
           const data = await response.json();
@@ -125,9 +115,7 @@ export default function AdminProjectsPage() {
         toast.success("Project approved successfully");
         // Update project status in list
         setProjects((prev) =>
-          prev.map((p) =>
-            p.id === project.id ? { ...p, status: "active" } : p,
-          ),
+          prev.map((p) => (p.id === project.id ? { ...p, status: "active" } : p))
         );
       } else {
         const data = await response.json();
@@ -136,6 +124,42 @@ export default function AdminProjectsPage() {
     } catch (error) {
       console.error("Error approving project:", error);
       toast.error("Failed to approve project");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleReactivate = async (project: EnrichedProject) => {
+    setActionLoading(project.id);
+
+    try {
+      const token = localStorage.getItem(ADMIN_TOKEN_KEY);
+      const response = await fetch(`/api/admin/projects/${project.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { "x-admin-token": token } : {}),
+        },
+        body: JSON.stringify({ action: "reactivate" }),
+      });
+
+      if (response.ok) {
+        toast.success("Project reactivated successfully");
+        // Update project status in list and clear completion timestamp
+        setProjects((prev) =>
+          prev.map((p) =>
+            p.id === project.id
+              ? ({ ...p, status: "active", completedAt: undefined } as EnrichedProject)
+              : p
+          )
+        );
+      } else {
+        const data = await response.json();
+        toast.error(data.error || "Failed to reactivate project");
+      }
+    } catch (error) {
+      console.error("Error reactivating project:", error);
+      toast.error("Failed to reactivate project");
     } finally {
       setActionLoading(null);
     }
@@ -159,9 +183,7 @@ export default function AdminProjectsPage() {
         toast.success("Project declined");
         // Update project status in list
         setProjects((prev) =>
-          prev.map((p) =>
-            p.id === declineTarget.id ? { ...p, status: "declined" } : p,
-          ),
+          prev.map((p) => (p.id === declineTarget.id ? { ...p, status: "declined" } : p))
         );
         // Close dialog
         setDeclineTarget(null);
@@ -261,9 +283,7 @@ export default function AdminProjectsPage() {
       {/* Page header */}
       <div>
         <h1 className="text-3xl font-bold">Projects Management</h1>
-        <p className="text-base-content/60 mt-1">
-          View and manage all projects in the system
-        </p>
+        <p className="text-base-content/60 mt-1">View and manage all projects in the system</p>
       </div>
 
       {/* Filters */}
@@ -300,9 +320,7 @@ export default function AdminProjectsPage() {
           </svg>
           <div>
             <h3 className="text-lg font-semibold">No projects found</h3>
-            <p className="text-base-content/60 mt-1">
-              Try adjusting your filters
-            </p>
+            <p className="text-base-content/60 mt-1">Try adjusting your filters</p>
           </div>
           <button className="btn btn-ghost btn-sm" onClick={handleClearFilters}>
             Clear Filters
@@ -317,9 +335,7 @@ export default function AdminProjectsPage() {
                 {/* Header row: Title + Status */}
                 <div className="flex items-start justify-between gap-4">
                   <h3 className="card-title text-xl">{project.title}</h3>
-                  <span
-                    className={`badge ${getStatusBadgeClass(project.status)}`}
-                  >
+                  <span className={`badge ${getStatusBadgeClass(project.status)}`}>
                     {project.status}
                   </span>
                 </div>
@@ -368,25 +384,15 @@ export default function AdminProjectsPage() {
                     </div>
                   </div>
                   <div className="text-center">
-                    <div className="text-xs text-base-content/60">
-                      Applications
-                    </div>
-                    <div className="text-sm font-semibold">
-                      {project.applicationCount}
-                    </div>
+                    <div className="text-xs text-base-content/60">Applications</div>
+                    <div className="text-sm font-semibold">{project.applicationCount}</div>
                   </div>
                   <div className="text-center">
-                    <div className="text-xs text-base-content/60">
-                      Invitations
-                    </div>
-                    <div className="text-sm font-semibold">
-                      {project.invitationCount}
-                    </div>
+                    <div className="text-xs text-base-content/60">Invitations</div>
+                    <div className="text-sm font-semibold">{project.invitationCount}</div>
                   </div>
                   <div className="text-center">
-                    <div className="text-xs text-base-content/60">
-                      Difficulty
-                    </div>
+                    <div className="text-xs text-base-content/60">Difficulty</div>
                     <div>
                       <span
                         className={`badge badge-sm ${getDifficultyBadgeClass(project.difficulty)}`}
@@ -400,8 +406,7 @@ export default function AdminProjectsPage() {
                 {/* Timestamps row */}
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-2 mt-3 text-xs text-base-content/60">
                   <div>
-                    <span className="font-semibold">Created:</span>{" "}
-                    {formatDate(project.createdAt)}
+                    <span className="font-semibold">Created:</span> {formatDate(project.createdAt)}
                   </div>
                   {project.lastActivityAt && (
                     <div>
@@ -493,10 +498,7 @@ export default function AdminProjectsPage() {
                         </Link>
                       </li>
                       <li>
-                        <Link
-                          href={`/projects/${project.id}/edit`}
-                          target="_blank"
-                        >
+                        <Link href={`/projects/${project.id}/edit`} target="_blank">
                           Edit Project
                         </Link>
                       </li>
@@ -529,27 +531,42 @@ export default function AdminProjectsPage() {
                         </>
                       )}
 
-                      {project.status === "update_pending" &&
-                        project.pendingUpdates && (
-                          <>
-                            <li className="border-t border-base-300 pt-2">
-                              <button
-                                className="text-primary font-medium"
-                                onClick={() => {
-                                  setReviewTarget(project);
-                                  setDeclineReason("");
-                                }}
-                              >
-                                📋 Review Changes
-                              </button>
-                            </li>
-                          </>
-                        )}
+                      {project.status === "completed" && (
+                        <li className="border-t border-base-300 pt-2">
+                          <button
+                            className="text-success"
+                            onClick={() => handleReactivate(project)}
+                            disabled={actionLoading === project.id}
+                          >
+                            {actionLoading === project.id ? (
+                              <>
+                                <span className="loading loading-spinner loading-xs"></span>
+                                Reactivating...
+                              </>
+                            ) : (
+                              "Reactivate Project"
+                            )}
+                          </button>
+                        </li>
+                      )}
+
+                      {project.status === "update_pending" && project.pendingUpdates && (
+                        <>
+                          <li className="border-t border-base-300 pt-2">
+                            <button
+                              className="text-primary font-medium"
+                              onClick={() => {
+                                setReviewTarget(project);
+                                setDeclineReason("");
+                              }}
+                            >
+                              📋 Review Changes
+                            </button>
+                          </li>
+                        </>
+                      )}
                       <li className="border-t border-base-300 pt-2">
-                        <button
-                          className="text-error"
-                          onClick={() => setDeleteTarget(project)}
-                        >
+                        <button className="text-error" onClick={() => setDeleteTarget(project)}>
                           Delete Project
                         </button>
                       </li>
@@ -582,10 +599,7 @@ export default function AdminProjectsPage() {
 
       {/* Deletion summary modal */}
       {deletionSummary && (
-        <DeletionSummaryModal
-          summary={deletionSummary}
-          onClose={() => setDeletionSummary(null)}
-        />
+        <DeletionSummaryModal summary={deletionSummary} onClose={() => setDeletionSummary(null)} />
       )}
 
       {/* Review Pending Updates Modal */}
@@ -594,8 +608,7 @@ export default function AdminProjectsPage() {
           <div className="modal-box max-w-2xl">
             <h3 className="font-bold text-lg">Review Project Updates</h3>
             <p className="py-2 text-base-content/70">
-              Review changes requested by project creator for{" "}
-              <strong>{reviewTarget.title}</strong>
+              Review changes requested by project creator for <strong>{reviewTarget.title}</strong>
             </p>
 
             <div className="divider"></div>
@@ -629,9 +642,7 @@ export default function AdminProjectsPage() {
                   <div className="font-medium">Title</div>
                   <div className="grid grid-cols-2 gap-4 mt-2">
                     <div>
-                      <div className="text-sm text-error line-through">
-                        {reviewTarget.title}
-                      </div>
+                      <div className="text-sm text-error line-through">{reviewTarget.title}</div>
                     </div>
                     <div>
                       <div className="text-sm text-success font-medium">
@@ -714,9 +725,7 @@ export default function AdminProjectsPage() {
             {/* Decline Reason Input */}
             <div className="form-control mt-6">
               <label className="label">
-                <span className="label-text font-semibold">
-                  Decline Reason (optional)
-                </span>
+                <span className="label-text font-semibold">Decline Reason (optional)</span>
               </label>
               <textarea
                 placeholder="Enter reason for declining these changes... This will be sent to the project creator."
@@ -743,20 +752,17 @@ export default function AdminProjectsPage() {
                   setActionLoading(reviewTarget.id);
                   try {
                     const token = localStorage.getItem(ADMIN_TOKEN_KEY);
-                    const response = await fetch(
-                      `/api/admin/projects/${reviewTarget.id}`,
-                      {
-                        method: "PUT",
-                        headers: {
-                          "Content-Type": "application/json",
-                          ...(token ? { "x-admin-token": token } : {}),
-                        },
-                        body: JSON.stringify({
-                          action: "decline_update",
-                          declineReason,
-                        }),
+                    const response = await fetch(`/api/admin/projects/${reviewTarget.id}`, {
+                      method: "PUT",
+                      headers: {
+                        "Content-Type": "application/json",
+                        ...(token ? { "x-admin-token": token } : {}),
                       },
-                    );
+                      body: JSON.stringify({
+                        action: "decline_update",
+                        declineReason,
+                      }),
+                    });
 
                     if (response.ok) {
                       toast.success("Project updates declined");
@@ -769,8 +775,8 @@ export default function AdminProjectsPage() {
                                 status: "active",
                                 pendingUpdates: undefined,
                               } as EnrichedProject)
-                            : p,
-                        ),
+                            : p
+                        )
                       );
                       setReviewTarget(null);
                       setDeclineReason("");
@@ -789,8 +795,7 @@ export default function AdminProjectsPage() {
               >
                 {actionLoading === reviewTarget.id ? (
                   <>
-                    <span className="loading loading-spinner loading-sm"></span>{" "}
-                    Declining...
+                    <span className="loading loading-spinner loading-sm"></span> Declining...
                   </>
                 ) : (
                   "❌ Decline Changes"
@@ -802,17 +807,14 @@ export default function AdminProjectsPage() {
                   setActionLoading(reviewTarget.id);
                   try {
                     const token = localStorage.getItem(ADMIN_TOKEN_KEY);
-                    const response = await fetch(
-                      `/api/admin/projects/${reviewTarget.id}`,
-                      {
-                        method: "PUT",
-                        headers: {
-                          "Content-Type": "application/json",
-                          ...(token ? { "x-admin-token": token } : {}),
-                        },
-                        body: JSON.stringify({ action: "approve_update" }),
+                    const response = await fetch(`/api/admin/projects/${reviewTarget.id}`, {
+                      method: "PUT",
+                      headers: {
+                        "Content-Type": "application/json",
+                        ...(token ? { "x-admin-token": token } : {}),
                       },
-                    );
+                      body: JSON.stringify({ action: "approve_update" }),
+                    });
 
                     if (response.ok) {
                       toast.success("Project updates approved successfully");
@@ -826,8 +828,8 @@ export default function AdminProjectsPage() {
                                 status: "active",
                                 pendingUpdates: undefined,
                               } as EnrichedProject)
-                            : p,
-                        ),
+                            : p
+                        )
                       );
                       setReviewTarget(null);
                       setDeclineReason("");
@@ -846,8 +848,7 @@ export default function AdminProjectsPage() {
               >
                 {actionLoading === reviewTarget.id ? (
                   <>
-                    <span className="loading loading-spinner loading-sm"></span>{" "}
-                    Approving...
+                    <span className="loading loading-spinner loading-sm"></span> Approving...
                   </>
                 ) : (
                   "✅ Approve Changes"

--- a/src/app/api/admin/projects/[id]/__tests__/route.test.ts
+++ b/src/app/api/admin/projects/[id]/__tests__/route.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+// Discord side-effects are not exercised by the reactivate path — stub them out.
+vi.mock("@/lib/discord", () => ({
+  deleteDiscordChannel: vi.fn(),
+  getChannel: vi.fn(),
+  sendDirectMessage: vi.fn(),
+  createProjectChannel: vi.fn(),
+  sendProjectDetailsMessage: vi.fn(),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: vi.fn().mockReturnValue({ _type: "serverTimestamp" }),
+    delete: vi.fn().mockReturnValue({ _type: "delete" }),
+  },
+}));
+
+// Firestore mock — use vi.hoisted so variables are available in the factory.
+const hoisted = vi.hoisted(() => {
+  const state = {
+    projectData: null as Record<string, unknown> | null,
+    projectExists: true,
+    sessionExists: true,
+    sessionExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+  };
+
+  const mockProjectUpdate = vi.fn().mockResolvedValue(undefined);
+  const mockSessionDelete = vi.fn().mockResolvedValue(undefined);
+
+  const projectDocRef = {
+    id: "project-123",
+    update: mockProjectUpdate,
+    get: vi.fn(async () => ({
+      exists: state.projectExists,
+      id: "project-123",
+      data: () => state.projectData,
+      ref: projectDocRef,
+    })),
+  };
+
+  const sessionDocRef = {
+    delete: mockSessionDelete,
+    get: vi.fn(async () => ({
+      exists: state.sessionExists,
+      data: () => ({
+        adminId: "admin-1",
+        expiresAt: { toDate: () => state.sessionExpiresAt },
+      }),
+    })),
+  };
+
+  const mockCollection = vi.fn((name: string) => ({
+    doc: vi.fn(() => (name === "projects" ? projectDocRef : sessionDocRef)),
+  }));
+
+  return { state, mockProjectUpdate, mockCollection };
+});
+
+vi.mock("@/lib/firebaseAdmin", () => ({
+  db: { collection: hoisted.mockCollection },
+}));
+
+// ─── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { PUT } from "../route";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRequest(body: unknown, adminToken: string | null = "valid-token"): NextRequest {
+  return new NextRequest("http://localhost/api/admin/projects/project-123", {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      ...(adminToken ? { "x-admin-token": adminToken } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const params = Promise.resolve({ id: "project-123" });
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PUT /api/admin/projects/[id] — reactivate action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.state.projectExists = true;
+    hoisted.state.sessionExists = true;
+    hoisted.state.sessionExpiresAt = new Date(Date.now() + 60 * 60 * 1000);
+    hoisted.state.projectData = { status: "completed", title: "Test Project" };
+  });
+
+  it("returns 401 when admin token is missing", async () => {
+    const res = await PUT(makeRequest({ action: "reactivate" }, null), { params });
+
+    expect(res.status).toBe(401);
+    expect(hoisted.mockProjectUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the project is not completed", async () => {
+    hoisted.state.projectData = { status: "active", title: "Test Project" };
+
+    const res = await PUT(makeRequest({ action: "reactivate" }), { params });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/only completed projects can be reactivated/i);
+    expect(hoisted.mockProjectUpdate).not.toHaveBeenCalled();
+  });
+
+  it("reactivates a completed project back to active", async () => {
+    const res = await PUT(makeRequest({ action: "reactivate" }), { params });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+
+    expect(hoisted.mockProjectUpdate).toHaveBeenCalledTimes(1);
+    const updatePayload = hoisted.mockProjectUpdate.mock.calls[0][0];
+    expect(updatePayload.status).toBe("active");
+    // completedAt must be cleared so the project no longer reads as completed.
+    expect(updatePayload.completedAt).toEqual({ _type: "delete" });
+    expect(updatePayload.reactivatedBy).toBe("admin-1");
+  });
+});

--- a/src/app/api/admin/projects/[id]/route.ts
+++ b/src/app/api/admin/projects/[id]/route.ts
@@ -282,6 +282,26 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
         { success: true, message: "Project updates declined" },
         { status: 200 }
       );
+    } else if (action === "reactivate") {
+      // Verify project is completed
+      if (projectData.status !== "completed") {
+        return NextResponse.json(
+          { error: "Only completed projects can be reactivated" },
+          { status: 400 }
+        );
+      }
+
+      // Update project status back to active and clear the completion marker
+      await projectRef.update({
+        status: "active",
+        completedAt: FieldValue.delete(),
+        reactivatedAt: FieldValue.serverTimestamp(),
+        reactivatedBy: session.adminId || "admin",
+        updatedAt: FieldValue.serverTimestamp(),
+        lastActivityAt: FieldValue.serverTimestamp(),
+      });
+
+      return NextResponse.json({ success: true, message: "Project reactivated" }, { status: 200 });
     } else {
       return NextResponse.json({ error: "Invalid action" }, { status: 400 });
     }


### PR DESCRIPTION
## What

Adds the ability for admins to **reactivate a completed project** back to `active` from the admin projects panel.

## Why

Requested in #294 — admins had no way to move a project out of `completed` once it had been marked complete.

## Changes

- **API** (`src/app/api/admin/projects/[id]/route.ts`): new `reactivate` action on the existing `PUT` handler. Authorizes via the same admin-session token check as approve/decline, validates the project is currently `completed` (400 otherwise), then sets `status: "active"`, clears `completedAt` (`FieldValue.delete()`), and records `reactivatedAt` / `reactivatedBy`. Reuses the existing action-dispatch pattern — no new route or auth mechanism.
- **UI** (`src/app/admin/projects/page.tsx`): a "Reactivate Project" action in the project actions dropdown, shown only for `completed` projects, mirroring the existing approve/decline controls with loading state + toast.
- **Tests** (`src/app/api/admin/projects/[id]/__tests__/route.test.ts`): covers 401 (no token), 400 (project not completed), and the happy path (status → active, `completedAt` cleared, `reactivatedBy` recorded).

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — passes
- New tests pass; changed files are lint-clean (repo has pre-existing lint errors/warnings in unrelated files).
- Pre-existing test failures in `email-blast` and `firestore.rules` (emulator) suites are unrelated — confirmed they also fail on `main`.

Closes #294