### PR TITLE
fix(consulting): show approved advisory testimonials (missing Firestore indexes)

### DIFF
--- a/.agent/skills/firestore-indexes/SKILL.md
+++ b/.agent/skills/firestore-indexes/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: firestore-indexes
+description: "Keep Firestore composite indexes in the repo. Use whenever writing, editing, or reviewing code that queries Firestore — any `.where()`, `.orderBy()`, `.findNearest()`, or a new collection — and before opening a PR that touches src/app/api, src/services, src/lib, or scripts. Also use when a query works locally but returns 500 / FAILED_PRECONDITION in production, or when a page section silently renders nothing."
+---
+
+# Firestore indexes live in the repo
+
+A Firestore query that needs a composite index **does not fail at build time, in
+tests, or in the emulator**. It fails at runtime, in production, only on the code
+path that runs it — as `FAILED_PRECONDITION: The query requires an index`. The
+API route catches it, returns an empty array, and the UI renders nothing. Nobody
+notices for weeks.
+
+Creating the index by clicking the link in the Firebase console error "fixes"
+production and leaves the repo wrong: the next `firebase deploy --only
+firestore:indexes` from a clean checkout drops it, and no reviewer can see the
+index exists.
+
+**The index is part of the change. It ships in the same commit as the query.**
+
+## Every time you touch a Firestore query
+
+1. Write the query.
+2. Add the composite index to `firestore.indexes.json` (rules below).
+3. Run `npm run check:firestore-indexes` and get a clean pass.
+4. Commit query + index together.
+5. Deploy the index — it must land **before or with** the code that needs it:
+   ```
+   npx firebase deploy --only firestore:indexes --project code-with-ahsan-45496
+   ```
+   Large collections take minutes to build. Say so in the PR description.
+
+Step 3 also runs automatically on `git commit` via `.husky/pre-commit`. If it
+fails, add the index — do not `--no-verify`.
+
+## When a composite index is required
+
+Required:
+
+- a filter on one field plus an `orderBy` on a **different** field
+  (`.where("isApproved","==",true).orderBy("createdAt","desc")`)
+- a range/inequality (`<`, `<=`, `>`, `>=`, `!=`, `not-in`) plus any other
+  filtered field, including two ranges on different fields
+- `array-contains` / `array-contains-any` combined with any other filter or an
+  `orderBy`
+- more than one `orderBy` field
+- `findNearest()` vector search combined with any filter — the filter fields go
+  first, the vector field last with its `vectorConfig`
+
+Not required — the automatic single-field indexes already serve these:
+
+- a single filter, with or without an `orderBy` on that same field
+- equality-only conjunctions (`==` and `in`), however many; Firestore merges the
+  single-field indexes with a zigzag join
+
+## Field order in the index
+
+Equality and `array-contains` fields first (their order among themselves does not
+matter), then range fields, then `orderBy` fields in query order with matching
+direction, vector field last.
+
+```jsonc
+{
+  "collectionGroup": "consulting_reviews",
+  "queryScope": "COLLECTION",
+  "fields": [
+    { "fieldPath": "isApproved", "order": "ASCENDING" }, // equality
+    { "fieldPath": "createdAt", "order": "DESCENDING" }, // orderBy, matching direction
+  ],
+}
+```
+
+Array field: `{ "fieldPath": "roles", "arrayConfig": "CONTAINS" }`.
+Vector field: `{ "fieldPath": "bioEmbedding", "vectorConfig": { "dimension": 768, "flat": {} } }`.
+
+Append new entries at the end of `"indexes"`. Do not re-sort the file — it makes
+the diff unreviewable.
+
+## Make the read survive a building index
+
+An index takes time to build after deploy. Where the query backs user-visible
+content, degrade instead of 500ing — fall back to a narrower query and finish the
+work in memory, and log a warning so the fallback is visible:
+
+```ts
+try {
+  return await approvedQuery.orderBy("createdAt", "desc").limit(10).get();
+} catch (orderError) {
+  console.warn("Falling back to unordered testimonials query:", orderError);
+  const snap = await approvedQuery.get();
+  return snap.docs.sort(byCreatedAtDesc).slice(0, 10);
+}
+```
+
+This is a safety net, not a substitute for the index. Ship both.
+
+## The checker
+
+`scripts/check-firestore-indexes.mjs` parses `src/` and `scripts/` for query
+chains — including ones split across statements, which is the shape that hides a
+missing index — works out which need a composite index, and diffs that against
+`firestore.indexes.json`. On a miss it prints the file:line and the exact JSON to
+paste in.
+
+It reads static code, so it cannot see a collection name or field that is only
+known at runtime. Run `npm run check:firestore-indexes -- --verbose` to list the
+dynamically built queries it had to skip, and check those by hand.
+
+## Debugging a query that returns nothing in production
+
+1. `curl -sL -o /dev/null -w "%{http_code}" https://www.codewithahsan.dev/api/<route>`
+   — a 500 with an empty payload is the signature.
+2. Check whether another Firestore route returns 200. If it does, credentials are
+   fine and the failure is index-specific.
+3. `grep` the collection in `firestore.indexes.json`. No entry is the answer.
+4. Add the index, run the checker, deploy indexes, then redeploy the app.

