### PR TITLE
fix(events): correct team registration copy for Ship Karachi

### DIFF
--- a/src/app/events/cwa-ship-karachi/2026/components/AboutSection.tsx
+++ b/src/app/events/cwa-ship-karachi/2026/components/AboutSection.tsx
@@ -25,8 +25,8 @@ const AboutSection = () => {
           <p className="text-base-content/70 leading-relaxed text-base sm:text-lg mb-5">
             <span className="text-base-content font-semibold">{EVENT.name}</span> is a single-day,
             on-site <span className="text-base-content font-semibold">hackathon</span> run by the
-            Code With Ahsan community. You arrive in the morning, form a team, and spend the day
-            building — with mentors on the floor the whole time.
+            Code With Ahsan community. You register as a team, arrive in the morning, and spend the
+            day building — with mentors on the floor the whole time.
           </p>
           <p className="text-base-content/70 leading-relaxed text-sm sm:text-base">
             The theme is <span className="text-accent font-semibold">{EVENT.theme}</span> — not a

--- a/src/app/events/cwa-ship-karachi/2026/constants.ts
+++ b/src/app/events/cwa-ship-karachi/2026/constants.ts
@@ -298,10 +298,10 @@ export const TRACK: EventTrack = {
   label: "One Track",
   title: "The Hackathon",
   tagline:
-    "A single-day, on-site build sprint. Form a team in the morning, ship a working demo by 4 PM, and pitch it to the judges the same evening.",
+    "A single-day, on-site build sprint. Register with your team, ship a working demo by 4 PM, and pitch it to the judges the same evening.",
   timeLabel: EVENT.timeLabel,
   points: [
-    "Team formation and theme reveal at kick-off",
+    "Teams register in advance — theme revealed at kick-off",
     "Five hours of heads-down build time across two sessions",
     "Mentors on the floor all day to unblock your team",
     "Same-day judging with prizes for the top three teams",
@@ -330,7 +330,7 @@ export const DAY_SCHEDULE: ScheduleItem[] = [
     time: "9:00 – 9:30 AM",
     title: "Registration",
     kind: "registration",
-    description: "Check in, collect your badge, grab coffee, and find your team.",
+    description: "Check in with your team, collect your badges, and grab coffee before we start.",
   },
   {
     time: "9:30 – 10:00 AM",

--- a/src/app/events/cwa-ship-karachi/2026/layout.tsx
+++ b/src/app/events/cwa-ship-karachi/2026/layout.tsx
@@ -11,7 +11,7 @@ const bebasNeue = Bebas_Neue({
 });
 
 const TITLE = `${EVENT.name} | Code with Ahsan`;
-const DESCRIPTION = `${EVENT.name} on ${EVENT.dateLabel}: a single-day, on-site hackathon in Karachi. Form a team, build with AI, and demo to the judges the same evening.`;
+const DESCRIPTION = `${EVENT.name} on ${EVENT.dateLabel}: a single-day, on-site hackathon in Karachi. Bring your team, build and ship an AI product, and demo to the judges the same evening.`;
 
 export const metadata: Metadata = {
   title: TITLE,

--- a/src/content/events/cwa-ship-karachi-2026/event.mdx
+++ b/src/content/events/cwa-ship-karachi-2026/event.mdx
@@ -1,7 +1,7 @@
 ---
 slug: cwa-ship-karachi-2026
 title: "CWA Ship Karachi 2026 – Build & Ship AI Product in One Day"
-description: "A single-day, on-site hackathon by the Code With Ahsan community in Karachi. Form a team, build and ship a production-ready AI product, and demo it to the judges the same evening."
+description: "A single-day, on-site hackathon by the Code With Ahsan community in Karachi. Register with your team, build and ship a production-ready AI product, and demo it to the judges the same evening."
 type: hackathon
 date: "2026-09-12"
 endDate: ""


### PR DESCRIPTION
Registration is taken by the team, so teams are not formed on the day. Four places on the page say otherwise, plus the page metadata.

- Hackathon panel: "Register with your team" rather than "Form a team in the morning"
- Hackathon bullet now states the actual rule: "Teams register in advance — theme revealed at kick-off"
- About section and the Registration schedule slot reworded to assume an existing team
- layout.tsx description, which feeds the OG and Twitter cards, said "Form a team" — every shared link preview carried the wrong instruction. The MDX description had the same wording.


<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/938172e2-2e52-44b4-ab4b-d36008feeb65" />

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/c0855b9b-ba87-4ada-a902-652a39b5d93d" />

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/e2da42b2-8675-4a50-92e0-4a3248f78022" />

