### PR TITLE
feat(admin): broadcast a message to a recipient group (GH#298)

### DIFF
--- a/src/app/admin/broadcast/BroadcastClient.tsx
+++ b/src/app/admin/broadcast/BroadcastClient.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState } from "react";
+import { ADMIN_TOKEN_KEY } from "@/components/admin/AdminAuthGate";
+import {
+  BROADCAST_GROUPS,
+  BROADCAST_GROUP_LABELS,
+  type BroadcastGroup,
+} from "@/lib/admin-broadcast/groups";
+
+type SendResult = {
+  name: string;
+  email: string;
+  ok: boolean;
+  error?: string;
+};
+
+type SendResponse = {
+  broadcastId: string;
+  group: BroadcastGroup;
+  results: SendResult[];
+  sent: number;
+  failed: number;
+};
+
+function adminHeaders(): HeadersInit {
+  const token = typeof window !== "undefined" ? localStorage.getItem(ADMIN_TOKEN_KEY) : null;
+  return {
+    "Content-Type": "application/json",
+    "x-admin-token": token ?? "",
+  };
+}
+
+const MAX_SUBJECT = 200;
+const MAX_MESSAGE = 20000;
+
+export function BroadcastClient() {
+  const [group, setGroup] = useState<BroadcastGroup>("mentors");
+  const [subject, setSubject] = useState("");
+  const [message, setMessage] = useState("");
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [result, setResult] = useState<SendResponse | null>(null);
+  const [error, setError] = useState("");
+
+  const canSend =
+    subject.trim() !== "" &&
+    subject.length <= MAX_SUBJECT &&
+    message.trim() !== "" &&
+    message.length <= MAX_MESSAGE &&
+    !sending;
+
+  const handleSend = async () => {
+    setSending(true);
+    setError("");
+    setResult(null);
+    try {
+      const res = await fetch("/api/admin/broadcast", {
+        method: "POST",
+        headers: adminHeaders(),
+        body: JSON.stringify({ group, subject, message }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error ?? `Failed to send (${res.status})`);
+        return;
+      }
+      setResult(data as SendResponse);
+      // Clear the composer on success so the same message isn't re-sent by mistake.
+      setSubject("");
+      setMessage("");
+    } catch {
+      setError("Network error while sending the broadcast.");
+    } finally {
+      setSending(false);
+      setShowConfirm(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <div>
+        <h1 className="text-3xl font-bold">Direct Message Broadcast</h1>
+        <p className="text-base-content/60 mt-1 text-sm">
+          Compose a message and email it to one audience. Delivery is via email only for now.
+        </p>
+      </div>
+
+      {/* Recipient group */}
+      <div className="form-control">
+        <label className="label" htmlFor="broadcast-group">
+          <span className="label-text font-semibold">Recipient group</span>
+        </label>
+        <select
+          id="broadcast-group"
+          className="select select-bordered"
+          value={group}
+          onChange={(e) => setGroup(e.target.value as BroadcastGroup)}
+          disabled={sending}
+        >
+          {BROADCAST_GROUPS.map((g) => (
+            <option key={g} value={g}>
+              {BROADCAST_GROUP_LABELS[g]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Subject */}
+      <div className="form-control">
+        <label className="label" htmlFor="broadcast-subject">
+          <span className="label-text font-semibold">Subject</span>
+          <span className="label-text-alt text-base-content/50">
+            {subject.length}/{MAX_SUBJECT}
+          </span>
+        </label>
+        <input
+          id="broadcast-subject"
+          type="text"
+          className="input input-bordered"
+          value={subject}
+          maxLength={MAX_SUBJECT}
+          placeholder="Subject line"
+          onChange={(e) => setSubject(e.target.value)}
+          disabled={sending}
+        />
+      </div>
+
+      {/* Message */}
+      <div className="form-control">
+        <label className="label" htmlFor="broadcast-message">
+          <span className="label-text font-semibold">Message</span>
+          <span className="label-text-alt text-base-content/50">
+            {message.length}/{MAX_MESSAGE}
+          </span>
+        </label>
+        <textarea
+          id="broadcast-message"
+          className="textarea textarea-bordered min-h-40"
+          value={message}
+          maxLength={MAX_MESSAGE}
+          placeholder="Write your message. Line breaks are preserved."
+          onChange={(e) => setMessage(e.target.value)}
+          disabled={sending}
+        />
+      </div>
+
+      {error && (
+        <div className="alert alert-error">
+          <span>{error}</span>
+        </div>
+      )}
+
+      {result && (
+        <div className={`alert ${result.failed === 0 ? "alert-success" : "alert-warning"}`}>
+          <div>
+            <p className="font-semibold">
+              Broadcast to {BROADCAST_GROUP_LABELS[result.group]} complete.
+            </p>
+            <p className="text-sm">
+              {result.sent} sent
+              {result.failed > 0 ? `, ${result.failed} failed` : ""}.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <button
+          className="btn btn-primary"
+          onClick={() => setShowConfirm(true)}
+          disabled={!canSend}
+        >
+          Review &amp; Send
+        </button>
+      </div>
+
+      {/* Confirm dialog */}
+      {showConfirm && (
+        <dialog className="modal modal-open">
+          <div className="modal-box">
+            <h3 className="font-bold text-lg">Send this broadcast?</h3>
+            <p className="py-2 text-sm">
+              This will email <strong>all {BROADCAST_GROUP_LABELS[group]}</strong> with the subject
+              &ldquo;{subject.trim()}&rdquo;. This cannot be undone.
+            </p>
+            <div className="modal-action">
+              <button
+                className="btn btn-ghost"
+                onClick={() => setShowConfirm(false)}
+                disabled={sending}
+              >
+                Cancel
+              </button>
+              <button className="btn btn-primary" onClick={handleSend} disabled={sending}>
+                {sending ? (
+                  <>
+                    <span className="loading loading-spinner loading-sm"></span>
+                    Sending…
+                  </>
+                ) : (
+                  "Yes, send"
+                )}
+              </button>
+            </div>
+          </div>
+          <form method="dialog" className="modal-backdrop">
+            <button onClick={() => setShowConfirm(false)}>close</button>
+          </form>
+        </dialog>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/broadcast/page.tsx
+++ b/src/app/admin/broadcast/page.tsx
@@ -1,0 +1,7 @@
+import { BroadcastClient } from "./BroadcastClient";
+
+export const dynamic = "force-dynamic";
+
+export default function BroadcastPage() {
+  return <BroadcastClient />;
+}

--- a/src/app/api/admin/broadcast/route.ts
+++ b/src/app/api/admin/broadcast/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest, NextResponse } from "next/server";
+import { FieldValue } from "firebase-admin/firestore";
+import { requireAdmin } from "@/lib/ambassador/adminAuth";
+import { sendEmailBatch } from "@/lib/email";
+import { db } from "@/lib/firebaseAdmin";
+import { isBroadcastGroup, BROADCAST_GROUP_LABELS } from "@/lib/admin-broadcast/groups";
+import { renderBroadcastHtml } from "@/lib/admin-broadcast/renderMessage";
+import { resolveGroupRecipients } from "@/lib/admin-broadcast/resolveRecipients";
+
+const MAX_SUBJECT = 200;
+const MAX_MESSAGE = 20000;
+
+interface SendResult {
+  name: string;
+  email: string;
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * POST /api/admin/broadcast  (GH#298)
+ *
+ * Admin composes a plain-text message and sends it to ONE recipient group
+ * (mentors | mentees | collaborators | ambassadors). Recipients are resolved
+ * from the existing collections; delivery reuses the shared Resend batch sender.
+ * An audit doc is written to `admin-broadcasts/{id}` (mirrors email-blast).
+ *
+ * v1 is email-only — no in-app messaging/threads/replies (see PR follow-ups).
+ */
+export async function POST(request: NextRequest) {
+  const admin = await requireAdmin(request);
+  if (!admin.ok) {
+    return NextResponse.json({ error: admin.error }, { status: admin.status });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Request body required" }, { status: 400 });
+  }
+
+  const { group, subject, message } = body as Record<string, unknown>;
+
+  if (!isBroadcastGroup(group)) {
+    return NextResponse.json(
+      { error: "group must be one of: mentors, mentees, collaborators, ambassadors" },
+      { status: 400 }
+    );
+  }
+
+  if (!subject || typeof subject !== "string" || subject.trim() === "") {
+    return NextResponse.json(
+      { error: "subject is required and must be a non-empty string" },
+      { status: 400 }
+    );
+  }
+
+  if (subject.length > MAX_SUBJECT) {
+    return NextResponse.json(
+      { error: `subject must be ${MAX_SUBJECT} characters or fewer` },
+      { status: 400 }
+    );
+  }
+
+  if (!message || typeof message !== "string" || message.trim() === "") {
+    return NextResponse.json(
+      { error: "message is required and must be a non-empty string" },
+      { status: 400 }
+    );
+  }
+
+  if (message.length > MAX_MESSAGE) {
+    return NextResponse.json(
+      { error: `message must be ${MAX_MESSAGE} characters or fewer` },
+      { status: 400 }
+    );
+  }
+
+  const cleanSubject = subject.trim();
+
+  // Resolve recipients from the existing collections for this group.
+  const recipients = await resolveGroupRecipients(db, group);
+
+  if (recipients.length === 0) {
+    return NextResponse.json(
+      { error: `No recipients with an email found for group "${BROADCAST_GROUP_LABELS[group]}"` },
+      { status: 404 }
+    );
+  }
+
+  const html = renderBroadcastHtml(message, cleanSubject);
+
+  // Pre-create Firestore audit doc (mirrors email-blast/route.ts).
+  const broadcastRef = db.collection("admin-broadcasts").doc();
+  await broadcastRef.set({
+    group,
+    subject: cleanSubject,
+    status: "in_progress",
+    sentBy: admin.uid,
+    startedAt: FieldValue.serverTimestamp(),
+    recipientCount: recipients.length,
+  });
+
+  const results: SendResult[] = [];
+
+  try {
+    const batchResults = await sendEmailBatch(
+      recipients.map((r) => ({ to: r.email, subject: cleanSubject, html }))
+    );
+
+    for (let i = 0; i < recipients.length; i++) {
+      const { ok, error } = batchResults[i];
+      results.push({
+        name: recipients[i].name,
+        email: recipients[i].email,
+        ok,
+        ...(error ? { error } : {}),
+      });
+    }
+
+    const sentCount = results.filter((r) => r.ok).length;
+    const failedCount = results.filter((r) => !r.ok).length;
+
+    await broadcastRef.update({
+      status: "completed",
+      completedAt: FieldValue.serverTimestamp(),
+      sentCount,
+      failedCount,
+    });
+
+    return NextResponse.json({
+      broadcastId: broadcastRef.id,
+      group,
+      results,
+      sent: sentCount,
+      failed: failedCount,
+    });
+  } catch (err) {
+    console.error("[admin-broadcast] POST send error:", err);
+
+    const sentCount = results.filter((r) => r.ok).length;
+    const failedCount = results.filter((r) => !r.ok).length;
+
+    try {
+      await broadcastRef.update({
+        status: "errored",
+        erroredAt: FieldValue.serverTimestamp(),
+        errorMessage: err instanceof Error ? err.message : String(err),
+        sentCount,
+        failedCount,
+      });
+    } catch (updateErr) {
+      console.error("[admin-broadcast] Failed to update Firestore on error:", updateErr);
+    }
+
+    return NextResponse.json(
+      {
+        error: "Broadcast partially failed",
+        broadcastId: broadcastRef.id,
+        results,
+        sent: sentCount,
+        failed: failedCount,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -50,6 +50,7 @@ const NAV: NavSection[] = [
     items: [
       { label: "Raffle", href: "/admin/raffle" },
       { label: "Email Blasts", href: "/admin/events/email" },
+      { label: "Broadcast", href: "/admin/broadcast" },
     ],
   },
 ];
@@ -57,8 +58,7 @@ const NAV: NavSection[] = [
 function isActive(pathname: string, href: string, exact?: boolean) {
   if (exact) return pathname === href;
   // Avoid /admin/ambassadors matching /admin/ambassadors/members etc. for the top entry
-  if (href === "/admin/ambassadors")
-    return pathname === href || pathname === "/admin/ambassadors/";
+  if (href === "/admin/ambassadors") return pathname === href || pathname === "/admin/ambassadors/";
   return pathname.startsWith(href);
 }
 

--- a/src/lib/admin-broadcast/__tests__/groups.test.ts
+++ b/src/lib/admin-broadcast/__tests__/groups.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Admin broadcast — recipient-group helpers (GH#298).
+ * Pure logic only; Firestore resolution is exercised separately.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  BROADCAST_GROUPS,
+  BROADCAST_GROUP_LABELS,
+  isBroadcastGroup,
+  dedupeRecipients,
+  type BroadcastRecipient,
+} from "@/lib/admin-broadcast/groups";
+
+describe("BROADCAST_GROUPS", () => {
+  it("covers exactly the four MVP recipient groups", () => {
+    expect([...BROADCAST_GROUPS].sort()).toEqual(
+      ["ambassadors", "collaborators", "mentees", "mentors"].sort()
+    );
+  });
+
+  it("has a human label for every group", () => {
+    for (const group of BROADCAST_GROUPS) {
+      expect(BROADCAST_GROUP_LABELS[group]).toBeTruthy();
+    }
+  });
+});
+
+describe("isBroadcastGroup", () => {
+  it("accepts valid groups", () => {
+    expect(isBroadcastGroup("mentors")).toBe(true);
+    expect(isBroadcastGroup("mentees")).toBe(true);
+    expect(isBroadcastGroup("collaborators")).toBe(true);
+    expect(isBroadcastGroup("ambassadors")).toBe(true);
+  });
+
+  it("rejects anything else", () => {
+    expect(isBroadcastGroup("everyone")).toBe(false);
+    expect(isBroadcastGroup("")).toBe(false);
+    expect(isBroadcastGroup(null)).toBe(false);
+    expect(isBroadcastGroup(undefined)).toBe(false);
+    expect(isBroadcastGroup(42)).toBe(false);
+  });
+});
+
+describe("dedupeRecipients", () => {
+  const a: BroadcastRecipient = { name: "Ann", email: "ann@example.com" };
+  const b: BroadcastRecipient = { name: "Bob", email: "bob@example.com" };
+
+  it("removes duplicate emails case-insensitively, keeping first occurrence", () => {
+    const dup: BroadcastRecipient = { name: "Ann Two", email: "ANN@example.com" };
+    const result = dedupeRecipients([a, dup, b]);
+    expect(result).toEqual([a, b]);
+  });
+
+  it("drops entries without a usable email", () => {
+    const result = dedupeRecipients([
+      a,
+      { name: "NoEmail", email: "" },
+      { name: "Spacey", email: "   " },
+    ]);
+    expect(result).toEqual([a]);
+  });
+
+  it("trims surrounding whitespace on email while preserving name", () => {
+    const result = dedupeRecipients([{ name: "Pad", email: " pad@example.com " }]);
+    expect(result).toEqual([{ name: "Pad", email: "pad@example.com" }]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(dedupeRecipients([])).toEqual([]);
+  });
+});

--- a/src/lib/admin-broadcast/__tests__/renderMessage.test.ts
+++ b/src/lib/admin-broadcast/__tests__/renderMessage.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Admin broadcast — message → HTML rendering (GH#298).
+ * Admin-authored plain text is escaped and newline-preserved before send.
+ */
+
+import { describe, it, expect } from "vitest";
+import { renderBroadcastHtml } from "@/lib/admin-broadcast/renderMessage";
+
+describe("renderBroadcastHtml", () => {
+  it("escapes HTML so admin text can't inject markup", () => {
+    const html = renderBroadcastHtml("<script>alert(1)</script>", "Hello");
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("converts newlines to <br/> so line breaks survive", () => {
+    const html = renderBroadcastHtml("line one\nline two", "Subj");
+    expect(html).toContain("line one<br/>line two");
+  });
+
+  it("normalizes CRLF newlines", () => {
+    const html = renderBroadcastHtml("a\r\nb", "Subj");
+    expect(html).toContain("a<br/>b");
+    expect(html).not.toContain("\r");
+  });
+
+  it("includes the subject in the document title", () => {
+    const html = renderBroadcastHtml("body", "My Subject");
+    expect(html).toContain("<title>My Subject</title>");
+  });
+
+  it("escapes the subject in the title too", () => {
+    const html = renderBroadcastHtml("body", "A & B <x>");
+    expect(html).toContain("A &amp; B &lt;x&gt;");
+    expect(html).not.toContain("<x>");
+  });
+
+  it("produces a full HTML document", () => {
+    const html = renderBroadcastHtml("hi", "Subj");
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html.toLowerCase()).toContain("</html>");
+  });
+});

--- a/src/lib/admin-broadcast/groups.ts
+++ b/src/lib/admin-broadcast/groups.ts
@@ -1,0 +1,51 @@
+/**
+ * Admin broadcast — recipient-group definitions and pure recipient helpers (GH#298).
+ *
+ * A "broadcast" lets an admin compose a plain-text message and send it to one
+ * selected audience via the existing email channel. This module holds the group
+ * enum + framework-agnostic helpers so they can be unit-tested without Firestore.
+ */
+
+/** The audiences an admin can broadcast to in v1. */
+export const BROADCAST_GROUPS = ["mentors", "mentees", "collaborators", "ambassadors"] as const;
+
+export type BroadcastGroup = (typeof BROADCAST_GROUPS)[number];
+
+/** Human-friendly labels for the UI select. */
+export const BROADCAST_GROUP_LABELS: Record<BroadcastGroup, string> = {
+  mentors: "Mentors",
+  mentees: "Mentees",
+  collaborators: "Project Collaborators",
+  ambassadors: "Ambassadors",
+};
+
+/** A resolved recipient of a broadcast. */
+export interface BroadcastRecipient {
+  name: string;
+  email: string;
+}
+
+/** Runtime type guard for untrusted request input. */
+export function isBroadcastGroup(value: unknown): value is BroadcastGroup {
+  return typeof value === "string" && (BROADCAST_GROUPS as readonly string[]).includes(value);
+}
+
+/**
+ * Drop recipients without a usable email and remove duplicate emails
+ * (case-insensitive), keeping the first occurrence. Emails are trimmed.
+ * A single person can be in multiple projects/roles, so dedupe is required
+ * before handing the list to the batch sender.
+ */
+export function dedupeRecipients(recipients: BroadcastRecipient[]): BroadcastRecipient[] {
+  const seen = new Set<string>();
+  const out: BroadcastRecipient[] = [];
+  for (const r of recipients) {
+    const email = (r.email ?? "").trim();
+    if (!email) continue;
+    const key = email.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ name: r.name, email });
+  }
+  return out;
+}

--- a/src/lib/admin-broadcast/renderMessage.ts
+++ b/src/lib/admin-broadcast/renderMessage.ts
@@ -1,0 +1,58 @@
+/**
+ * Admin broadcast — render an admin's plain-text message to email HTML (GH#298).
+ *
+ * The message is admin-authored plain text (not HTML). We escape it to avoid
+ * broken/injected markup, preserve line breaks, and wrap it in a minimal branded
+ * shell that matches the tone of the existing mentorship emails in src/lib/email.ts.
+ */
+
+import { htmlEscape } from "@/lib/email-blast/escapeHtml";
+
+function getSiteUrl(): string {
+  return process.env.NEXT_PUBLIC_SITE_URL ?? "https://codewithahsan.dev";
+}
+
+const styles = `
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }
+  .header { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 30px; text-align: center; border-radius: 10px 10px 0 0; }
+  .header h1 { margin: 0; font-size: 22px; }
+  .content { background: #f9fafb; padding: 30px; border: 1px solid #e5e7eb; border-top: none; }
+  .footer { text-align: center; padding: 20px; color: #6b7280; font-size: 14px; }
+`;
+
+/**
+ * Convert an admin's plain-text message into a full, safe HTML email document.
+ *
+ * @param message Admin-authored plain text. Escaped; newlines become <br/>.
+ * @param subject Used as the document <title> (escaped).
+ */
+export function renderBroadcastHtml(message: string, subject: string): string {
+  const safeBody = htmlEscape(message)
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/\n/g, "<br/>");
+  const safeTitle = htmlEscape(subject);
+  const siteUrl = getSiteUrl();
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${safeTitle}</title>
+  <style>${styles}</style>
+</head>
+<body>
+  <div class="header">
+    <h1>🎓 Code with Ahsan</h1>
+  </div>
+  <div class="content">
+    ${safeBody}
+  </div>
+  <div class="footer">
+    <p>This message was sent to you by the Code with Ahsan team.</p>
+    <p><a href="${siteUrl}">codewithahsan.dev</a></p>
+  </div>
+</body>
+</html>`;
+}

--- a/src/lib/admin-broadcast/resolveRecipients.ts
+++ b/src/lib/admin-broadcast/resolveRecipients.ts
@@ -1,0 +1,101 @@
+/**
+ * Admin broadcast — resolve a recipient group to concrete {name, email} rows (GH#298).
+ *
+ * Reuses the exact collections the existing admin features read from, so we add
+ * no new data model:
+ *   - mentors / mentees  → `mentorship_profiles` filtered by `roles array-contains`
+ *   - ambassadors        → collection-group `ambassador` (active) → parent profile
+ *   - collaborators      → `project_members` → member profile
+ *
+ * Ambassadors and collaborators reference a user by uid; their display name +
+ * email live on `mentorship_profiles/{uid}` (doc id === uid), so we batch-fetch
+ * those profiles via getAll. Results are de-duplicated by the caller.
+ */
+
+import type { Firestore } from "firebase-admin/firestore";
+import {
+  dedupeRecipients,
+  type BroadcastGroup,
+  type BroadcastRecipient,
+} from "@/lib/admin-broadcast/groups";
+
+/** Guard against unbounded fan-out; the batch sender also caps at 500. */
+const MAX_UIDS = 500;
+
+interface ProfileShape {
+  displayName?: string;
+  email?: string;
+}
+
+function toRecipient(data: ProfileShape | undefined): BroadcastRecipient | null {
+  const email = (data?.email ?? "").trim();
+  if (!email) return null;
+  return { name: (data?.displayName ?? "").trim() || email, email };
+}
+
+/** Recipients for a role-based mentorship group (mentor | mentee). */
+async function resolveByRole(
+  db: Firestore,
+  role: "mentor" | "mentee"
+): Promise<BroadcastRecipient[]> {
+  const snap = await db
+    .collection("mentorship_profiles")
+    .where("roles", "array-contains", role)
+    .get();
+  return snap.docs
+    .map((d) => toRecipient(d.data() as ProfileShape))
+    .filter((r): r is BroadcastRecipient => r !== null);
+}
+
+/** Fetch mentorship profiles for a set of uids and map to recipients. */
+async function profilesForUids(db: Firestore, uids: string[]): Promise<BroadcastRecipient[]> {
+  const unique = Array.from(new Set(uids)).filter(Boolean).slice(0, MAX_UIDS);
+  if (unique.length === 0) return [];
+  const refs = unique.map((uid) => db.collection("mentorship_profiles").doc(uid));
+  const snaps = await db.getAll(...refs);
+  return snaps
+    .map((s) => toRecipient(s.data() as ProfileShape | undefined))
+    .filter((r): r is BroadcastRecipient => r !== null);
+}
+
+/** Recipients for all active ambassadors. */
+async function resolveAmbassadors(db: Firestore): Promise<BroadcastRecipient[]> {
+  const subdocs = await db.collectionGroup("ambassador").where("active", "==", true).get();
+  const uids = subdocs.docs.map((d) => d.ref.parent.parent?.id ?? "").filter(Boolean);
+  return profilesForUids(db, uids);
+}
+
+/** Recipients for all project collaborators (project_members). */
+async function resolveCollaborators(db: Firestore): Promise<BroadcastRecipient[]> {
+  const members = await db.collection("project_members").get();
+  const uids = members.docs
+    .map((d) => (d.data().userId as string | undefined) ?? "")
+    .filter(Boolean);
+  return profilesForUids(db, uids);
+}
+
+/**
+ * Resolve a broadcast group to a de-duplicated recipient list.
+ * Returns an empty array when the group has no addressable members.
+ */
+export async function resolveGroupRecipients(
+  db: Firestore,
+  group: BroadcastGroup
+): Promise<BroadcastRecipient[]> {
+  let recipients: BroadcastRecipient[];
+  switch (group) {
+    case "mentors":
+      recipients = await resolveByRole(db, "mentor");
+      break;
+    case "mentees":
+      recipients = await resolveByRole(db, "mentee");
+      break;
+    case "ambassadors":
+      recipients = await resolveAmbassadors(db);
+      break;
+    case "collaborators":
+      recipients = await resolveCollaborators(db);
+      break;
+  }
+  return dedupeRecipients(recipients);
+}


### PR DESCRIPTION
Closes #298

## What
Adds an admin-dashboard **Broadcast** page (`/admin/broadcast`, in the sidebar under *Tools*) that lets an admin compose a plain-text message and send it to **one** selected audience:

- Mentors
- Mentees
- Project Collaborators
- Ambassadors

Delivery reuses the existing email channel (`sendEmailBatch` in `src/lib/email.ts`, the same Resend batch path the email-blast feature uses). Auth reuses `requireAdmin` (`x-admin-token`) — no new auth mechanism. An audit doc is written to `admin-broadcasts/{id}`, mirroring the email-blast route.

## Scope (bounded first cut)
Ahsan approved this on board review without specifying scope, so this is a deliberately lowest-risk MVP for review — please course-correct.

**In scope (this PR):**
- One admin page to compose a subject + message and pick a single recipient group.
- Recipient resolution from existing collections only (no new data model):
  - mentors/mentees → `mentorship_profiles` filtered by `roles array-contains`
  - ambassadors → collection-group `ambassador` where `active == true` → parent `mentorship_profiles` for name/email
  - collaborators → `project_members` → member `mentorship_profiles` for name/email
- De-dup by email; drop recipients with no email; a "review & send" confirm step.
- New API route `POST /api/admin/broadcast`.
- Unit tests for the pure helpers (group validation/dedupe + message→HTML rendering).

## Decisions made
- **Email-only delivery**, reusing `sendEmailBatch` rather than the email-blast route directly (that route requires a Ghost draft `ghostPostId`; here the admin authors free-form text).
- Message is treated as **plain text**: HTML-escaped, newlines preserved as `<br/>`, wrapped in a minimal branded shell consistent with existing mentorship emails.
- Recipient resolution capped at 500 uids (batch sender also caps at 500) to guard against unbounded fan-out; paginate later if a group grows.
- Confirm dialog names the group + subject before sending (no pre-send recipient-count endpoint added — kept minimal).

## Out of scope — proposed follow-ups
- No in-app messaging / threads / inbox data model — this is not "DM" storage, it's a one-way email broadcast.
- No replies / threading / read receipts.
- No push / Discord notifications.
- No per-recipient preview or a recipient-count preview endpoint before send.
- No scheduling, drafts, or send history UI (audit docs are written but not surfaced).
- "All users" / multi-group / custom-segment targeting.

## Sensitive path — human review expected
This is an **admin-tree change** (`src/app/admin/**`, `src/app/api/**/admin/**`) and it sends email to real users, so it is intentionally routed to human review rather than auto-merge.

## Verification
- `npx tsc --noEmit` — pass
- `npx eslint` on changed files — clean
- `npm run build` — pass (`/admin/broadcast` + `/api/admin/broadcast` registered)
- `npm test` — new `admin-broadcast` suites pass (14). The only red suites are the two pre-existing failures on `main` (`email-blast` timing/mock tests and the Firestore security-rules emulator tests) — untouched by this PR.
