### PR TITLE
fix(mentorship): allow avatar uploads to mentorship-profiles (GH#285)

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -16,6 +16,22 @@ service firebase.storage {
       allow read: if request.auth != null && request.auth.token.admin == true;
     }
 
+    // ─── Mentorship profiles: avatar uploads (GH#285) ───
+    // Path: mentorship-profiles/{userId}/avatar-{timestamp}.{ext}
+    // Writer: the profile owner only (signed-in + matching uid).
+    //   Used by MentorRegistrationForm's handleImageUpload(); ambassadors edit
+    //   via the same mentorship profile form. Without this block the write hit
+    //   the default-deny below → "Failed to upload image. Please try again."
+    // Reader: public — avatars are shown on public mentor/ambassador profiles,
+    //   matching how the stored downloadURL (photoURL) is displayed.
+    match /mentorship-profiles/{userId}/{fileName} {
+      allow write: if request.auth != null
+                      && request.auth.uid == userId
+                      && request.resource.size < 10 * 1024 * 1024          // 10 MB cap
+                      && request.resource.contentType.matches('image/.*'); // images only
+      allow read: if true;
+    }
+
     // Deny everything else by default (default-deny policy).
     match /{allPaths=**} {
       allow read, write: if false;


### PR DESCRIPTION
## Problem

`handleImageUpload()` in `src/components/mentorship/MentorRegistrationForm.tsx` uploads avatars to Firebase Storage at `mentorship-profiles/{userId}/avatar-{timestamp}.{ext}`, but `storage.rules` had **no** match block for that path — so it hit the default-deny and every upload failed with the toast "Failed to upload image. Please try again." Ambassadors hit this too, since they edit via the same mentorship profile form.

## Fix

Added a scoped `match /mentorship-profiles/{userId}/{fileName}` block, modeled on the existing `applications/**` block:

- `write` allowed only when `request.auth.uid == userId` (profile owner only)
- restricted to image content-type (`request.resource.contentType.matches('image/.*')`)
- 10 MB size cap (mirrors the applications block; comfortably covers the form's own 5 MB client cap)
- `read: if true` (public) — avatars are displayed on public mentor/ambassador profiles via the stored `photoURL` download URL

**No existing rule was removed, weakened, or reordered.** The `applications/**` block and the default-deny catch-all are untouched.

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — compiled successfully (exit 0)
- `npm test` — only the two pre-existing red suites on `main` fail (email-blast setTimeout timing; firestore emulator security-rules). No new failures.
- `npm run lint` — only pre-existing errors in untouched files (`tailwind.config.js`, `src/lib/*.js`). No new lint issues in the change (`storage.rules` is not linted).
- Storage emulator (`firebase emulators:exec --only storage`) loaded `storage.rules` with **no compilation error**, confirming the new rule parses and deploys.

> Note: `npm run test:rules` targets the Firestore emulator + `src/__tests__/security-rules/` (firestore.test.ts only) — there is no Storage-rules test suite, so it does not exercise this change. Validated via the Storage emulator startup compile instead.

Closes #285
