### PR TITLE
chore(agent-loop): orchestrator re-verifies builds from worktree implementers

### DIFF
--- a/.claude/skills/agent-loop/SKILL.md
+++ b/.claude/skills/agent-loop/SKILL.md
@@ -61,11 +61,13 @@ items:{}}` if absent). This is your idempotency + sync spine.
 
 ## Phase A2 — Implement (for auto-fix items)
 
-> **Run implementers ONE AT A TIME.** They mutate the shared working tree, so a
-> second implementer launched while another's branch is still checked out starts
-> dirty (this actually happened — a broadcast PR inherited a prior task's branch).
-> Never spawn two implementers concurrently on the same repo. If you must
-> parallelize, give each `isolation: 'worktree'`.
+> **Run implementers ONE AT A TIME** on the shared tree. They mutate the working
+> tree, so a second implementer launched while another's branch is still checked
+> out starts dirty (this actually happened — a broadcast PR inherited a prior
+> task's branch). To parallelize safely, give each `isolation: 'worktree'` —
+> but then you MUST re-verify the build yourself (see the merge gate: Turbopack
+> can't build inside a worktree, and the branch is locked to that worktree, so
+> only a `--detach` checkout at the head sha gives a real result).
 
 1. **Reset the tree yourself BEFORE every implementer — do not trust the previous
    step to have left you on `main`:**
@@ -77,6 +79,23 @@ items:{}}` if absent). This is your idempotency + sync spine.
    `fix-implementer`) with the issue + triage JSON. Parse its JSON.
    Increment `attempts` in the ledger.
 3. **Merge gate — authoritative, on the REAL diff** (not the triage guess):
+   - **Re-verify the build yourself when the implementer ran in a worktree.**
+     `npm run build` (Turbopack) FAILS inside `.claude/worktrees/*` — it infers the
+     workspace root as the parent worktrees dir and errors "couldn't find the
+     Next.js package". So a worktree implementer literally cannot run the repo's
+     real build; treat its "build green" as unverified and re-run it here.
+     **Use a detached checkout — a plain `git checkout <branch>` SILENTLY FAILS
+     while the agent's worktree still holds that branch, leaving you on `main` and
+     building the wrong tree (this happened; the "verification" was of main):**
+     ```
+     git fetch origin <branch>
+     git checkout --detach <headSha>     # NOT `git checkout <branch>`
+     git rev-parse --short HEAD          # assert it equals <headSha>
+     npm run build; echo "exit=$?"       # exit 0 required
+     npx vitest run                      # no NEW failures vs main's baseline
+     git checkout main && git pull --ff-only
+     ```
+     Never report a build as verified without asserting HEAD == the PR's head sha.
    - **Provenance check first:** `git fetch origin <branch>` then
      `git log --oneline main..origin/<branch>` — confirm the branch contains
      ONLY this issue's commit(s) and nothing from another task (guards against a

--- a/.claude/skills/agent-loop/references/config.md
+++ b/.claude/skills/agent-loop/references/config.md
@@ -74,6 +74,21 @@ are escalated (never auto-merged), so the loop does not run it inline.
 "Green" = tsc + lint + build + vitest all pass. There is **no CI status gate**,
 so local green is the bar.
 
+**Known environment traps when verifying:**
+
+- `npm run build` (Turbopack) **cannot run inside `.claude/worktrees/*`** — it
+  infers the workspace root as the parent worktrees dir ("couldn't find the
+  Next.js package"). A worktree implementer's "build green" is therefore
+  unverified; the orchestrator must re-run it from the main checkout.
+- While an agent's worktree holds a branch, `git checkout <branch>` in the main
+  checkout **fails and leaves you on `main`** — building the wrong tree. Always
+  `git checkout --detach <headSha>` and assert `git rev-parse --short HEAD`.
+- `npm run lint` may OOM on large local runs; compare behaviour against `main`
+  rather than trusting an absolute problem count.
+- Some suites are **red on `main`** (email-blast timing mocks; firestore
+  security-rules tests needing the emulator). Judge "no NEW failures vs main",
+  never "all green".
+
 ## Conventions
 
 - Branch: `fix/<issue#>-<slug>` or `feat/<issue#>-<slug>` (kebab slug, ≤ ~5 words).


### PR DESCRIPTION
Fourth loop-safety gap, found live while gating PRs #308/#309.

**Problem 1 — worktree implementers can't build.** `npm run build` (Turbopack) fails inside `.claude/worktrees/*` ("couldn't find the Next.js package" — it infers the workspace root as the parent worktrees dir). So an isolated implementer's "build green" is unverified by construction.

**Problem 2 — the obvious re-check is wrong.** While the agent's worktree holds the branch, `git checkout <branch>` in the main checkout **fails and leaves you on `main`** — so the orchestrator happily "verifies" the wrong tree. This actually happened on #308 before it was caught.

**Fix:** merge gate now mandates a detached checkout at the PR head sha, asserting `HEAD` matches before trusting build/test output, then returning to `main`. Also documents the `npm run lint` OOM and the suites already red on `main`, so the bar is explicitly "no NEW failures vs main".

Docs-only (`SKILL.md` + `config.md`); non-sensitive.