--- a/.claude/skills/firestore-indexes/SKILL.md
+++ b/.claude/skills/firestore-indexes/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: firestore-indexes
+description: "Keep Firestore composite indexes in the repo. Use whenever writing, editing, or reviewing code that queries Firestore — any `.where()`, `.orderBy()`, `.findNearest()`, or a new collection — and before opening a PR that touches src/app/api, src/services, src/lib, or scripts. Also use when a query works locally but returns 500 / FAILED_PRECONDITION in production, or when a page section silently renders nothing."
+---
+
+# Firestore indexes live in the repo
+
+A Firestore query that needs a composite index **does not fail at build time, in
+tests, or in the emulator**. It fails at runtime, in production, only on the code
+path that runs it — as `FAILED_PRECONDITION: The query requires an index`. The
+API route catches it, returns an empty array, and the UI renders nothing. Nobody
+notices for weeks.
+
+Creating the index by clicking the link in the Firebase console error "fixes"
+production and leaves the repo wrong: the next `firebase deploy --only
+firestore:indexes` from a clean checkout drops it, and no reviewer can see the
+index exists.
+
+**The index is part of the change. It ships in the same commit as the query.**
+
+## Every time you touch a Firestore query
+
+1. Write the query.
+2. Add the composite index to `firestore.indexes.json` (rules below).
+3. Run `npm run check:firestore-indexes` and get a clean pass.
+4. Commit query + index together.
+5. Deploy the index — it must land **before or with** the code that needs it:
+   ```
+   npx firebase deploy --only firestore:indexes --project code-with-ahsan-45496
+   ```
+   Large collections take minutes to build. Say so in the PR description.
+
+Step 3 also runs automatically on `git commit` via `.husky/pre-commit`. If it
+fails, add the index — do not `--no-verify`.
+
+## When a composite index is required
+
+Required:
+
+- a filter on one field plus an `orderBy` on a **different** field
+  (`.where("isApproved","==",true).orderBy("createdAt","desc")`)
+- a range/inequality (`<`, `<=`, `>`, `>=`, `!=`, `not-in`) plus any other
+  filtered field, including two ranges on different fields
+- `array-contains` / `array-contains-any` combined with any other filter or an
+  `orderBy`
+- more than one `orderBy` field
+- `findNearest()` vector search combined with any filter — the filter fields go
+  first, the vector field last with its `vectorConfig`
+
+Not required — the automatic single-field indexes already serve these:
+
+- a single filter, with or without an `orderBy` on that same field
+- equality-only conjunctions (`==` and `in`), however many; Firestore merges the
+  single-field indexes with a zigzag join
+
+## Field order in the index
+
+Equality and `array-contains` fields first (their order among themselves does not
+matter), then range fields, then `orderBy` fields in query order with matching
+direction, vector field last.
+
+```jsonc
+{
+  "collectionGroup": "consulting_reviews",
+  "queryScope": "COLLECTION",
+  "fields": [
+    { "fieldPath": "isApproved", "order": "ASCENDING" }, // equality
+    { "fieldPath": "createdAt", "order": "DESCENDING" }, // orderBy, matching direction
+  ],
+}
+```
+
+Array field: `{ "fieldPath": "roles", "arrayConfig": "CONTAINS" }`.
+Vector field: `{ "fieldPath": "bioEmbedding", "vectorConfig": { "dimension": 768, "flat": {} } }`.
+
+Append new entries at the end of `"indexes"`. Do not re-sort the file — it makes
+the diff unreviewable.
+
+## Make the read survive a building index
+
+An index takes time to build after deploy. Where the query backs user-visible
+content, degrade instead of 500ing — fall back to a narrower query and finish the
+work in memory, and log a warning so the fallback is visible:
+
+```ts
+try {
+  return await approvedQuery.orderBy("createdAt", "desc").limit(10).get();
+} catch (orderError) {
+  console.warn("Falling back to unordered testimonials query:", orderError);
+  const snap = await approvedQuery.get();
+  return snap.docs.sort(byCreatedAtDesc).slice(0, 10);
+}
+```
+
+This is a safety net, not a substitute for the index. Ship both.
+
+## The checker
+
+`scripts/check-firestore-indexes.mjs` parses `src/` and `scripts/` for query
+chains — including ones split across statements, which is the shape that hides a
+missing index — works out which need a composite index, and diffs that against
+`firestore.indexes.json`. On a miss it prints the file:line and the exact JSON to
+paste in.
+
+It reads static code, so it cannot see a collection name or field that is only
+known at runtime. Run `npm run check:firestore-indexes -- --verbose` to list the
+dynamically built queries it had to skip, and check those by hand.
+
+## Debugging a query that returns nothing in production
+
+1. `curl -sL -o /dev/null -w "%{http_code}" https://www.codewithahsan.dev/api/<route>`
+   — a 500 with an empty payload is the signature.
+2. Check whether another Firestore route returns 200. If it does, credentials are
+   fine and the failure is index-specific.
+3. `grep` the collection in `firestore.indexes.json`. No entry is the answer.
+4. Add the index, run the checker, deploy indexes, then redeploy the app.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 npx lint-staged
+npm run check:firestore-indexes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Project instructions
+
+These apply to every agent working in this repo (Google Antigravity, Gemini CLI,
+Claude Code, and anything else that reads `AGENTS.md`).
+
+## Firestore indexes ship with the query
+
+Any change that adds or edits a Firestore query must add the composite index it
+needs to `firestore.indexes.json` **in the same commit**, and deploy it with
+`npx firebase deploy --only firestore:indexes --project code-with-ahsan-45496`.
+
+Never "fix" a missing index by clicking the link in the Firebase console error.
+That leaves production working and the repo wrong, and the next indexes deploy
+from a clean checkout drops it.
+
+A missing composite index does not fail the build, the tests, or the emulator. It
+throws `FAILED_PRECONDITION` at runtime in production, the route returns an empty
+array, and the UI silently renders nothing.
+
+Verify before committing:
+
+```
+npm run check:firestore-indexes
+```
+
+This also runs on `git commit` via `.husky/pre-commit`. If it fails, add the
+index — do not bypass with `--no-verify`.
+
+Full rules (when an index is required, field ordering, array and vector index
+shapes, graceful fallbacks while an index builds) are in the
+**`firestore-indexes` skill**: `.agent/skills/firestore-indexes/SKILL.md`.
+Read it before touching Firestore query code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,21 @@ When the main (orchestrator) agent is running on **Opus**:
 Rule of thumb: Opus decides _what_ to do, Sonnet does it.
 
 If the main agent is not Opus, use the model each agent definition specifies.
