### PR TITLE
feat(admin): show completed mentorships count on overview dashboard (GH#307)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -282,6 +282,31 @@ export default function AdminOverviewPage() {
               </div>
             </div>
 
+            {/* Completed Mentorships */}
+            <div className="stats shadow bg-base-100">
+              <div className="stat">
+                <div className="stat-figure text-accent">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-8 w-8"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"
+                    />
+                  </svg>
+                </div>
+                <div className="stat-title">Completed Mentorships</div>
+                <div className="stat-value text-accent">{stats.completedMentorships}</div>
+                <div className="stat-desc">of {stats.totalMatches} total</div>
+              </div>
+            </div>
+
             {/* Avg Session Rating */}
             <div className="stats shadow bg-base-100">
               <div className="stat">

--- a/src/app/api/mentorship/admin/stats/route.ts
+++ b/src/app/api/mentorship/admin/stats/route.ts
@@ -1,90 +1,101 @@
-import { NextResponse } from 'next/server'
-import { db } from '@/lib/firebaseAdmin'
+import { NextResponse } from "next/server";
+import { db } from "@/lib/firebaseAdmin";
 
 export async function GET() {
   try {
     // Get mentor count
-    const mentorsSnapshot = await db.collection('mentorship_profiles')
-      .where('roles', 'array-contains', 'mentor')
-      .get()
-    const totalMentors = mentorsSnapshot.size
+    const mentorsSnapshot = await db
+      .collection("mentorship_profiles")
+      .where("roles", "array-contains", "mentor")
+      .get();
+    const totalMentors = mentorsSnapshot.size;
 
     // Get mentee count
-    const menteesSnapshot = await db.collection('mentorship_profiles')
-      .where('roles', 'array-contains', 'mentee')
-      .get()
-    const totalMentees = menteesSnapshot.size
+    const menteesSnapshot = await db
+      .collection("mentorship_profiles")
+      .where("roles", "array-contains", "mentee")
+      .get();
+    const totalMentees = menteesSnapshot.size;
 
     // Get match stats
-    const matchesSnapshot = await db.collection('mentorship_sessions').get()
-    const totalMatches = matchesSnapshot.size
-    const activeMatches = matchesSnapshot.docs.filter(d => d.data().status === 'active').length
-    const pendingMatches = matchesSnapshot.docs.filter(d => d.data().status === 'pending').length
+    const matchesSnapshot = await db.collection("mentorship_sessions").get();
+    const totalMatches = matchesSnapshot.size;
+    const activeMatches = matchesSnapshot.docs.filter((d) => d.data().status === "active").length;
+    const pendingMatches = matchesSnapshot.docs.filter((d) => d.data().status === "pending").length;
+    const completedMentorships = matchesSnapshot.docs.filter(
+      (d) => d.data().status === "completed"
+    ).length;
 
     // Get goal stats
-    const goalsSnapshot = await db.collection('mentorship_goals').get()
-    const totalGoals = goalsSnapshot.size
-    const completedGoals = goalsSnapshot.docs.filter(d => d.data().status === 'completed').length
+    const goalsSnapshot = await db.collection("mentorship_goals").get();
+    const totalGoals = goalsSnapshot.size;
+    const completedGoals = goalsSnapshot.docs.filter((d) => d.data().status === "completed").length;
 
     // Get session stats
-    const sessionsSnapshot = await db.collection('mentorship_sessions').get()
-    const totalSessions = sessionsSnapshot.size
+    const sessionsSnapshot = await db.collection("mentorship_sessions").get();
+    const totalSessions = sessionsSnapshot.size;
 
     // Get ratings from mentor_ratings collection
-    const ratingsSnapshot = await db.collection('mentor_ratings').get()
+    const ratingsSnapshot = await db.collection("mentor_ratings").get();
     const ratingsSum = ratingsSnapshot.docs.reduce((sum, doc) => {
-      const rating = doc.data().rating
-      return rating ? sum + rating : sum
-    }, 0)
-    const totalRatings = ratingsSnapshot.size
-    const averageRating = totalRatings > 0 ? ratingsSum / totalRatings : 0
+      const rating = doc.data().rating;
+      return rating ? sum + rating : sum;
+    }, 0);
+    const totalRatings = ratingsSnapshot.size;
+    const averageRating = totalRatings > 0 ? ratingsSum / totalRatings : 0;
 
     // Get unresolved alerts
-    const alertsSnapshot = await db.collection('mentorship_alerts')
-      .where('resolved', '==', false)
-      .orderBy('createdAt', 'desc')
+    const alertsSnapshot = await db
+      .collection("mentorship_alerts")
+      .where("resolved", "==", false)
+      .orderBy("createdAt", "desc")
       .limit(10)
-      .get()
+      .get();
 
-    const alerts = alertsSnapshot.docs.map(doc => ({
+    const alerts = alertsSnapshot.docs.map((doc) => ({
       id: doc.id,
       ...doc.data(),
       createdAt: doc.data().createdAt?.toDate?.() || null,
-    }))
+    }));
 
     // Get pending project and roadmap counts
-    const [pendingProjectsSnapshot, pendingRoadmapsSnapshot, pendingDraftRoadmapsSnapshot] = await Promise.all([
-      db.collection('projects').where('status', '==', 'pending').get(),
-      db.collection('roadmaps').where('status', '==', 'pending').get(),
-      db.collection('roadmaps').where('hasPendingDraft', '==', true).get(),
-    ]);
+    const [pendingProjectsSnapshot, pendingRoadmapsSnapshot, pendingDraftRoadmapsSnapshot] =
+      await Promise.all([
+        db.collection("projects").where("status", "==", "pending").get(),
+        db.collection("roadmaps").where("status", "==", "pending").get(),
+        db.collection("roadmaps").where("hasPendingDraft", "==", true).get(),
+      ]);
     const pendingProjects = pendingProjectsSnapshot.size;
     // Deduplicate: a roadmap could be both pending AND hasPendingDraft (unlikely but safe)
     const pendingRoadmapIds = new Set([
-      ...pendingRoadmapsSnapshot.docs.map(d => d.id),
-      ...pendingDraftRoadmapsSnapshot.docs.map(d => d.id),
+      ...pendingRoadmapsSnapshot.docs.map((d) => d.id),
+      ...pendingDraftRoadmapsSnapshot.docs.map((d) => d.id),
     ]);
     const pendingRoadmaps = pendingRoadmapIds.size;
 
-    return NextResponse.json({
-      stats: {
-        totalMentors,
-        totalMentees,
-        totalMatches,
-        activeMatches,
-        pendingMatches,
-        completedGoals,
-        totalGoals,
-        totalSessions,
-        averageRating,
-        lowRatingAlerts: alerts.length,
-        pendingProjects,
-        pendingRoadmaps,
+    return NextResponse.json(
+      {
+        stats: {
+          totalMentors,
+          totalMentees,
+          totalMatches,
+          activeMatches,
+          pendingMatches,
+          completedMentorships,
+          completedGoals,
+          totalGoals,
+          totalSessions,
+          averageRating,
+          lowRatingAlerts: alerts.length,
+          pendingProjects,
+          pendingRoadmaps,
+        },
+        alerts,
       },
-      alerts,
-    }, { status: 200 })
+      { status: 200 }
+    );
   } catch (error) {
-    console.error('Error fetching admin stats:', error)
-    return NextResponse.json({ error: 'Failed to fetch stats' }, { status: 500 })
+    console.error("Error fetching admin stats:", error);
+    return NextResponse.json({ error: "Failed to fetch stats" }, { status: 500 });
   }
 }

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -6,6 +6,7 @@ export interface AdminStats {
   totalMatches: number;
   activeMatches: number;
   pendingMatches: number;
+  completedMentorships: number;
   completedGoals: number;
   totalGoals: number;
   totalSessions: number;


### PR DESCRIPTION
Closes #307

## What

Adds a **Completed Mentorships** count to the admin overview dashboard.

- `src/types/admin.ts` — new `completedMentorships: number` on `AdminStats`.
- `src/app/api/mentorship/admin/stats/route.ts` — derives the count from the
  `mentorship_sessions` snapshot **already fetched** for `activeMatches` /
  `pendingMatches`. No new Firestore query.
- `src/app/admin/page.tsx` — new stat tile beside *Active Matches*, matching the
  existing `stats shadow bg-base-100` markup (`text-accent`, desc `of N total`).

## Definition of "completed"

`mentorship_sessions` docs where `status === 'completed'` — the same definition
used by `src/app/api/stats/route.ts` (`completedMentorships`) and
`src/app/api/mentorship/admin/matches/route.ts`. The admin stats route already
reads that exact collection into `matchesSnapshot`, so the new number is
consistent with the public stats page and the matches admin view.

## Verification

- `npx tsc --noEmit` — clean for the changed files.
- `npx eslint` on the 3 changed files — clean.
- `npx next build --webpack` — `✓ Compiled successfully`.
- `npm test` — 423 passing; only the two suites already red on `main`
  (`email-blast/__tests__/route.test.ts` timing mocks, `security-rules/firestore.test.ts`
  which needs the Firestore emulator) still fail. No new failures.

## Notes

- Touches admin trees (`src/app/admin/**`, `src/app/api/**/mentorship/admin/**`)
  → **sensitive path**, human review rather than auto-merge.
- No unit test added: the count is a one-line `.filter()` inline in the route
  handler with no pure-logic seam; extracting one would mean refactoring the two
  other routes that share the pattern (out of scope for this issue).