+
+## Firestore indexes ship with the query
+
+Any change that adds or edits a Firestore query must add the composite index it
+needs to `firestore.indexes.json` **in the same commit**, and deploy it with
+`npx firebase deploy --only firestore:indexes --project code-with-ahsan-45496`.
+Never resolve a missing index by clicking the link in the Firebase console error
+— that leaves production working and the repo wrong.
+
+A missing composite index does not fail the build, the tests, or the emulator; it
+throws `FAILED_PRECONDITION` in production and the UI silently renders nothing.
+
+Verify with `npm run check:firestore-indexes` (also enforced by
+`.husky/pre-commit`). Read the **`firestore-indexes` skill**
+(`.claude/skills/firestore-indexes/SKILL.md`) before touching Firestore query
+code. The same instructions are mirrored for other agents in `AGENTS.md` and
+`.agent/skills/firestore-indexes/SKILL.md`; the checker fails if the two skill
+copies drift apart.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -700,6 +700,56 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "consulting_reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "isApproved",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "consulting_bookings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "startTime",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "endTime",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "mentorship_bookings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "mentorId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "menteeId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "startTime",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "content:sync:strapi": "npm run content:export:strapi && npm run content:mdx:from-json && npm run content:build",
     "start": "next start",
     "lint": "eslint",
+    "check:firestore-indexes": "node scripts/check-firestore-indexes.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",

--- a/scripts/check-firestore-indexes.mjs
+++ b/scripts/check-firestore-indexes.mjs
@@ -1,0 +1,395 @@
+#!/usr/bin/env node
+/**
+ * Static check: every Firestore query that needs a composite index must have one
+ * declared in firestore.indexes.json.
+ *
+ * A missing composite index does not fail at build time or in tests — it throws
+ * FAILED_PRECONDITION at runtime, in production, only for the code path that runs
+ * the query. This script catches it before the deploy.
+ *
+ * Usage: node scripts/check-firestore-indexes.mjs [--verbose]
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const INDEX_FILE = path.join(ROOT, "firestore.indexes.json");
+const SCAN_DIRS = ["src", "scripts"];
+const VERBOSE = process.argv.includes("--verbose");
+
+// `in` is a disjunction of equalities and is served like one, so it is not a range op.
+const RANGE_OPS = new Set(["<", "<=", ">", ">=", "!=", "not-in"]);
+const ARRAY_OPS = new Set(["array-contains", "array-contains-any"]);
+
+/* ------------------------------------------------------------------ sources */
+
+function walk(dir, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+      walk(full, out);
+    } else if (/\.(ts|tsx|js|mjs)$/.test(entry.name) && !full.endsWith(".d.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Map local `const FOO = "bar"` so `.collection(FOO)` resolves to a name. */
+function collectStringConstants(source) {
+  const constants = new Map();
+  const re = /(?:const|let|var)\s+([A-Za-z0-9_$]+)\s*(?::\s*[^=]+)?=\s*["'`]([^"'`]+)["'`]/g;
+  let match;
+  while ((match = re.exec(source))) constants.set(match[1], match[2]);
+  return constants;
+}
+
+function resolveArg(raw, constants) {
+  const literal = raw.match(/^\s*["'`]([^"'`]+)["'`]\s*$/);
+  if (literal) return literal[1];
+  const ident = raw.trim().match(/^[A-Za-z0-9_$.]+$/);
+  if (ident) {
+    const key = raw.trim().split(".").pop();
+    if (constants.has(key)) return constants.get(key);
+  }
+  return null;
+}
+
+/** Split a call's argument list on top-level commas. */
+function splitArgs(argString) {
+  const args = [];
+  let depth = 0;
+  let quote = null;
+  let current = "";
+  for (const char of argString) {
+    if (quote) {
+      current += char;
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      current += char;
+      continue;
+    }
+    if ("([{".includes(char)) depth++;
+    if (")]}".includes(char)) depth--;
+    if (char === "," && depth === 0) {
+      args.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim()) args.push(current);
+  return args;
+}
+
+/** Read the balanced argument list starting at the "(" index. */
+function readCallArgs(source, openParen) {
+  let depth = 0;
+  let quote = null;
+  for (let i = openParen; i < source.length; i++) {
+    const char = source[i];
+    if (quote) {
+      if (char === quote && source[i - 1] !== "\\") quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "(") depth++;
+    else if (char === ")") {
+      depth--;
+      if (depth === 0) return { args: source.slice(openParen + 1, i), end: i };
+    }
+  }
+  return null;
+}
+
+/* ------------------------------------------------------------------- parser */
+
+/**
+ * Walk forward from `.collection(...)` collecting the chained
+ * `.where()` / `.orderBy()` calls that belong to the same expression.
+ */
+function parseChain(source, startIndex, constants) {
+  const wheres = [];
+  const orderBys = [];
+  let cursor = startIndex;
+  let dynamic = false;
+
+  while (true) {
+    const rest = source.slice(cursor);
+    const next = rest.match(/^\s*(?:as\s+[^.;]+)?\s*\.\s*([A-Za-z0-9_$]+)\s*\(/);
+    if (!next) {
+      // The chain may continue after a reassignment (`query = query.orderBy(...)`).
+      if (/^\s*(?:as\s+[^;]+)?\s*;/.test(rest)) dynamic = true;
+      break;
+    }
+    const method = next[1];
+    // `.doc()` / `.collection()` start a different collection — that is a new query.
+    if (method === "doc" || method === "collection" || method === "collectionGroup") break;
+    const openParen = cursor + next[0].length - 1;
+    const call = readCallArgs(source, openParen);
+    if (!call) break;
+
+    if (method === "where") {
+      const args = splitArgs(call.args);
+      const field = resolveArg(args[0] ?? "", constants);
+      const op = resolveArg(args[1] ?? "", constants);
+      if (!field || !op) dynamic = true;
+      else wheres.push({ field, op });
+    } else if (method === "orderBy") {
+      const args = splitArgs(call.args);
+      const field = resolveArg(args[0] ?? "", constants);
+      const dir = resolveArg(args[1] ?? "", constants) ?? "asc";
+      if (!field) dynamic = true;
+      else if (field !== "__name__") orderBys.push({ field, dir: dir.toLowerCase() });
+    }
+
+    cursor = call.end + 1;
+  }
+
+  return { wheres, orderBys, dynamic };
+}
+
+/** Name of the variable a chain starting at `matchIndex` is assigned to, if any. */
+function assignedVariable(source, matchIndex) {
+  const before = source.slice(Math.max(0, matchIndex - 200), matchIndex);
+  const match = before.match(/(?:const|let|var)\s+([A-Za-z0-9_$]+)[^=]*=\s*(?:await\s+)?[^=;]*$/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Collect every query in a file, including chains that are split across
+ * statements (`const q = col.where(...)` … `q.orderBy(...)`), which is exactly
+ * the shape that hides a missing index from a naive scan.
+ */
+function findQueries(file) {
+  const source = fs.readFileSync(file, "utf8");
+  const constants = collectStringConstants(source);
+  const queries = [];
+  const bases = [];
+
+  const re = /\.\s*collection(?:Group)?\s*\(/g;
+  let match;
+  while ((match = re.exec(source))) {
+    const openParen = match.index + match[0].length - 1;
+    const call = readCallArgs(source, openParen);
+    if (!call) continue;
+    const collection = resolveArg(splitArgs(call.args)[0] ?? "", constants);
+    if (!collection) continue;
+
+    const chain = parseChain(source, call.end + 1, constants);
+    const line = source.slice(0, match.index).split("\n").length;
+    const base = { file, line, collection, ...chain };
+    queries.push(base);
+
+    const variable = assignedVariable(source, match.index);
+    if (variable) bases.push({ variable, at: match.index, base });
+  }
+
+  // Continuations: `q.orderBy(...)`, `query = query.where(...)`, etc.
+  // Variable names like `query` are reused across functions, so a use binds to
+  // the nearest preceding assignment of that name, not to any assignment of it.
+  const variables = [...new Set(bases.map((b) => b.variable))];
+  for (const variable of variables) {
+    const useRe = new RegExp(`\\b${variable}\\s*\\.\\s*(?:where|orderBy)\\s*\\(`, "g");
+    let use;
+    while ((use = useRe.exec(source))) {
+      const binding = bases
+        .filter((b) => b.variable === variable && b.at < use.index)
+        .pop();
+      if (!binding) continue;
+      const dot = source.indexOf(".", use.index + variable.length - 1);
+      const continuation = parseChain(source, dot, constants);
+      if (!continuation.wheres.length && !continuation.orderBys.length) continue;
+      queries.push({
+        file,
+        line: source.slice(0, use.index).split("\n").length,
+        collection: binding.base.collection,
+        wheres: [...binding.base.wheres, ...continuation.wheres],
+        orderBys: [...binding.base.orderBys, ...continuation.orderBys],
+        dynamic: binding.base.dynamic || continuation.dynamic,
+      });
+    }
+  }
+
+  return queries;
+}
+
+/* ------------------------------------------------------ index requirements */
+
+/**
+ * Firestore serves some queries from the automatic single-field indexes:
+ *   - a single filter, with or without an orderBy on that same field
+ *   - equality-only conjunctions (`==` / `in`), merged with a zigzag join
+ *
+ * A composite index is required when the query mixes fields in a way those
+ * indexes cannot answer:
+ *   - a filter on one field plus an orderBy on another
+ *   - a range/inequality filter alongside any other filtered field
+ *   - an array-contains filter alongside any other filter or an orderBy
+ *   - more than one orderBy field
+ */
+function requiredIndex(query) {
+  const equality = [];
+  const range = [];
+  const arrays = [];
+  for (const { field, op } of query.wheres) {
+    if (ARRAY_OPS.has(op)) arrays.push(field);
+    else if (RANGE_OPS.has(op)) range.push(field);
+    else equality.push(field);
+  }
+
+  const orderFields = query.orderBys.map((o) => o.field);
+  const filterFields = new Set([...equality, ...range, ...arrays]);
+  const allFields = new Set([...filterFields, ...orderFields]);
+  if (allFields.size < 2) return null;
+
+  const needsIndex =
+    query.orderBys.length > 1 ||
+    (orderFields.length > 0 && [...filterFields].some((f) => !orderFields.includes(f))) ||
+    (range.length > 0 && filterFields.size > 1) ||
+    (arrays.length > 0 && allFields.size > 1);
+
+  if (!needsIndex) return null;
+
+  return {
+    collection: query.collection,
+    // Equality and array-contains fields form the index prefix; their order
+    // among themselves does not matter for index selection.
+    prefix: [...new Set([...equality, ...arrays])].map((field) => ({
+      field,
+      array: arrays.includes(field) && !equality.includes(field),
+    })),
+    // Range filters and orderBy fields must follow the prefix, in order.
+    tail: [
+      ...[...new Set(range)].map((field) => ({ field, dir: null })),
+      ...query.orderBys.map((o) => ({ field: o.field, dir: o.dir })),
+    ].filter((item, i, arr) => arr.findIndex((x) => x.field === item.field) === i),
+  };
+}
+
+function describe(req) {
+  const parts = [
+    ...req.prefix.map((f) => `${f.field} ${f.array ? "array-contains" : "=="}`),
+    ...req.tail.map((t) => `${t.field} ${t.dir ?? "range"}`),
+  ];
+  return `${req.collection}: ${parts.join(", ")}`;
+}
+
+function satisfies(index, req) {
+  if (index.collectionGroup !== req.collection) return false;
+  // Vector fields only ever come last and are irrelevant to filter/sort matching.
+  const fields = index.fields.filter((f) => f.fieldPath !== "__name__" && !f.vectorConfig);
+
+  const prefix = fields.slice(0, req.prefix.length);
+  if (prefix.length !== req.prefix.length) return false;
+  for (const required of req.prefix) {
+    const found = prefix.find((f) => f.fieldPath === required.field);
+    if (!found) return false;
+    if (required.array && found.arrayConfig !== "CONTAINS") return false;
+  }
+
+  const tail = fields.slice(req.prefix.length);
+  if (tail.length < req.tail.length) return false;
+  return req.tail.every((item, i) => {
+    const actual = tail[i];
+    if (!actual || actual.fieldPath !== item.field) return false;
+    if (!item.dir) return true;
+    return (actual.order ?? "ASCENDING").toLowerCase().startsWith(item.dir);
+  });
+}
+
+function suggestion(req) {
+  return {
+    collectionGroup: req.collection,
+    queryScope: "COLLECTION",
+    fields: [
+      ...req.prefix.map((f) =>
+        f.array
+          ? { fieldPath: f.field, arrayConfig: "CONTAINS" }
+          : { fieldPath: f.field, order: "ASCENDING" }
+      ),
+      ...req.tail.map((t) => ({
+        fieldPath: t.field,
+        order: t.dir === "desc" ? "DESCENDING" : "ASCENDING",
+      })),
+    ],
+  };
+}
+
+/* --------------------------------------------------------------------- run */
+
+// The Claude and Antigravity copies of the skill must not drift apart.
+const SKILL_COPIES = [
+  ".claude/skills/firestore-indexes/SKILL.md",
+  ".agent/skills/firestore-indexes/SKILL.md",
+];
+const skills = SKILL_COPIES.map((rel) => ({ rel, full: path.join(ROOT, rel) }));
+if (skills.every((s) => fs.existsSync(s.full))) {
+  const [a, b] = skills.map((s) => fs.readFileSync(s.full, "utf8"));
+  if (a !== b) {
+    console.error(`\u2717 ${SKILL_COPIES[0]} and ${SKILL_COPIES[1]} have drifted apart.`);
+    console.error(`  Copy one over the other so both agents get the same instructions.`);
+    process.exit(1);
+  }
+}
+
+const declared = JSON.parse(fs.readFileSync(INDEX_FILE, "utf8")).indexes ?? [];
+const files = SCAN_DIRS.flatMap((dir) => walk(path.join(ROOT, dir)));
+
+const missing = [];
+const dynamic = [];
+const seen = new Set();
+
+for (const file of files) {
+  for (const query of findQueries(file)) {
+    const req = requiredIndex(query);
+    const where = `${path.relative(ROOT, file)}:${query.line}`;
+    if (!req) {
+      if (query.dynamic && (query.wheres.length || query.orderBys.length)) {
+        dynamic.push(`${where}  ${query.collection} (chain built dynamically)`);
+      }
+      continue;
+    }
+    if (declared.some((index) => satisfies(index, req))) continue;
+    const key = `${where}|${describe(req)}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    missing.push({ where, req });
+  }
+}
+
+if (VERBOSE && dynamic.length) {
+  console.log("Dynamically built queries — verify their indexes by hand:");
+  for (const entry of dynamic) console.log(`  - ${entry}`);
+  console.log("");
+}
+
+if (!missing.length) {
+  console.log(`✓ firestore.indexes.json covers every statically detectable composite query (${files.length} files scanned).`);
+  process.exit(0);
+}
+
+console.error("✗ Missing Firestore composite indexes:\n");
+for (const { where, req } of missing) {
+  console.error(`  ${where}`);
+  console.error(`    query: ${describe(req)}`);
+  console.error(`    add to firestore.indexes.json -> "indexes":`);
+  console.error(
+    JSON.stringify(suggestion(req), null, 2)
+      .split("\n")
+      .map((line) => `      ${line}`)
+      .join("\n")
+  );
+  console.error("");
+}
+console.error("Then deploy: npx firebase deploy --only firestore:indexes");
+process.exit(1);

--- a/src/app/api/consulting/testimonials/route.ts
+++ b/src/app/api/consulting/testimonials/route.ts
@@ -2,16 +2,36 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/firebaseAdmin";
 import { ConsultingReview } from "@/types/consulting";
 
+const MAX_TESTIMONIALS = 10;
+
+type ReviewDoc = FirebaseFirestore.QueryDocumentSnapshot<FirebaseFirestore.DocumentData>;
+
+const toIsoDate = (value: unknown): string => {
+  if (value && typeof (value as { toDate?: () => Date }).toDate === "function") {
+    return (value as { toDate: () => Date }).toDate().toISOString();
+  }
+  return typeof value === "string" ? value : "";
+};
+
 export async function GET() {
   try {
-    const reviewsSnap = await db
-      .collection("consulting_reviews")
-      .where("isApproved", "==", true)
-      .orderBy("createdAt", "desc")
-      .limit(10)
-      .get();
+    const approvedQuery = db.collection("consulting_reviews").where("isApproved", "==", true);
 
-    const testimonials: ConsultingReview[] = reviewsSnap.docs.map((doc) => {
+    let docs: ReviewDoc[];
+    try {
+      const snap = await approvedQuery.orderBy("createdAt", "desc").limit(MAX_TESTIMONIALS).get();
+      docs = snap.docs;
+    } catch (orderError) {
+      // The composite index (isApproved + createdAt) may still be building.
+      // Fall back to an unordered read and sort in memory so the section stays live.
+      console.warn("Falling back to unordered testimonials query:", orderError);
+      const snap = await approvedQuery.get();
+      docs = snap.docs
+        .sort((a, b) => toIsoDate(b.data().createdAt).localeCompare(toIsoDate(a.data().createdAt)))
+        .slice(0, MAX_TESTIMONIALS);
+    }
+
+    const testimonials: ConsultingReview[] = docs.map((doc) => {
       const data = doc.data();
       return {
         id: doc.id,
@@ -29,9 +49,7 @@ export async function GET() {
         isApproved: true,
         packageName: data.packageName || "",
         sessionDate: data.sessionDate || "",
-        createdAt: data.createdAt?.toDate
-          ? data.createdAt.toDate().toISOString()
-          : data.createdAt || "",
+        createdAt: toIsoDate(data.createdAt),
       };
     });
 


### PR DESCRIPTION
## What was broken

Approved 1:1 advisory testimonials never showed up on `/consulting`.

`/api/consulting/testimonials` filters on `isApproved` and orders by `createdAt`. That combination needs a composite index, and `consulting_reviews` had **no entry** in `firestore.indexes.json`. Firestore threw `FAILED_PRECONDITION`, the route returned `500 {"testimonials":[]}`, and `ConsultingTestimonials` returns `null` on an empty list — so the section silently disappeared and approving a review in the admin did nothing visible.

Verified against production: `/api/consulting/testimonials` returned 500 while `/api/stats` and `/api/leaderboard` returned 200, ruling out credentials.

## Changes

**The fix**
- `consulting_reviews`: `isApproved` ASC, `createdAt` DESC
- `consulting_bookings`: `startTime` ASC, `endTime` ASC — pre-existing gap
- `mentorship_bookings`: `mentorId`, `menteeId`, `status`, `startTime` ASC — pre-existing gap

The latter two had already been papered over with runtime `try/catch` fallbacks, which is the same bug going unnoticed twice.

The testimonials route now also falls back to an unordered read plus an in-memory sort when the ordered query fails, so the section still renders while an index is building.

**Stopping the recurrence**

`scripts/check-firestore-indexes.mjs` (`npm run check:firestore-indexes`) parses `src/` and `scripts/` for query chains, works out which need a composite index, and diffs that against `firestore.indexes.json`. On a miss it prints `file:line` and the exact JSON to paste in.

It handles the cases that matter here: equality-only conjunctions served by zigzag merge (not reported), range and `array-contains` filters, `findNearest` vector indexes, subcollections, and — the shape that hid this bug — chains split across statements (`const q = col.where(...)` … `q.orderBy(...)`).

Regression-checked: removing the `consulting_reviews` index makes the checker fail with exactly that finding; restoring it passes. Currently clean across 687 files.

Wired into `.husky/pre-commit`, so a query can no longer be committed without its index.

**Instructions for both agents**
- `.claude/skills/firestore-indexes/SKILL.md` (Claude) and `.agent/skills/firestore-indexes/SKILL.md` (Antigravity) — identical; the checker fails if they drift apart
- `AGENTS.md` (new) and a `CLAUDE.md` section pointing at the skill

## Deploying

Indexes must land before or with this code:

```
firebase deploy --only firestore:indexes --project code-with-ahsan-45496
```

Large collections take a few minutes to build. **Note:** as of this PR, production `/api/consulting/testimonials` still returns 500 — either the index is still building, or the deploy covered rules rather than indexes. Worth confirming `firestore:indexes` specifically before merging.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` — clean
- `npm run check:firestore-indexes` — passes
